### PR TITLE
fix: resolve text extraction issues in tables and reading order (#150)

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -141,6 +141,10 @@ public class DocumentProcessor {
             }
             List<IObject> pageContents = TableBorderProcessor.processTableBorders(contents.get(pageNumber), pageNumber);
             pageContents = pageContents.stream().filter(x -> !(x instanceof LineChunk)).collect(Collectors.toList());
+            // Apply reading order sorting BEFORE text line processing to ensure correct merge order
+            if (Config.READING_ORDER_XYCUT.equals(config.getReadingOrder())) {
+                pageContents = XYCutPlusPlusSorter.sort(pageContents);
+            }
             pageContents = TextLineProcessor.processTextLines(pageContents);
             pageContents = SpecialTableProcessor.detectSpecialTables(pageContents);
             contents.set(pageNumber, pageContents);

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ContentFilterProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ContentFilterProcessorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Hancom Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.opendataloader.pdf.processors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.content.TextChunk;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ContentFilterProcessorTest {
+
+    @Test
+    public void testFixAbnormalTextChunkBoundingBoxes_shortTextWithAbnormalWidth() throws Exception {
+        // Given: A short text chunk (1 char) with abnormally wide bounding box
+        // This simulates the bug where '4' has width ~38 instead of expected ~7
+        List<IObject> contents = new ArrayList<>();
+        double height = 10.0;
+        double leftX = 180.0;
+        double abnormalRightX = 222.0; // Much wider than expected for single char
+        contents.add(new TextChunk(
+            new BoundingBox(0, leftX, 100.0, abnormalRightX, 100.0 + height),
+            "4", height, height));
+
+        // When: Fix abnormal bounding boxes
+        Method method = ContentFilterProcessor.class.getDeclaredMethod(
+            "fixAbnormalTextChunkBoundingBoxes", List.class);
+        method.setAccessible(true);
+        method.invoke(null, contents);
+
+        // Then: Width should be corrected
+        TextChunk fixed = (TextChunk) contents.get(0);
+        double fixedWidth = fixed.getBoundingBox().getWidth();
+        double expectedWidth = 1 * height * 0.7; // char_count * height * 0.7
+
+        // Fixed width should be close to expected (much smaller than original)
+        Assertions.assertTrue(fixedWidth < 15,
+            "Width should be corrected to reasonable size, got: " + fixedWidth);
+        Assertions.assertEquals(leftX, fixed.getBoundingBox().getLeftX(),
+            "LeftX should remain unchanged");
+    }
+
+    @Test
+    public void testFixAbnormalTextChunkBoundingBoxes_normalWidthNotChanged() throws Exception {
+        // Given: A normal text chunk with reasonable width
+        List<IObject> contents = new ArrayList<>();
+        double height = 10.0;
+        double leftX = 100.0;
+        double normalRightX = 115.0; // Reasonable width for 2 chars
+        contents.add(new TextChunk(
+            new BoundingBox(0, leftX, 100.0, normalRightX, 100.0 + height),
+            "AB", height, height));
+
+        double originalWidth = normalRightX - leftX;
+
+        // When: Fix abnormal bounding boxes
+        Method method = ContentFilterProcessor.class.getDeclaredMethod(
+            "fixAbnormalTextChunkBoundingBoxes", List.class);
+        method.setAccessible(true);
+        method.invoke(null, contents);
+
+        // Then: Width should remain unchanged
+        TextChunk chunk = (TextChunk) contents.get(0);
+        Assertions.assertEquals(originalWidth, chunk.getBoundingBox().getWidth(), 0.01,
+            "Normal width should not be changed");
+    }
+
+    @Test
+    public void testFixAbnormalTextChunkBoundingBoxes_longTextNotChanged() throws Exception {
+        // Given: A long text chunk (more than 3 chars) - should not be fixed even if wide
+        List<IObject> contents = new ArrayList<>();
+        double height = 10.0;
+        double leftX = 100.0;
+        double rightX = 200.0; // Wide but acceptable for longer text
+        contents.add(new TextChunk(
+            new BoundingBox(0, leftX, 100.0, rightX, 100.0 + height),
+            "Hello", height, height));
+
+        double originalWidth = rightX - leftX;
+
+        // When: Fix abnormal bounding boxes
+        Method method = ContentFilterProcessor.class.getDeclaredMethod(
+            "fixAbnormalTextChunkBoundingBoxes", List.class);
+        method.setAccessible(true);
+        method.invoke(null, contents);
+
+        // Then: Width should remain unchanged (long text is not processed)
+        TextChunk chunk = (TextChunk) contents.get(0);
+        Assertions.assertEquals(originalWidth, chunk.getBoundingBox().getWidth(), 0.01,
+            "Long text width should not be changed");
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/TextProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/TextProcessorTest.java
@@ -14,6 +14,7 @@ import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,5 +42,87 @@ public class TextProcessorTest {
         contents = DocumentProcessor.removeNullObjectsFromList(contents);
         Assertions.assertEquals(1, contents.size());
         Assertions.assertTrue(contents.get(0) instanceof TextChunk);
+    }
+
+    /**
+     * Tests that areNeighborsTextChunks returns false when physical leftX gap is too large,
+     * even if textEnd/textStart positions are close (simulating non-sequential PDF stream order).
+     *
+     * Note: TextChunk's setTextStart() also modifies the bounding box leftX, so we need to
+     * set textStart/End first, then manually update the bounding box to simulate the bug scenario.
+     */
+    @Test
+    public void testAreNeighborsTextChunksRejectsDistantChunks() throws Exception {
+        double height = 10.0;
+        double fontSize = 10.0;
+
+        // Chunk 1: single char "4" - textEnd=107 means PDF stream position 107
+        TextChunk first = new TextChunk(
+            new BoundingBox(0, 183.0, 100.0, 190.0, 100.0 + height),
+            "4", fontSize, height);
+        // setTextStart/End will change bbox, so set them to values close to each other
+        // then we manually fix the bounding box
+        first.setTextStart(100.0);
+        first.setTextEnd(107.0);
+        // Override bounding box to physical position x=183
+        first.setBoundingBox(new BoundingBox(0, 183.0, 100.0, 190.0, 100.0 + height));
+
+        // Chunk 2: single char "4" at physical position x=222 (different table cell)
+        // textStart=107.5 is close to first's textEnd=107 (PDF stream proximity)
+        TextChunk second = new TextChunk(
+            new BoundingBox(0, 222.0, 100.0, 229.0, 100.0 + height),
+            "4", fontSize, height);
+        second.setTextStart(107.5);
+        second.setTextEnd(114.0);
+        // Override bounding box to physical position x=222
+        second.setBoundingBox(new BoundingBox(0, 222.0, 100.0, 229.0, 100.0 + height));
+
+        // Get private method via reflection
+        Method method = TextProcessor.class.getDeclaredMethod(
+            "areNeighborsTextChunks", TextChunk.class, TextChunk.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(null, first, second);
+
+        // Physical gap = 222 - 183 = 39
+        // Expected max gap for single char = 1 * 10 * 0.6 + 10 * 2 = 26
+        // Since 39 > 26, should return false
+        Assertions.assertFalse(result,
+            "Should reject chunks with leftX gap (39) exceeding max allowed (26)");
+    }
+
+    /**
+     * Tests that areNeighborsTextChunks returns true for physically adjacent chunks.
+     * Note: setBoundingBox() also updates textStart/textEnd, so we use bbox values
+     * that result in textEnd and textStart being close.
+     */
+    @Test
+    public void testAreNeighborsTextChunksAcceptsAdjacentChunks() throws Exception {
+        double height = 10.0;
+        double fontSize = 10.0;
+
+        // Chunk 1: "Hello" at x=100, rightX=130, so textEnd will be 130
+        TextChunk first = new TextChunk(
+            new BoundingBox(0, 100.0, 100.0, 130.0, 100.0 + height),
+            "Hello", fontSize, height);
+
+        // Chunk 2: "World" at x=130.5 (physically close, 0.5px gap from first's rightX)
+        // This makes textStart=130.5, which is close to first's textEnd=130
+        TextChunk second = new TextChunk(
+            new BoundingBox(0, 130.5, 100.0, 160.5, 100.0 + height),
+            "World", fontSize, height);
+
+        Method method = TextProcessor.class.getDeclaredMethod(
+            "areNeighborsTextChunks", TextChunk.class, TextChunk.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(null, first, second);
+
+        // textEnd=130, textStart=130.5, diff=0.5 < epsilon(1.0) => textPositionsClose=true
+        // Physical gap = 130.5 - 100 = 30.5
+        // Expected max gap for "Hello" = 5 * 10 * 0.6 + 10 * 2 = 50
+        // Since 30.5 < 50, should return true
+        Assertions.assertTrue(result,
+            "Should accept chunks with leftX gap (30.5) within max allowed (50)");
     }
 }


### PR DESCRIPTION
## Summary

- Fix table text missing issue where numbers (4, 6) were dropped from cells due to incorrect VeraPDF bounding box calculations
- Fix text order problem where Q:/A: markers appeared after content instead of before
- Add null safety checks to prevent potential NPE

## Changes

### 1. Abnormal Bounding Box Fix (`ContentFilterProcessor.java`)
Added `fixAbnormalTextChunkBoundingBoxes()` to correct oversized bounding boxes for short text chunks (1-3 characters). This occurs when PDF streams have non-sequential text rendering within a single Tj/TJ operation.

### 2. Neighbor Detection Enhancement (`TextProcessor.java`)
Enhanced `areNeighborsTextChunks()` with physical position verification using leftX gap. This prevents merging of text chunks that appear close in PDF stream order but are physically distant (e.g., in different table cells).

### 3. Reading Order Fix (`DocumentProcessor.java`)
Apply XY-Cut++ sorting BEFORE `TextLineProcessor` to ensure text chunks are merged in correct visual order rather than PDF stream order.

### 4. Unit Tests
- `ContentFilterProcessorTest.java` - Tests for abnormal bounding box correction
- `TextProcessorTest.java` - Tests for neighbor detection with physical proximity check

## Test plan

- [x] All existing tests pass (39 tests)
- [x] Benchmark passes all thresholds (NID: 0.9057, TEDS: 0.4942, MHS: 0.6631, Table F1: 0.6364)
- [x] Manual verification with sample PDFs from issue #150

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)