### PR TITLE
fix: handle StringIndexOutOfBoundsException in list label processing

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -150,7 +150,9 @@ public class ListProcessor {
                     break;
                 }
             } catch (StringIndexOutOfBoundsException e) {
-                LOGGER.log(Level.WARNING, "Malformed list label: " + listItemTextInfo.getListItemValue().getValue(), e);
+                // Malformed label cannot be matched; treat as new list (isSingle remains true)
+                LOGGER.log(Level.WARNING, "Malformed list label, starting new list: " + listItemTextInfo.getListItemValue().getValue(), e);
+                break;
             }
             if (shouldHaveSameLeftDifference && !NodeUtils.areCloseNumbers(previousLeftDifference, leftDifference)) {
                 break;

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ListProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ListProcessorTest.java
@@ -108,8 +108,12 @@ public class ListProcessorTest {
             "나. 두 번째 항목", 10, 30.0)));
         pageContents.add(new TextLine(new TextChunk(new BoundingBox(0, 10.0, 20.0, 20.0, 30.0),
             ")", 10, 20.0)));
-        Assertions.assertDoesNotThrow(() -> ListProcessor.processLists(contents, false),
-            "processLists should handle single character labels without throwing StringIndexOutOfBoundsException");
+        int originalSize = pageContents.size();
+        ListProcessor.processLists(contents, false);
+        Assertions.assertFalse(contents.get(0).isEmpty(),
+            "Content should not be empty after processing");
+        Assertions.assertTrue(contents.get(0).size() <= originalSize,
+            "Content size should not exceed original size");
     }
 
     @Test
@@ -127,7 +131,11 @@ public class ListProcessorTest {
             "1)", 10, 30.0)));
         pageContents.add(new TextLine(new TextChunk(new BoundingBox(0, 10.0, 20.0, 20.0, 30.0),
             "2)", 10, 20.0)));
-        Assertions.assertDoesNotThrow(() -> ListProcessor.processLists(contents, false),
-            "processLists should handle edge case labels without throwing StringIndexOutOfBoundsException");
+        int originalSize = pageContents.size();
+        ListProcessor.processLists(contents, false);
+        Assertions.assertFalse(contents.get(0).isEmpty(),
+            "Content should not be empty after processing");
+        Assertions.assertTrue(contents.get(0).size() <= originalSize,
+            "Content size should not exceed original size");
     }
 }


### PR DESCRIPTION
## Summary
- Add defensive handling for `StringIndexOutOfBoundsException` when calling `ListLabelsUtils.isTwoListItemsOfOneList()`
- When processing list items with single-character labels or empty suffixes, start a new list instead of crashing
- Add 2 edge case test cases

## Test plan
- [x] `testProcessListsWithSingleCharacterLabels` - Test single character labels
- [x] `testProcessListsWithEdgeCaseLabels` - Test edge case labels
- [x] Verify existing tests pass

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)