### PR TITLE
fix(build): Resolve JNI error due to invalid signature in fat JAR

### DIFF
--- a/java/opendataloader-pdf-runtime/pom.xml
+++ b/java/opendataloader-pdf-runtime/pom.xml
@@ -46,6 +46,16 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.hancom.opendataloader.pdf.cli.CLIMain</mainClass>


### PR DESCRIPTION
Fixed a JNI error on executing the fat JAR, which was caused by "java.lang.SecurityException: Invalid signature file digest for Manifest main attributes". 
This issue arose from conflicts between signature files (META-INF/*.SF, *.DSA, *.RSA) from different dependencies being combined into the uber JAR. 
Resolved the problem by adding a filter to the maven-shade-plugin in pom.xml to exclude these conflicting signature files from the final build artifact.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
