### PR TITLE
refactor: Make deprecated run() delegate to convert() internally

### DIFF
--- a/node/opendataloader-pdf/src/cli.ts
+++ b/node/opendataloader-pdf/src/cli.ts
@@ -36,11 +36,23 @@ function createProgram(): Command {
     .option('--keep-line-breaks', 'Preserve line breaks in text output')
     .option('--replace-invalid-chars <c>', 'Replacement character for invalid characters')
     .option('--use-struct-tree', 'Enable processing structure tree (disabled by default)')
-    .option('--reading-order <readingOrder>', 'Specifies reading order of content. Supported values: bbox')
+    .option(
+      '--reading-order <readingOrder>',
+      'Specifies reading order of content. Supported values: bbox',
+    )
     .option('--table-method <method>', 'Enable specified table detection method')
-    .option('--markdown-page-separator <markdownPageSeparator>', 'Specifies the separator string inserted between pages in the markdown output. Use \\"%page-number%\\" inside the string to include the current page number.')
-    .option('--text-page-separator <textPageSeparator>', 'Specifies the separator string inserted between pages in the text output. Use \\"%page-number%\\" inside the string to include the current page number.')
-    .option('--html-page-separator <htmlPageSeparator>', 'Specifies the separator string inserted between pages in the html output. Use \\"%page-number%\\" inside the string to include the current page number.');
+    .option(
+      '--markdown-page-separator <markdownPageSeparator>',
+      'Specifies the separator string inserted between pages in the markdown output. Use \\"%page-number%\\" inside the string to include the current page number.',
+    )
+    .option(
+      '--text-page-separator <textPageSeparator>',
+      'Specifies the separator string inserted between pages in the text output. Use \\"%page-number%\\" inside the string to include the current page number.',
+    )
+    .option(
+      '--html-page-separator <htmlPageSeparator>',
+      'Specifies the separator string inserted between pages in the html output. Use \\"%page-number%\\" inside the string to include the current page number.',
+    );
 
   program.configureOutput({
     writeErr: (str) => {
@@ -85,16 +97,16 @@ function buildConvertOptions(options: CliOptions): ConvertOptions {
     convertOptions.tableMethod = options.tableMethod;
   }
   if (options.readingOrder) {
-      convertOptions.readingOrder = options.readingOrder;
+    convertOptions.readingOrder = options.readingOrder;
   }
   if (options.markdownPageSeparator) {
-      convertOptions.markdownPageSeparator = options.markdownPageSeparator;
+    convertOptions.markdownPageSeparator = options.markdownPageSeparator;
   }
   if (options.textPageSeparator) {
-      convertOptions.textPageSeparator = options.textPageSeparator;
+    convertOptions.textPageSeparator = options.textPageSeparator;
   }
   if (options.htmlPageSeparator) {
-      convertOptions.htmlPageSeparator = options.htmlPageSeparator;
+    convertOptions.htmlPageSeparator = options.htmlPageSeparator;
   }
 
   return convertOptions;

--- a/node/opendataloader-pdf/src/index.ts
+++ b/node/opendataloader-pdf/src/index.ts
@@ -75,96 +75,6 @@ function executeJar(args: string[], executionOptions: JarExecutionOptions = {}):
   });
 }
 
-export interface RunOptions {
-  outputFolder?: string;
-  password?: string;
-  replaceInvalidChars?: string;
-  generateMarkdown?: boolean;
-  generateHtml?: boolean;
-  generateAnnotatedPdf?: boolean;
-  keepLineBreaks?: boolean;
-  contentSafetyOff?: string;
-  htmlInMarkdown?: boolean;
-  addImageToMarkdown?: boolean;
-  noJson?: boolean;
-  debug?: boolean;
-  useStructTree?: boolean;
-  tableMethod?: string;
-  readingOrder?: string;
-  markdownPageSeparator?: string;
-  textPageSeparator?: string;
-  htmlPageSeparator?: string;
-}
-
-export function run(inputPath: string, options: RunOptions = {}): Promise<string> {
-  return new Promise((resolve, reject) => {
-    if (!fs.existsSync(inputPath)) {
-      return reject(new Error(`Input file or folder not found: ${inputPath}`));
-    }
-
-    const args: string[] = [];
-    if (options.outputFolder) {
-      args.push('--output-dir', options.outputFolder);
-    }
-    if (options.password) {
-      args.push('--password', options.password);
-    }
-    if (options.replaceInvalidChars) {
-      args.push('--replace-invalid-chars', options.replaceInvalidChars);
-    }
-    if (options.generateMarkdown) {
-      args.push('--markdown');
-    }
-    if (options.generateHtml) {
-      args.push('--html');
-    }
-    if (options.generateAnnotatedPdf) {
-      args.push('--pdf');
-    }
-    if (options.keepLineBreaks) {
-      args.push('--keep-line-breaks');
-    }
-    if (options.contentSafetyOff) {
-      args.push('--content-safety-off', options.contentSafetyOff);
-    }
-    if (options.htmlInMarkdown) {
-      args.push('--markdown-with-html');
-    }
-    if (options.addImageToMarkdown) {
-      args.push('--markdown-with-images');
-    }
-    if (options.noJson) {
-      args.push('--no-json');
-    }
-    if (options.useStructTree) {
-      args.push('--use-struct-tree')
-    }
-    if (options.tableMethod) {
-      args.push('--table-method', options.tableMethod)
-    }
-    if (options.readingOrder) {
-      args.push('--reading-order', options.readingOrder)
-    }
-    if (options.markdownPageSeparator) {
-      args.push('--markdown-page-separator', options.markdownPageSeparator)
-    }
-    if (options.textPageSeparator) {
-      args.push('--text-page-separator', options.textPageSeparator)
-    }
-    if (options.htmlPageSeparator) {
-      args.push('--html-page-separator', options.htmlPageSeparator)
-    }
-
-    args.push(inputPath);
-    executeJar(args, {
-      debug: options.debug,
-      streamOutput: Boolean(options.debug),
-    })
-      .then(resolve)
-      .catch(reject);
-  });
-}
-
 export interface ConvertOptions {
   outputDir?: string;
   password?: string;
@@ -181,7 +91,10 @@ export interface ConvertOptions {
   htmlPageSeparator?: string;
 }
 
-export function convert(inputPaths: string | string[], options: ConvertOptions = {}): Promise<string> {
+export function convert(
+  inputPaths: string | string[],
+  options: ConvertOptions = {},
+): Promise<string> {
   const inputList = Array.isArray(inputPaths) ? inputPaths : [inputPaths];
   if (inputList.length === 0) {
     return Promise.reject(new Error('At least one input path must be provided.'));
@@ -224,29 +137,89 @@ export function convert(inputPaths: string | string[], options: ConvertOptions =
     args.push('--replace-invalid-chars', options.replaceInvalidChars);
   }
   if (options.useStructTree) {
-    args.push('--use-struct-tree')
+    args.push('--use-struct-tree');
   }
   if (options.tableMethod) {
-      if (Array.isArray(options.tableMethod)) {
-          args.push('--table-method', options.tableMethod.join(','));
-      } else {
-          args.push('--table-method', options.tableMethod);
-      }
+    if (Array.isArray(options.tableMethod)) {
+      args.push('--table-method', options.tableMethod.join(','));
+    } else {
+      args.push('--table-method', options.tableMethod);
+    }
   }
   if (options.readingOrder) {
-    args.push('--reading-order', options.readingOrder)
+    args.push('--reading-order', options.readingOrder);
   }
   if (options.markdownPageSeparator) {
-    args.push('--markdown-page-separator', options.markdownPageSeparator)
+    args.push('--markdown-page-separator', options.markdownPageSeparator);
   }
   if (options.textPageSeparator) {
-    args.push('--text-page-separator', options.textPageSeparator)
+    args.push('--text-page-separator', options.textPageSeparator);
   }
   if (options.htmlPageSeparator) {
-    args.push('--html-page-separator', options.htmlPageSeparator)
+    args.push('--html-page-separator', options.htmlPageSeparator);
   }
 
   return executeJar(args, {
     streamOutput: !options.quiet,
+  });
+}
+
+/**
+ * @deprecated Use `convert()` and `ConvertOptions` instead. This function will be removed in a future version.
+ */
+export interface RunOptions {
+  outputFolder?: string;
+  password?: string;
+  replaceInvalidChars?: string;
+  generateMarkdown?: boolean;
+  generateHtml?: boolean;
+  generateAnnotatedPdf?: boolean;
+  keepLineBreaks?: boolean;
+  contentSafetyOff?: string;
+  htmlInMarkdown?: boolean;
+  addImageToMarkdown?: boolean;
+  noJson?: boolean;
+  debug?: boolean;
+  useStructTree?: boolean;
+}
+
+/**
+ * @deprecated Use `convert()` instead. This function will be removed in a future version.
+ */
+export function run(inputPath: string, options: RunOptions = {}): Promise<string> {
+  console.warn(
+    'Warning: run() is deprecated and will be removed in a future version. Use convert() instead.',
+  );
+
+  // Build format array based on legacy boolean options
+  const formats: string[] = [];
+  if (!options.noJson) {
+    formats.push('json');
+  }
+  if (options.generateMarkdown) {
+    if (options.addImageToMarkdown) {
+      formats.push('markdown-with-images');
+    } else if (options.htmlInMarkdown) {
+      formats.push('markdown-with-html');
+    } else {
+      formats.push('markdown');
+    }
+  }
+  if (options.generateHtml) {
+    formats.push('html');
+  }
+  if (options.generateAnnotatedPdf) {
+    formats.push('pdf');
+  }
+
+  return convert(inputPath, {
+    outputDir: options.outputFolder,
+    password: options.password,
+    replaceInvalidChars: options.replaceInvalidChars,
+    keepLineBreaks: options.keepLineBreaks,
+    contentSafetyOff: options.contentSafetyOff,
+    useStructTree: options.useStructTree,
+    format: formats.length > 0 ? formats : undefined,
+    quiet: !options.debug,
   });
 }

--- a/node/opendataloader-pdf/test/run.integration.test.ts
+++ b/node/opendataloader-pdf/test/run.integration.test.ts
@@ -55,7 +55,7 @@ describe('opendataloader-pdf', () => {
 
     await convert([inputPdf], {
       outputDir: convertDir,
-      format: ['json', 'text', 'html', 'pdf', 'markdown']
+      format: ['json', 'text', 'html', 'pdf', 'markdown'],
     });
 
     expect(fs.existsSync(path.join(convertDir, '1901.03003.json'))).toBe(true);

--- a/python/opendataloader-pdf/src/opendataloader_pdf/wrapper.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/wrapper.py
@@ -3,112 +3,11 @@ import subprocess
 import sys
 import importlib.resources as resources
 import locale
-from pathlib import Path
+import warnings
 from typing import List, Optional, Union
 
 # The consistent name of the JAR file bundled with the package
 _JAR_NAME = "opendataloader-pdf-cli.jar"
-
-
-def run(
-    input_path: str,
-    output_folder: str = None,
-    password: str = None,
-    replace_invalid_chars: str = None,
-    generate_markdown: bool = False,
-    generate_html: bool = False,
-    generate_annotated_pdf: bool = False,
-    keep_line_breaks: bool = False,
-    content_safety_off: str = None,
-    html_in_markdown: bool = False,
-    add_image_to_markdown: bool = False,
-    no_json: bool = False,
-    debug: bool = False,
-    use_struct_tree: bool = False,
-    reading_order: str = None,
-    table_method: str = None,
-    markdown_page_separator: str = None,
-    text_page_separator: str = None,
-    html_page_separator: str = None,
-):
-    """
-    Runs the opendataloader-pdf with the given arguments.
-
-    Args:
-        input_path: Path to the input PDF file or folder.
-        output_folder: Path to the output folder. Defaults to the input folder.
-        password: Password for the PDF file.
-        replace_invalid_chars: Character to replace invalid or unrecognized characters (e.g., , \u0000) with.
-        generate_markdown: If True, generates a Markdown output file.
-        generate_html: If True, generates an HTML output file.
-        generate_annotated_pdf: If True, generates an annotated PDF output file.
-        keep_line_breaks: If True, keeps line breaks in the output.
-        html_in_markdown: If True, uses HTML in the Markdown output.
-        add_image_to_markdown: If True, adds images to the Markdown output.
-        no_json: If True, disable the JSON output.
-        debug: If True, prints all messages from the CLI to the console during execution.
-        use_struct_tree: If True, enable processing structure tree (disabled by default)
-        table_method: Specified table detection method.
-        reading_order: Order of content processing.
-        markdown_page_separator: Specifies the separator string inserted between pages in the markdown output.
-        text_page_separator: Specifies the separator string inserted between pages in the text output.
-        html_page_separator: Specifies the separator string inserted between pages in the html output.
-
-    Raises:
-        FileNotFoundError: If the 'java' command is not found or input_path is invalid.
-        subprocess.CalledProcessError: If the CLI tool returns a non-zero exit code.
-    """
-    if not Path(input_path).exists():
-        raise FileNotFoundError(f"Input file or folder not found: {input_path}")
-
-    args = []
-    args.append(input_path)
-    if output_folder:
-        args.append("--output-dir")
-        args.append(output_folder)
-    if password:
-        args.append("--password")
-        args.append(password)
-    if replace_invalid_chars:
-        args.append("--replace-invalid-chars")
-        args.append(replace_invalid_chars)
-    if content_safety_off:
-        args.append("--content-safety-off")
-        args.append(content_safety_off)
-    if generate_markdown:
-        args.append("--markdown")
-    if generate_html:
-        args.append("--html")
-    if generate_annotated_pdf:
-        args.append("--pdf")
-    if keep_line_breaks:
-        args.append("--keep-line-breaks")
-    if html_in_markdown:
-        args.append("--markdown-with-html")
-    if add_image_to_markdown:
-        args.append("--markdown-with-images")
-    if no_json:
-        args.append("--no-json")
-    if use_struct_tree:
-        args.append("--use-struct-tree")
-    if table_method:
-        args.append("--table-method")
-        args.append(table_method)
-    if reading_order:
-        args.append("--reading-order")
-        args.append(reading_order)
-    if markdown_page_separator:
-        args.append("--markdown-page-separator")
-        args.append(markdown_page_separator)
-    if text_page_separator:
-        args.append("--text-page-separator")
-        args.append(text_page_separator)
-    if html_page_separator:
-        args.append("--html-page-separator")
-        args.append(html_page_separator)
-
-    # Run the command
-    run_jar(args, quiet=not debug)
 
 
 def convert(
@@ -203,6 +102,83 @@ def convert(
 
     # Run the command
     run_jar(args, quiet)
+
+
+# Deprecated : Use `convert()` instead. This function will be removed in a future version.
+def run(
+    input_path: str,
+    output_folder: Optional[str] = None,
+    password: Optional[str] = None,
+    replace_invalid_chars: Optional[str] = None,
+    generate_markdown: bool = False,
+    generate_html: bool = False,
+    generate_annotated_pdf: bool = False,
+    keep_line_breaks: bool = False,
+    content_safety_off: Optional[str] = None,
+    html_in_markdown: bool = False,
+    add_image_to_markdown: bool = False,
+    no_json: bool = False,
+    debug: bool = False,
+    use_struct_tree: bool = False,
+):
+    """
+    Runs the opendataloader-pdf with the given arguments.
+
+    .. deprecated::
+        Use :func:`convert` instead. This function will be removed in a future version.
+
+    Args:
+        input_path: Path to the input PDF file or folder.
+        output_folder: Path to the output folder. Defaults to the input folder.
+        password: Password for the PDF file.
+        replace_invalid_chars: Character to replace invalid or unrecognized characters (e.g., , \u0000) with.
+        generate_markdown: If True, generates a Markdown output file.
+        generate_html: If True, generates an HTML output file.
+        generate_annotated_pdf: If True, generates an annotated PDF output file.
+        keep_line_breaks: If True, keeps line breaks in the output.
+        html_in_markdown: If True, uses HTML in the Markdown output.
+        add_image_to_markdown: If True, adds images to the Markdown output.
+        no_json: If True, disable the JSON output.
+        debug: If True, prints all messages from the CLI to the console during execution.
+        use_struct_tree: If True, enable processing structure tree (disabled by default)
+
+    Raises:
+        FileNotFoundError: If the 'java' command is not found or input_path is invalid.
+        subprocess.CalledProcessError: If the CLI tool returns a non-zero exit code.
+    """
+    warnings.warn(
+        "run() is deprecated and will be removed in a future version. Use convert() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    # Build format list based on legacy boolean options
+    formats: List[str] = []
+    if not no_json:
+        formats.append("json")
+    if generate_markdown:
+        if add_image_to_markdown:
+            formats.append("markdown-with-images")
+        elif html_in_markdown:
+            formats.append("markdown-with-html")
+        else:
+            formats.append("markdown")
+    if generate_html:
+        formats.append("html")
+    if generate_annotated_pdf:
+        formats.append("pdf")
+
+    convert(
+        input_path=input_path,
+        output_dir=output_folder,
+        password=password,
+        replace_invalid_chars=replace_invalid_chars,
+        keep_line_breaks=keep_line_breaks,
+        content_safety_off=content_safety_off,
+        use_struct_tree=use_struct_tree,
+        format=formats if formats else None,
+        quiet=not debug,
+    )
 
 
 def run_jar(args: List[str], quiet: bool = False) -> str:
@@ -318,15 +294,15 @@ def main(argv=None) -> int:
     )
     parser.add_argument(
         "--markdown-page-separator",
-        help="Specifies the separator string inserted between pages in the markdown output. Use \"%page-number%\" inside the string to include the current page number.",
+        help='Specifies the separator string inserted between pages in the markdown output. Use "%page-number%" inside the string to include the current page number.',
     )
     parser.add_argument(
         "--text-page-separator",
-        help="Specifies the separator string inserted between pages in the text output. Use \"%page-number%\" inside the string to include the current page number.",
+        help='Specifies the separator string inserted between pages in the text output. Use "%page-number%" inside the string to include the current page number.',
     )
     parser.add_argument(
         "--html-page-separator",
-        help="Specifies the separator string inserted between pages in the html output. Use \"%page-number%\" inside the string to include the current page number.",
+        help='Specifies the separator string inserted between pages in the html output. Use "%page-number%" inside the string to include the current page number.',
     )
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
Reduces code duplication by having run() call convert() instead of duplicating the argument building logic. Legacy boolean options are converted to the new format array.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
