### PR TITLE
build(python): Add importlib_resources to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ AI-safety is enabled by default and automatically filters likely prompt-injectio
 ### Installation
 
 ```sh
-pip install -U opendataloader-pdf importlib_resources
+pip install -U opendataloader-pdf
 ```
 
 ### Usage

--- a/python/opendataloader-pdf/setup.py
+++ b/python/opendataloader-pdf/setup.py
@@ -79,4 +79,7 @@ setup(
         ],
     },
     cmdclass={"build_py": CustomBuildPy},
+    install_requires=[
+        'importlib_resources; python_version < "3.9"',
+    ],
 )


### PR DESCRIPTION
The `importlib_resources` backport is required for Python < 3.9.

Previously, it was not listed in `install_requires`, leading to an `ImportError` and requiring users to install it manually. This commit adds it as a conditional dependency, resolving the installation issue and simplifying the setup process for end-users.

<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
