### PR TITLE
fix: initialize ContrastRatioConsumer in HtmlGenerator constructor

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
@@ -59,6 +59,8 @@ public class HtmlGenerator implements Closeable {
         this.figureDirName = pdfFileName.substring(0, pdfFileName.length() - 4) + "_figures";
         this.figureDirPath = Path.of(outputFolder, figureDirName);
         this.htmlWriter = new FileWriter(htmlFilePath.toFile(), StandardCharsets.UTF_8);
+        this.figureDirPath.toFile().mkdirs();
+        this.contrastRatioConsumer = new ContrastRatioConsumer(this.pdfFilePath.toString(), password, false, null);
     }
 
     public void writeToHtml(List<List<IObject>> contents) {
@@ -105,11 +107,6 @@ public class HtmlGenerator implements Closeable {
 
     protected void writeImage(ImageChunk image) throws IOException {
         int currentImageIndex = StaticLayoutContainers.incrementImageIndex();
-        if (currentImageIndex == 1) {
-            figureDirPath.toFile().mkdirs();
-            contrastRatioConsumer = new ContrastRatioConsumer(this.pdfFilePath.toString(), password, false, null);
-        }
-
         String figureFileName = String.format(HtmlSyntax.IMAGE_FILE_NAME_FORMAT, currentImageIndex);
         Path figureFilePath = figureDirPath.resolve(figureFileName);
         boolean isFileCreated = createImageFile(image, figureFilePath.toString());


### PR DESCRIPTION
Fix NullPointerException in HtmlGenerator when processing images

  PR Description

  ## Problem
  When generating HTML output with images, a `NullPointerException` occurs because `ContrastRatioConsumer` is not properly initialized before use.

  ### Error Details
  java.lang.NullPointerException: Cannot invoke "org.verapdf.wcag.algorithms.semanticalgorithms.consumers.ContrastRatioConsumer.getPageSubImage(...)"
  because "this.contrastRatioConsumer" is null
      at org.opendataloader.pdf.html.HtmlGenerator.createImageFile(HtmlGenerator.java:129)

  ## Root Cause
  1. `contrastRatioConsumer` field is declared but not initialized in the constructor
  2. It was only initialized when the first image was encountered in `writeImage()` method (line 110-113)
  3. This caused NPE when `createImageFile()` was called before any image processing

  ## Solution
  ### 1. Initialize ContrastRatioConsumer in constructor
  - Moved initialization to constructor to ensure it's always available
  - This prevents NPE regardless of when images are processed

  ### 2. Create figures directory in constructor
  - Moved `figureDirPath.toFile().mkdirs()` to constructor
  - Previously only created when first image was encountered
  - This prevents `FileNotFoundException` when static image counter doesn't start at 1

  ## Changes
  - **HtmlGenerator.java**:
    - Added `ContrastRatioConsumer` initialization in constructor
    - Added figures directory creation in constructor
    - Removed redundant initialization code from `writeImage()` method

  ## Testing
  Tested with PDF files containing:
  - ✅ Multiple images across pages
  - ✅ Documents without images
  - ✅ Large PDFs with 20+ images

  All tests pass without NPE or file system errors.

  ## Backwards Compatibility
  ✅ No breaking changes - all existing functionality preserved