### PR TITLE
chore(java): update all dependencies to latest stable versions

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,18 +52,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <verapdf.version>[1.29.0,1.30.0-RC)</verapdf.version>
         <junit.jupiter.version>5.14.0</junit.jupiter.version>
-        <assertj.version>3.27.6</assertj.version>
-        <commons.cli.version>1.10.0</commons.cli.version>
+        <assertj.version>3.27.7</assertj.version>
+        <commons.cli.version>1.11.0</commons.cli.version>
         <maven-compiler.plugin.version>3.14.1</maven-compiler.plugin.version>
         <flatten.plugin.version>1.7.3</flatten.plugin.version>
-        <jacoco.plugin.version>0.8.13</jacoco.plugin.version>
+        <jacoco.plugin.version>0.8.14</jacoco.plugin.version>
         <maven-source.plugin.version>3.3.1</maven-source.plugin.version>
         <maven-javadoc.plugin.version>3.12.0</maven-javadoc.plugin.version>
         <maven-shade.plugin.version>3.6.1</maven-shade.plugin.version>
         <maven-gpg.plugin.version>3.2.8</maven-gpg.plugin.version>
-        <central-publishing.plugin.version>0.9.0</central-publishing.plugin.version>
+        <central-publishing.plugin.version>0.10.0</central-publishing.plugin.version>
         <checkstyle.plugin.version>3.6.0</checkstyle.plugin.version>
-        <spotbugs.plugin.version>4.9.3.0</spotbugs.plugin.version>
+        <spotbugs.plugin.version>4.9.8.2</spotbugs.plugin.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Summary
- Update all Java dependencies to latest stable versions
- **Fixes CVE-2026-24400** (AssertJ XXE vulnerability)

## Key Updates
| Package | From | To | Note |
|---------|------|----|----|
| assertj-core | 3.27.6 | 3.27.7 | 🔒 Security fix |
| commons-cli | 1.10.0 | 1.11.0 | |
| jacoco-maven-plugin | 0.8.13 | 0.8.14 | |
| central-publishing-maven-plugin | 0.9.0 | 0.10.0 | |
| spotbugs-maven-plugin | 4.9.3.0 | 4.9.8.2 | |

## Test plan
- [x] All Java tests pass locally

🤖 Generated with [Claude Code](https://claude.ai/code)