### PR TITLE
fix: Modified markdown-with-html to extract more naturally.

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -92,7 +92,7 @@ public class MarkdownGenerator implements Closeable {
         }
 
         if (!isInsideTable()) {
-            markdownWriter.write(MarkdownSyntax.LINE_BREAK);
+            markdownWriter.write(MarkdownSyntax.DOUBLE_LINE_BREAK);
         }
     }
 
@@ -134,6 +134,7 @@ public class MarkdownGenerator implements Closeable {
         for (ListItem item : list.getListItems()) {
             markdownWriter.write(getCorrectMarkdownString(item.toString()));
             for (IObject object : item.getContents()) {
+                markdownWriter.write(MarkdownSyntax.LINE_BREAK);
                 write(object);
             }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownHTMLGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownHTMLGenerator.java
@@ -9,13 +9,9 @@ package org.opendataloader.pdf.markdown;
 
 import org.opendataloader.pdf.api.Config;
 import org.verapdf.wcag.algorithms.entities.IObject;
-import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
-import org.verapdf.wcag.algorithms.entities.lists.ListItem;
-import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
-import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,32 +24,20 @@ public class MarkdownHTMLGenerator extends MarkdownGenerator {
     }
 
     @Override
-    protected void writeParagraph(SemanticParagraph paragraph) throws IOException {
-        String paragraphValue = paragraph.getValue();
-        double paragraphIndent = paragraph.getColumns().get(0).getBlocks().get(0).getFirstLineIndent();
-        if (paragraphIndent > 0) {
-            markdownWriter.write(MarkdownSyntax.HTML_INDENT);
-        }
-
-        if (isInsideTable() && StaticContainers.isKeepLineBreaks()) {
-            paragraphValue = paragraphValue.replace(MarkdownSyntax.LINE_BREAK, MarkdownSyntax.HTML_LINE_BREAK_TAG);
-        }
-
-        markdownWriter.write(getCorrectMarkdownString(paragraphValue));
-    }
-
-    @Override
     protected void writeTable(TableBorder table) throws IOException {
         enterTable();
         markdownWriter.write(MarkdownSyntax.HTML_TABLE_TAG);
         markdownWriter.write(MarkdownSyntax.LINE_BREAK);
         for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
             TableBorderRow row = table.getRow(rowNumber);
+            markdownWriter.write(MarkdownSyntax.INDENT);
             markdownWriter.write(MarkdownSyntax.HTML_TABLE_ROW_TAG);
             markdownWriter.write(MarkdownSyntax.LINE_BREAK);
             for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
                 TableBorderCell cell = row.getCell(colNumber);
                 if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
+                    markdownWriter.write(MarkdownSyntax.INDENT);
+                    markdownWriter.write(MarkdownSyntax.INDENT);
                     writeCellTag(cell);
                     List<IObject> contents = cell.getContents();
                     if (!contents.isEmpty()) {
@@ -67,6 +51,7 @@ public class MarkdownHTMLGenerator extends MarkdownGenerator {
                 }
             }
 
+            markdownWriter.write(MarkdownSyntax.INDENT);
             markdownWriter.write(MarkdownSyntax.HTML_TABLE_ROW_CLOSE_TAG);
             markdownWriter.write(MarkdownSyntax.LINE_BREAK);
         }
@@ -74,21 +59,6 @@ public class MarkdownHTMLGenerator extends MarkdownGenerator {
         markdownWriter.write(MarkdownSyntax.HTML_TABLE_CLOSE_TAG);
         markdownWriter.write(MarkdownSyntax.LINE_BREAK);
         leaveTable();
-    }
-
-    @Override
-    protected void writeList(PDFList list) throws IOException {
-        markdownWriter.write(MarkdownSyntax.HTML_UNORDERED_LIST_TAG);
-        for (ListItem item : list.getListItems()) {
-            markdownWriter.write(MarkdownSyntax.HTML_LIST_ITEM_TAG);
-            markdownWriter.write(getCorrectMarkdownString(item.toString()));
-            for (IObject object : item.getContents()) {
-                write(object);
-            }
-            markdownWriter.write(MarkdownSyntax.HTML_LIST_ITEM_CLOSE_TAG);
-        }
-
-        markdownWriter.write(MarkdownSyntax.HTML_UNORDERED_LIST_CLOSE_TAG);
     }
 
     private void writeCellTag(TableBorderCell cell) throws IOException {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownSyntax.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownSyntax.java
@@ -10,8 +10,10 @@ package org.opendataloader.pdf.markdown;
 public class MarkdownSyntax {
     public static final String TABLE_COLUMN_SEPARATOR = "|";
     public static final String TABLE_HEADER_SEPARATOR = "---";
+    public static final String DOUBLE_LINE_BREAK = "\n\n";
     public static final String LINE_BREAK = "\n";
     public static final String SPACE = " ";
+    public static final String INDENT = "  ";
     public static final String HEADING_LEVEL = "#";
     public static final String IMAGE_FILE_NAME_FORMAT = "%s%simageFile%d.png";
     public static final String IMAGE_FORMAT = "![%s](%s)";


### PR DESCRIPTION
- Only table objects have been converted to HTML.
- Each object is separated by a double line break.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
