### PR TITLE
feat(java): add --pages option for selective page extraction

### DIFF
--- a/content/docs/_generated/node-convert-options.mdx
+++ b/content/docs/_generated/node-convert-options.mdx
@@ -24,3 +24,4 @@ description: Options for the Node.js convert function
 | `htmlPageSeparator`     | `string`             | -            | Separator between pages in HTML output. Use %page-number% for page numbers. Default: none                                          |
 | `imageOutput`           | `string`             | `"external"` | Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external             |
 | `imageFormat`           | `string`             | `"png"`      | Output format for extracted images. Values: png, jpeg. Default: png                                                                |
+| `pages`                 | `string`             | -            | Pages to extract (e.g., "1,3,5-7"). Default: all pages                                                                             |

--- a/content/docs/_generated/python-convert-options.mdx
+++ b/content/docs/_generated/python-convert-options.mdx
@@ -25,3 +25,4 @@ description: Options for the Python convert function
 | `html_page_separator`     | `str`                | -            | Separator between pages in HTML output. Use %page-number% for page numbers. Default: none                                          |
 | `image_output`            | `str`                | `"external"` | Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external             |
 | `image_format`            | `str`                | `"png"`      | Output format for extracted images. Values: png, jpeg. Default: png                                                                |
+| `pages`                   | `str`                | -            | Pages to extract (e.g., "1,3,5-7"). Default: all pages                                                                             |

--- a/content/docs/cli-options-reference.mdx
+++ b/content/docs/cli-options-reference.mdx
@@ -28,6 +28,7 @@ This page documents all available CLI options for opendataloader-pdf.
 | `--html-page-separator`     | -     | `string`  | -            | Separator between pages in HTML output. Use %page-number% for page numbers. Default: none                                          |
 | `--image-output`            | -     | `string`  | `"external"` | Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external             |
 | `--image-format`            | -     | `string`  | `"png"`      | Output format for extracted images. Values: png, jpeg. Default: png                                                                |
+| `--pages`                   | -     | `string`  | -            | Pages to extract (e.g., "1,3,5-7"). Default: all pages                                                                             |
 
 ## Examples
 

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
@@ -86,6 +86,10 @@ public class CLIOptions {
     private static final String IMAGE_FORMAT_LONG_OPTION = "image-format";
     private static final String IMAGE_FORMAT_DESC = "Output format for extracted images. Values: png, jpeg. Default: png";
 
+    // ===== Pages =====
+    private static final String PAGES_LONG_OPTION = "pages";
+    private static final String PAGES_DESC = "Pages to extract (e.g., \"1,3,5-7\"). Default: all pages";
+
     // ===== Export Options (internal) =====
     public static final String EXPORT_OPTIONS_LONG_OPTION = "export-options";
 
@@ -121,6 +125,7 @@ public class CLIOptions {
             new OptionDefinition(HTML_PAGE_SEPARATOR_LONG_OPTION, null, "string", null, HTML_PAGE_SEPARATOR_DESC, true),
             new OptionDefinition(IMAGE_OUTPUT_LONG_OPTION, null, "string", "external", IMAGE_OUTPUT_DESC, true),
             new OptionDefinition(IMAGE_FORMAT_LONG_OPTION, null, "string", "png", IMAGE_FORMAT_DESC, true),
+            new OptionDefinition(PAGES_LONG_OPTION, null, "string", null, PAGES_DESC, true),
             new OptionDefinition(EXPORT_OPTIONS_LONG_OPTION, null, "boolean", null, null, false),
 
             // Legacy options (not exported, for backward compatibility)
@@ -196,6 +201,7 @@ public class CLIOptions {
         applyFormatOption(config, commandLine);
         applyTableMethodOption(config, commandLine);
         applyImageOptions(config, commandLine);
+        applyPagesOption(config, commandLine);
         return config;
     }
 
@@ -227,6 +233,12 @@ public class CLIOptions {
                         String.format("Unsupported image format '%s'. Supported values: png, jpeg", format));
             }
             config.setImageFormat(format);
+        }
+    }
+
+    private static void applyPagesOption(Config config, CommandLine commandLine) {
+        if (commandLine.hasOption(PAGES_LONG_OPTION)) {
+            config.setPages(commandLine.getOptionValue(PAGES_LONG_OPTION));
         }
     }
 

--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIOptionsTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIOptionsTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -223,5 +224,76 @@ class CLIOptionsTest {
         Config config = CLIOptions.createConfigFromCommandLine(cmd);
 
         assertEquals(Config.READING_ORDER_OFF, config.getReadingOrder());
+    }
+
+    // ===== Pages Option Tests =====
+
+    @Test
+    void testDefineOptions_containsPagesOption() {
+        assertTrue(options.hasOption("pages"));
+    }
+
+    @Test
+    void testCreateConfig_withPages() throws ParseException {
+        String[] args = {"--pages", "1,3,5-7", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertEquals("1,3,5-7", config.getPages());
+        assertEquals(List.of(1, 3, 5, 6, 7), config.getPageNumbers());
+    }
+
+    @Test
+    void testCreateConfig_withSinglePage() throws ParseException {
+        String[] args = {"--pages", "5", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertEquals("5", config.getPages());
+        assertEquals(List.of(5), config.getPageNumbers());
+    }
+
+    @Test
+    void testCreateConfig_withPageRange() throws ParseException {
+        String[] args = {"--pages", "1-10", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertEquals("1-10", config.getPages());
+        assertEquals(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), config.getPageNumbers());
+    }
+
+    @Test
+    void testCreateConfig_defaultPages() throws ParseException {
+        String[] args = {testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertNull(config.getPages());
+        assertTrue(config.getPageNumbers().isEmpty());
+    }
+
+    @Test
+    void testCreateConfig_withInvalidPages() throws ParseException {
+        String[] args = {"--pages", "abc", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            CLIOptions.createConfigFromCommandLine(cmd);
+        });
+    }
+
+    @Test
+    void testCreateConfig_withReversePageRange() throws ParseException {
+        String[] args = {"--pages", "5-3", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            CLIOptions.createConfigFromCommandLine(cmd);
+        });
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PagesOptionIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PagesOptionIntegrationTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2025 Hancom Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.opendataloader.pdf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.processors.DocumentProcessor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration tests for the --pages option.
+ * Tests the full pipeline from Config to output files with page filtering.
+ */
+class PagesOptionIntegrationTest {
+
+    private static final String SAMPLE_PDF = "../../samples/pdf/1901.03003.pdf";
+    private static final String OUTPUT_BASENAME = "1901.03003";
+
+    @TempDir
+    Path tempDir;
+
+    private File samplePdf;
+
+    @BeforeEach
+    void setUp() {
+        samplePdf = new File(SAMPLE_PDF);
+        assumeTrue(samplePdf.exists(), "Sample PDF not found at " + samplePdf.getAbsolutePath());
+    }
+
+    @Test
+    void testPagesOption_singlePage() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setPages("1");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path jsonOutput = tempDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output should exist");
+
+        JsonNode root = parseJson(jsonOutput);
+        Set<Integer> pagesInOutput = getPageNumbersFromKids(root);
+
+        assertEquals(Set.of(1), pagesInOutput, "Only page 1 should have content when --pages=1");
+    }
+
+    @Test
+    void testPagesOption_multiplePages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setPages("1,3,5");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path jsonOutput = tempDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output should exist");
+
+        JsonNode root = parseJson(jsonOutput);
+        Set<Integer> pagesInOutput = getPageNumbersFromKids(root);
+
+        assertTrue(pagesInOutput.contains(1), "Page 1 should have content");
+        assertTrue(pagesInOutput.contains(3), "Page 3 should have content");
+        assertTrue(pagesInOutput.contains(5), "Page 5 should have content");
+        assertFalse(pagesInOutput.contains(2), "Page 2 should NOT have content");
+        assertFalse(pagesInOutput.contains(4), "Page 4 should NOT have content");
+    }
+
+    @Test
+    void testPagesOption_pageRange() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setPages("1-3");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path jsonOutput = tempDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output should exist");
+
+        JsonNode root = parseJson(jsonOutput);
+        Set<Integer> pagesInOutput = getPageNumbersFromKids(root);
+
+        assertTrue(pagesInOutput.contains(1), "Page 1 should have content");
+        assertTrue(pagesInOutput.contains(2), "Page 2 should have content");
+        assertTrue(pagesInOutput.contains(3), "Page 3 should have content");
+        assertFalse(pagesInOutput.contains(4), "Page 4 should NOT have content");
+    }
+
+    @Test
+    void testPagesOption_mixedRangeAndSingle() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setPages("1,3-5");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path jsonOutput = tempDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output should exist");
+
+        JsonNode root = parseJson(jsonOutput);
+        Set<Integer> pagesInOutput = getPageNumbersFromKids(root);
+
+        assertTrue(pagesInOutput.contains(1), "Page 1 should have content");
+        assertFalse(pagesInOutput.contains(2), "Page 2 should NOT have content");
+        assertTrue(pagesInOutput.contains(3), "Page 3 should have content");
+        assertTrue(pagesInOutput.contains(4), "Page 4 should have content");
+        assertTrue(pagesInOutput.contains(5), "Page 5 should have content");
+    }
+
+    @Test
+    void testPagesOption_allPages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        // No pages option - all pages should be processed
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path jsonOutput = tempDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output should exist");
+
+        JsonNode root = parseJson(jsonOutput);
+        Set<Integer> pagesInOutput = getPageNumbersFromKids(root);
+
+        // 15-page document should have content from many pages
+        assertTrue(pagesInOutput.size() > 5, "All pages should have content when no --pages option");
+    }
+
+    @Test
+    void testPagesOption_markdown() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateMarkdown(true);
+        config.setMarkdownPageSeparator("<!-- Page %page-number% -->");
+        config.setPages("1,3");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path mdOutput = tempDir.resolve(OUTPUT_BASENAME + ".md");
+        assertTrue(Files.exists(mdOutput), "Markdown output should exist");
+
+        String mdContent = Files.readString(mdOutput);
+        assertTrue(mdContent.contains("<!-- Page 1 -->"), "Should contain page 1 separator");
+        assertTrue(mdContent.contains("<!-- Page 3 -->"), "Should contain page 3 separator");
+        // Page 2 is skipped, so its separator shouldn't appear
+        // Note: Page separators are added between pages, so we verify page 1 and 3 content exists
+    }
+
+    @Test
+    void testPagesOption_exceedsDocumentPages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setPages("1,100,200"); // 100, 200 don't exist in 15-page document
+
+        // Should not throw - just warn and process existing pages
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path jsonOutput = tempDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output should exist");
+
+        JsonNode root = parseJson(jsonOutput);
+        Set<Integer> pagesInOutput = getPageNumbersFromKids(root);
+
+        assertTrue(pagesInOutput.contains(1), "Only page 1 should have content (100, 200 don't exist)");
+        assertFalse(pagesInOutput.contains(100), "Page 100 should NOT exist");
+        assertFalse(pagesInOutput.contains(200), "Page 200 should NOT exist");
+    }
+
+    @Test
+    void testPagesOption_allPagesExceedDocument() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setPages("100,200"); // All pages don't exist
+
+        // Should not throw - just warn and produce empty result
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path jsonOutput = tempDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output should exist");
+
+        JsonNode root = parseJson(jsonOutput);
+        Set<Integer> pagesInOutput = getPageNumbersFromKids(root);
+
+        assertTrue(pagesInOutput.isEmpty(), "No pages should have content when all requested pages don't exist");
+    }
+
+    private JsonNode parseJson(Path jsonPath) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readTree(Files.newInputStream(jsonPath));
+    }
+
+    /**
+     * Extracts all unique page numbers from the 'kids' array in the JSON output.
+     * Each kid element has a 'page number' field.
+     */
+    private Set<Integer> getPageNumbersFromKids(JsonNode root) {
+        Set<Integer> pageNumbers = new HashSet<>();
+        JsonNode kids = root.get("kids");
+        if (kids != null && kids.isArray()) {
+            for (JsonNode kid : kids) {
+                JsonNode pageNumber = kid.get("page number");
+                if (pageNumber != null && pageNumber.isInt()) {
+                    pageNumbers.add(pageNumber.asInt());
+                }
+            }
+        }
+        return pageNumbers;
+    }
+}

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -22,4 +22,5 @@ export function registerCliOptions(program: Command): void {
   program.option('--html-page-separator <value>', 'Separator between pages in HTML output. Use %page-number% for page numbers. Default: none');
   program.option('--image-output <value>', 'Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external');
   program.option('--image-format <value>', 'Output format for extracted images. Values: png, jpeg. Default: png');
+  program.option('--pages <value>', 'Pages to extract (e.g., "1,3,5-7"). Default: all pages');
 }

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -35,6 +35,8 @@ export interface ConvertOptions {
   imageOutput?: string;
   /** Output format for extracted images. Values: png, jpeg. Default: png */
   imageFormat?: string;
+  /** Pages to extract (e.g., "1,3,5-7"). Default: all pages */
+  pages?: string;
 }
 
 /**
@@ -56,6 +58,7 @@ export interface CliOptions {
   htmlPageSeparator?: string;
   imageOutput?: string;
   imageFormat?: string;
+  pages?: string;
 }
 
 /**
@@ -108,6 +111,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.imageFormat) {
     convertOptions.imageFormat = cliOptions.imageFormat;
+  }
+  if (cliOptions.pages) {
+    convertOptions.pages = cliOptions.pages;
   }
 
   return convertOptions;
@@ -175,6 +181,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.imageFormat) {
     args.push('--image-format', options.imageFormat);
+  }
+  if (options.pages) {
+    args.push('--pages', options.pages);
   }
 
   return args;

--- a/options.json
+++ b/options.json
@@ -119,6 +119,14 @@
       "required": false,
       "default": "png",
       "description": "Output format for extracted images. Values: png, jpeg. Default: png"
+    },
+    {
+      "name": "pages",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": null,
+      "description": "Pages to extract (e.g., \"1,3,5-7\"). Default: all pages"
     }
   ]
 }

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -144,6 +144,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "default": "png",
         "description": "Output format for extracted images. Values: png, jpeg. Default: png",
     },
+    {
+        "name": "pages",
+        "python_name": "pages",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": None,
+        "description": "Pages to extract (e.g., \"1,3,5-7\"). Default: all pages",
+    },
 ]
 
 

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -26,6 +26,7 @@ def convert(
     html_page_separator: Optional[str] = None,
     image_output: Optional[str] = None,
     image_format: Optional[str] = None,
+    pages: Optional[str] = None,
 ) -> None:
     """
     Convert PDF(s) into the requested output format(s).
@@ -47,6 +48,7 @@ def convert(
         html_page_separator: Separator between pages in HTML output. Use %page-number% for page numbers. Default: none
         image_output: Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external
         image_format: Output format for extracted images. Values: png, jpeg. Default: png
+        pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages
     """
     args: List[str] = []
 
@@ -94,5 +96,7 @@ def convert(
         args.extend(["--image-output", image_output])
     if image_format:
         args.extend(["--image-format", image_format])
+    if pages:
+        args.extend(["--pages", pages])
 
     run_jar(args, quiet)


### PR DESCRIPTION
## Summary
- Add a new CLI option `--pages` to extract specific pages from PDF documents
- The option accepts comma-separated page numbers and ranges (e.g., `"1,3,5-7"`)
- For batch processing, non-existent pages are logged as warnings and skipped (no error thrown)

## Changes
- **Config.java**: Add page range parsing logic with validation
- **CLIOptions.java**: Add `--pages` option definition (no short option)
- **DocumentProcessor.java**: Add page filtering with `getValidPageNumbers()` and `shouldProcessPage()`
- **TaggedDocumentProcessor.java**: Add page filtering support for tagged PDF processing
- **Tests**: Add unit tests for Config and CLIOptions, plus 8 integration tests

## Usage
```bash
# Extract specific pages
opendataloader-pdf --pages "1,3,5-7" document.pdf

# Single page
opendataloader-pdf --pages "5" document.pdf

# Page range
opendataloader-pdf --pages "1-10" document.pdf
```

## Test plan
- [x] Unit tests for page range parsing in Config
- [x] Unit tests for CLI option handling
- [x] Integration tests with real PDF files
- [x] All 203 tests passing (177 core + 26 CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)