### PR TITLE
build: Distribution excludes jacoco, a dev-only dependency.

### DIFF
--- a/java/opendataloader-pdf-core/pom.xml
+++ b/java/opendataloader-pdf-core/pom.xml
@@ -71,6 +71,12 @@
             <groupId>org.verapdf</groupId>
             <artifactId>wcag-validation</artifactId>
             <version>${verapdf.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -107,6 +113,7 @@
                 <version>1.6.0</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
+                    <flattenMode>oss</flattenMode>
                     <pomElements>
                         <name />
                         <description />


### PR DESCRIPTION
Distribution excludes jacoco, a dev-only dependency.

Settings that previous consumers must perform

```gradle
    implementation('org.opendataloader:opendataloader-pdf-core:0.0.16') {
        exclude group: 'org.jacoco', module: 'jacoco-maven-plugin'
    }
```

Settings that consumers must make after improvement

```gradle
    implementation 'org.opendataloader:opendataloader-pdf-core:0.0.16'
```

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
