### PR TITLE
feat(hybrid): add formula enrichment support with LaTeX extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,32 @@ opendataloader-pdf-hybrid --ocr-lang "ja" --force-ocr  # Japanese with forced OC
 - `--ocr-lang`: Comma-separated [EasyOCR language codes](https://www.jaided.ai/easyocr/) (default: EasyOCR default languages)
 - `--force-ocr`: Force full-page OCR on all pages regardless of embedded text
 
+**Enrichment Options:**
+```bash
+# With formula enrichment (LaTeX extraction)
+opendataloader-pdf-hybrid --enrich-formula
+
+# With picture classification
+opendataloader-pdf-hybrid --enrich-picture-classes
+
+# Combined: OCR + enrichments
+opendataloader-pdf-hybrid --ocr-lang "en" --enrich-formula --enrich-picture-classes
+```
+
+- `--enrich-formula / --no-enrich-formula`: Enable formula recognition (extracts LaTeX representation)
+- `--enrich-picture-classes / --no-enrich-picture-classes`: Enable picture classification (bar_chart, pie_chart, flow_chart, etc.)
+
+**Formula Processing Note:**
+When using `--enrich-formula`, use `--hybrid-mode full` on the client side to route all pages to the backend:
+```bash
+# Server
+opendataloader-pdf-hybrid --enrich-formula
+
+# Client
+opendataloader-pdf --hybrid docling-fast --hybrid-mode full input.pdf
+```
+This is required because the formula enrichment model runs on the backend, not in Java processing.
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -222,6 +222,42 @@ opendataloader_pdf.convert(
 - **Fallback**: If backend unavailable, gracefully falls back to local processing
 - **Privacy**: Run the backend locally in Docker for 100% on-premise
 
+### Formula Extraction (LaTeX)
+
+For PDFs containing mathematical formulas, enable formula enrichment to extract LaTeX representations:
+
+```bash
+# Start backend with formula enrichment
+opendataloader-pdf-hybrid --enrich-formula
+
+# Process with full backend mode (required for formula extraction)
+opendataloader-pdf --hybrid docling-fast --hybrid-mode full input.pdf
+```
+
+Output in JSON:
+```json
+{
+  "type": "formula",
+  "page number": 1,
+  "bounding box": [226.2, 144.7, 377.1, 168.7],
+  "content": "\\frac{f(x+h) - f(x)}{h}"
+}
+```
+
+Output in Markdown:
+```markdown
+$$
+\frac{f(x+h) - f(x)}{h}
+$$
+```
+
+Output in HTML (MathJax/KaTeX compatible):
+```html
+<div class="math-display">\[\frac{f(x+h) - f(x)}{h}\]</div>
+```
+
+> **Note**: Formula extraction requires `--hybrid-mode full` to route all pages to the backend where the formula enrichment model runs.
+
 [Hybrid Mode Guide →](https://opendataloader.org/docs/hybrid-mode)
 
 <br/>

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/entities/SemanticFormula.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/entities/SemanticFormula.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Hancom Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.opendataloader.pdf.entities;
+
+import org.verapdf.wcag.algorithms.entities.BaseObject;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+
+/**
+ * Represents a mathematical formula element with LaTeX content.
+ *
+ * <p>This class stores formula content in LaTeX format, which can be rendered
+ * using MathJax, KaTeX, or similar libraries in the output formats.
+ *
+ * <p>Extends BaseObject to leverage the standard IObject implementation.
+ */
+public class SemanticFormula extends BaseObject {
+
+    private final String latex;
+
+    /**
+     * Creates a SemanticFormula with the given bounding box and LaTeX content.
+     *
+     * @param boundingBox The bounding box of the formula
+     * @param latex       The LaTeX representation of the formula
+     */
+    public SemanticFormula(BoundingBox boundingBox, String latex) {
+        super(boundingBox);
+        this.latex = latex;
+    }
+
+    /**
+     * Gets the LaTeX representation of the formula.
+     *
+     * @return The LaTeX string, or empty string if null
+     */
+    public String getLatex() {
+        return latex != null ? latex : "";
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
@@ -9,6 +9,7 @@ package org.opendataloader.pdf.html;
 
 import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.markdown.MarkdownSyntax;
 import org.opendataloader.pdf.utils.Base64ImageUtils;
 import org.opendataloader.pdf.utils.ImagesUtils;
@@ -130,6 +131,8 @@ public class HtmlGenerator implements Closeable {
     protected void write(IObject object) throws IOException {
         if (object instanceof ImageChunk) {
             writeImage((ImageChunk) object);
+        } else if (object instanceof SemanticFormula) {
+            writeFormula((SemanticFormula) object);
         } else if (object instanceof SemanticHeading) {
             writeHeading((SemanticHeading) object);
         } else if (object instanceof SemanticParagraph) {
@@ -147,6 +150,21 @@ public class HtmlGenerator implements Closeable {
         if (!isInsideTable()) {
             htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
         }
+    }
+
+    /**
+     * Writes a formula element to the HTML output using MathJax-compatible markup.
+     *
+     * @param formula the formula to write
+     * @throws IOException if unable to write to the output
+     */
+    protected void writeFormula(SemanticFormula formula) throws IOException {
+        htmlWriter.write(HtmlSyntax.HTML_MATH_DISPLAY_TAG);
+        htmlWriter.write("\\[");
+        htmlWriter.write(getCorrectString(formula.getLatex()));
+        htmlWriter.write("\\]");
+        htmlWriter.write(HtmlSyntax.HTML_MATH_DISPLAY_CLOSE_TAG);
+        htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlSyntax.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlSyntax.java
@@ -55,4 +55,8 @@ public class HtmlSyntax {
     public static final String HTML_FIGURE_CAPTION_TAG = "<figcaption>";
     /** Closing figure caption tag. */
     public static final String HTML_FIGURE_CAPTION_CLOSE_TAG = "</figcaption>";
+    /** Opening math display block tag for MathJax/KaTeX rendering. */
+    public static final String HTML_MATH_DISPLAY_TAG = "<div class=\"math-display\">";
+    /** Closing math display block tag. */
+    public static final String HTML_MATH_DISPLAY_CLOSE_TAG = "</div>";
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingSchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingSchemaTransformer.java
@@ -9,6 +9,7 @@ package org.opendataloader.pdf.hybrid;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.SemanticHeading;
@@ -67,6 +68,7 @@ public class DoclingSchemaTransformer implements HybridSchemaTransformer {
     private static final String LABEL_PAGE_HEADER = "page_header";
     private static final String LABEL_PAGE_FOOTER = "page_footer";
     private static final String LABEL_LIST_ITEM = "list_item";
+    private static final String LABEL_FORMULA = "formula";
 
     // Docling coordinate origins
     private static final String COORD_ORIGIN_BOTTOMLEFT = "BOTTOMLEFT";
@@ -261,6 +263,8 @@ public class DoclingSchemaTransformer implements HybridSchemaTransformer {
         IObject object;
         if (LABEL_SECTION_HEADER.equals(label)) {
             object = createHeading(text, bbox, textNode);
+        } else if (LABEL_FORMULA.equals(label)) {
+            object = createFormula(text, bbox);
         } else {
             object = createParagraph(text, bbox);
         }
@@ -311,6 +315,19 @@ public class DoclingSchemaTransformer implements HybridSchemaTransformer {
         paragraph.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
 
         return paragraph;
+    }
+
+    /**
+     * Creates a SemanticFormula from Docling formula element.
+     *
+     * @param latex The LaTeX representation of the formula
+     * @param bbox  The bounding box
+     * @return A SemanticFormula object
+     */
+    private SemanticFormula createFormula(String latex, BoundingBox bbox) {
+        SemanticFormula formula = new SemanticFormula(bbox, latex);
+        formula.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+        return formula;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonName.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonName.java
@@ -55,4 +55,5 @@ public class JsonName {
     public static final String SOURCE = "source";
     public static final String DATA = "data";
     public static final String IMAGE_FORMAT = "format";
+    public static final String FORMULA_TYPE = "formula";
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/ObjectMapperHolder.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/ObjectMapperHolder.java
@@ -10,6 +10,7 @@ package org.opendataloader.pdf.json;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.json.serializers.*;
 import org.verapdf.wcag.algorithms.entities.SemanticCaption;
 import org.verapdf.wcag.algorithms.entities.SemanticHeaderOrFooter;
@@ -74,6 +75,9 @@ public class ObjectMapperHolder {
 
         HeaderFooterSerializer headerFooterSerializer = new HeaderFooterSerializer(SemanticHeaderOrFooter.class);
         module.addSerializer(SemanticHeaderOrFooter.class, headerFooterSerializer);
+
+        FormulaSerializer formulaSerializer = new FormulaSerializer(SemanticFormula.class);
+        module.addSerializer(SemanticFormula.class, formulaSerializer);
 
         //ParagraphSerializer paragraphSerializer = new ParagraphSerializer(SemanticParagraph.class);
         //module.addSerializer(SemanticParagraph.class, paragraphSerializer);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/FormulaSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/FormulaSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Hancom Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.opendataloader.pdf.json.serializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.opendataloader.pdf.entities.SemanticFormula;
+import org.opendataloader.pdf.json.JsonName;
+
+import java.io.IOException;
+
+/**
+ * JSON serializer for SemanticFormula objects.
+ *
+ * <p>Produces JSON output in the format:
+ * <pre>
+ * {
+ *   "type": "formula",
+ *   "id": 123,
+ *   "page number": 1,
+ *   "bounding box": [x1, y1, x2, y2],
+ *   "content": "\\frac{a}{b}"
+ * }
+ * </pre>
+ */
+public class FormulaSerializer extends StdSerializer<SemanticFormula> {
+
+    public FormulaSerializer(Class<SemanticFormula> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(SemanticFormula formula, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeStartObject();
+        SerializerUtil.writeEssentialInfo(jsonGenerator, formula, JsonName.FORMULA_TYPE);
+        jsonGenerator.writeStringField(JsonName.CONTENT, formula.getLatex());
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -9,6 +9,7 @@ package org.opendataloader.pdf.markdown;
 
 import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.utils.Base64ImageUtils;
 import org.opendataloader.pdf.utils.ImagesUtils;
 import org.verapdf.wcag.algorithms.entities.IObject;
@@ -83,6 +84,7 @@ public class MarkdownGenerator implements Closeable {
 
     protected boolean isSupportedContent(IObject content) {
         return content instanceof SemanticTextNode || // Heading, Paragraph etc...
+            content instanceof SemanticFormula ||
             content instanceof TableBorder ||
             content instanceof PDFList ||
             (content instanceof ImageChunk && isImageSupported);
@@ -96,6 +98,8 @@ public class MarkdownGenerator implements Closeable {
     protected void write(IObject object) throws IOException {
         if (object instanceof ImageChunk) {
             writeImage((ImageChunk) object);
+        } else if (object instanceof SemanticFormula) {
+            writeFormula((SemanticFormula) object);
         } else if (object instanceof SemanticHeading) {
             writeHeading((SemanticHeading) object);
         } else if (object instanceof SemanticParagraph) {
@@ -133,6 +137,19 @@ public class MarkdownGenerator implements Closeable {
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Unable to write image for markdown output: " + e.getMessage());
         }
+    }
+
+    /**
+     * Writes a formula in LaTeX format wrapped in $$ delimiters.
+     *
+     * @param formula The formula to write
+     */
+    protected void writeFormula(SemanticFormula formula) throws IOException {
+        markdownWriter.write(MarkdownSyntax.MATH_BLOCK_START);
+        markdownWriter.write(MarkdownSyntax.LINE_BREAK);
+        markdownWriter.write(formula.getLatex());
+        markdownWriter.write(MarkdownSyntax.LINE_BREAK);
+        markdownWriter.write(MarkdownSyntax.MATH_BLOCK_END);
     }
 
     protected void writeList(PDFList list) throws IOException {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownSyntax.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownSyntax.java
@@ -37,4 +37,6 @@ public class MarkdownSyntax {
     public static final String HTML_INDENT = "&nbsp;&nbsp;&nbsp;&nbsp;";
     public static final String HTML_PARAGRAPH_TAG = "<p>";
     public static final String HTML_PARAGRAPH_CLOSE_TAG = "</p>";
+    public static final String MATH_BLOCK_START = "$$";
+    public static final String MATH_BLOCK_END = "$$";
 }


### PR DESCRIPTION
## Summary

- Add `--enrich-formula` CLI option to hybrid server for LaTeX formula extraction
- Add `--enrich-picture-classes` CLI option for picture classification
- Create dedicated `SemanticFormula` entity for formula output in JSON, Markdown, HTML
- Add unit tests for formula parsing in `DoclingSchemaTransformer`

## Changes

| File | Description |
|------|-------------|
| `SemanticFormula.java` | New entity class for formula elements |
| `FormulaSerializer.java` | JSON serializer with `type: "formula"`, `content: "<latex>"` |
| `DoclingSchemaTransformer.java` | Handle `label: "formula"` from docling |
| `MarkdownGenerator.java` | Output `$$...$$` block syntax |
| `HtmlGenerator.java` | Output `\[...\]` MathJax-compatible syntax |
| `hybrid_server.py` | Add `--enrich-formula`, `--enrich-picture-classes` options |
| `README.md`, `CLAUDE.md` | Documentation updates |

## Output Examples

**JSON:**
```json
{
  "type": "formula",
  "page number": 1,
  "bounding box": [226.2, 144.7, 377.1, 168.7],
  "content": "\\frac{f(x+h) - f(x)}{h}"
}
```

**Markdown:**
```markdown
$$
\frac{f(x+h) - f(x)}{h}
$$
```

**HTML:**
```html
<div class="math-display">\[\frac{f(x+h) - f(x)}{h}\]</div>
```

## Test plan

### Quick test with formula PDF (01030000000143.pdf)

**Terminal 1: Start hybrid server with formula enrichment**
```bash
cd python/opendataloader-pdf && pip install -e ".[hybrid]"
opendataloader-pdf-hybrid --enrich-formula --log-level debug
```

**Terminal 2: Process PDF**
```bash
# Build CLI (if needed)
cd java && mvn package -DskipTests -q

# output
java -jar java/opendataloader-pdf-cli/target/opendataloader-pdf-cli-*-shaded.jar \
  --hybrid docling-fast --hybrid-mode full --format json,markdown,html \
  tests/benchmark/pdfs/01030000000143.pdf
```

### Unit tests
```bash
cd java && mvn test -Dtest=DoclingSchemaTransformerTest
```

- [ ] Hybrid server starts with `--enrich-formula` option
- [ ] JSON output contains `type: "formula"` elements with LaTeX in `content` field
- [ ] Markdown output contains `$$...$$` blocks
- [ ] HTML output contains `<div class="math-display">\[...\]</div>`
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)