### PR TITLE
feat: add --include-header-footer option for output generation

### DIFF
--- a/content/docs/_generated/node-convert-options.mdx
+++ b/content/docs/_generated/node-convert-options.mdx
@@ -26,6 +26,7 @@ description: Options for the Node.js convert function
 | `imageFormat`           | `string`             | `"png"`      | Output format for extracted images. Values: png, jpeg. Default: png                                                                |
 | `imageDir`              | `string`             | -            | Directory for extracted images                                                                                                     |
 | `pages`                 | `string`             | -            | Pages to extract (e.g., "1,3,5-7"). Default: all pages                                                                             |
+| `includeHeaderFooter`   | `boolean`            | `false`      | Include page headers and footers in output                                                                                         |
 | `hybrid`                | `string`             | `"off"`      | Hybrid backend for AI processing. Values: off (default), docling-fast                                                              |
 | `hybridMode`            | `string`             | `"auto"`     | Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)                               |
 | `hybridUrl`             | `string`             | -            | Hybrid backend server URL (overrides default)                                                                                      |

--- a/content/docs/_generated/python-convert-options.mdx
+++ b/content/docs/_generated/python-convert-options.mdx
@@ -27,6 +27,7 @@ description: Options for the Python convert function
 | `image_format`            | `str`                | `"png"`      | Output format for extracted images. Values: png, jpeg. Default: png                                                                |
 | `image_dir`               | `str`                | -            | Directory for extracted images                                                                                                     |
 | `pages`                   | `str`                | -            | Pages to extract (e.g., "1,3,5-7"). Default: all pages                                                                             |
+| `include_header_footer`   | `bool`               | `False`      | Include page headers and footers in output                                                                                         |
 | `hybrid`                  | `str`                | `"off"`      | Hybrid backend for AI processing. Values: off (default), docling-fast                                                              |
 | `hybrid_mode`             | `str`                | `"auto"`     | Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)                               |
 | `hybrid_url`              | `str`                | -            | Hybrid backend server URL (overrides default)                                                                                      |

--- a/content/docs/cli-options-reference.mdx
+++ b/content/docs/cli-options-reference.mdx
@@ -30,6 +30,7 @@ This page documents all available CLI options for opendataloader-pdf.
 | `--image-format`            | -     | `string`  | `"png"`      | Output format for extracted images. Values: png, jpeg. Default: png                                                                |
 | `--image-dir`               | -     | `string`  | -            | Directory for extracted images                                                                                                     |
 | `--pages`                   | -     | `string`  | -            | Pages to extract (e.g., "1,3,5-7"). Default: all pages                                                                             |
+| `--include-header-footer`   | -     | `boolean` | `false`      | Include page headers and footers in output                                                                                         |
 | `--hybrid`                  | -     | `string`  | `"off"`      | Hybrid backend for AI processing. Values: off (default), docling-fast                                                              |
 | `--hybrid-mode`             | -     | `string`  | `"auto"`     | Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)                               |
 | `--hybrid-url`              | -     | `string`  | -            | Hybrid backend server URL (overrides default)                                                                                      |

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
@@ -93,6 +93,10 @@ public class CLIOptions {
     private static final String PAGES_LONG_OPTION = "pages";
     private static final String PAGES_DESC = "Pages to extract (e.g., \"1,3,5-7\"). Default: all pages";
 
+    // ===== Include Header Footer =====
+    private static final String INCLUDE_HEADER_FOOTER_LONG_OPTION = "include-header-footer";
+    private static final String INCLUDE_HEADER_FOOTER_DESC = "Include page headers and footers in output";
+
     // ===== Hybrid Mode =====
     private static final String HYBRID_LONG_OPTION = "hybrid";
     private static final String HYBRID_DESC = "Hybrid backend for AI processing. Values: off (default), docling-fast";
@@ -150,6 +154,8 @@ public class CLIOptions {
             new OptionDefinition(IMAGE_FORMAT_LONG_OPTION, null, "string", "png", IMAGE_FORMAT_DESC, true),
             new OptionDefinition(IMAGE_DIR_LONG_OPTION, null, "string", null, IMAGE_DIR_DESC, true),
             new OptionDefinition(PAGES_LONG_OPTION, null, "string", null, PAGES_DESC, true),
+            new OptionDefinition(INCLUDE_HEADER_FOOTER_LONG_OPTION, null, "boolean", false,
+                    INCLUDE_HEADER_FOOTER_DESC, true),
             new OptionDefinition(HYBRID_LONG_OPTION, null, "string", "off", HYBRID_DESC, true),
             new OptionDefinition(HYBRID_MODE_LONG_OPTION, null, "string", "auto", HYBRID_MODE_DESC, true),
             new OptionDefinition(HYBRID_URL_LONG_OPTION, null, "string", null, HYBRID_URL_DESC, true),
@@ -206,6 +212,9 @@ public class CLIOptions {
         }
         if (commandLine.hasOption(CLIOptions.USE_STRUCT_TREE_LONG_OPTION)) {
             config.setUseStructTree(true);
+        }
+        if (commandLine.hasOption(INCLUDE_HEADER_FOOTER_LONG_OPTION)) {
+            config.setIncludeHeaderFooter(true);
         }
         if (commandLine.hasOption(CLIOptions.READING_ORDER_LONG_OPTION)) {
             config.setReadingOrder(commandLine.getOptionValue(CLIOptions.READING_ORDER_LONG_OPTION));

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -73,6 +73,7 @@ public class Config {
     private final FilterConfig filterConfig = new FilterConfig();
     private String hybrid = HYBRID_OFF;
     private final HybridConfig hybridConfig = new HybridConfig();
+    private boolean includeHeaderFooter = false;
 
     /** Table detection method: default (border-based detection). */
     public static final String TABLE_METHOD_DEFAULT = "default";
@@ -816,6 +817,24 @@ public class Config {
      */
     public static boolean isValidHybridMode(String mode) {
         return mode != null && hybridModeOptions.contains(mode.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Checks if page headers and footers should be included in output.
+     *
+     * @return true if headers and footers should be included, false otherwise.
+     */
+    public boolean isIncludeHeaderFooter() {
+        return includeHeaderFooter;
+    }
+
+    /**
+     * Enables or disables inclusion of page headers and footers in output.
+     *
+     * @param includeHeaderFooter true to include headers and footers, false to exclude.
+     */
+    public void setIncludeHeaderFooter(boolean includeHeaderFooter) {
+        this.includeHeaderFooter = includeHeaderFooter;
     }
 
 }

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -24,6 +24,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--image-format <value>', 'Output format for extracted images. Values: png, jpeg. Default: png');
   program.option('--image-dir <value>', 'Directory for extracted images');
   program.option('--pages <value>', 'Pages to extract (e.g., "1,3,5-7"). Default: all pages');
+  program.option('--include-header-footer', 'Include page headers and footers in output');
   program.option('--hybrid <value>', 'Hybrid backend for AI processing. Values: off (default), docling-fast');
   program.option('--hybrid-mode <value>', 'Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)');
   program.option('--hybrid-url <value>', 'Hybrid backend server URL (overrides default)');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -39,6 +39,8 @@ export interface ConvertOptions {
   imageDir?: string;
   /** Pages to extract (e.g., "1,3,5-7"). Default: all pages */
   pages?: string;
+  /** Include page headers and footers in output */
+  includeHeaderFooter?: boolean;
   /** Hybrid backend for AI processing. Values: off (default), docling-fast */
   hybrid?: string;
   /** Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend) */
@@ -72,6 +74,7 @@ export interface CliOptions {
   imageFormat?: string;
   imageDir?: string;
   pages?: string;
+  includeHeaderFooter?: boolean;
   hybrid?: string;
   hybridMode?: string;
   hybridUrl?: string;
@@ -135,6 +138,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.pages) {
     convertOptions.pages = cliOptions.pages;
+  }
+  if (cliOptions.includeHeaderFooter) {
+    convertOptions.includeHeaderFooter = true;
   }
   if (cliOptions.hybrid) {
     convertOptions.hybrid = cliOptions.hybrid;
@@ -223,6 +229,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.pages) {
     args.push('--pages', options.pages);
+  }
+  if (options.includeHeaderFooter) {
+    args.push('--include-header-footer');
   }
   if (options.hybrid) {
     args.push('--hybrid', options.hybrid);

--- a/options.json
+++ b/options.json
@@ -137,6 +137,14 @@
       "description": "Pages to extract (e.g., \"1,3,5-7\"). Default: all pages"
     },
     {
+      "name": "include-header-footer",
+      "shortName": null,
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "description": "Include page headers and footers in output"
+    },
+    {
       "name": "hybrid",
       "shortName": null,
       "type": "string",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -163,6 +163,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "description": "Pages to extract (e.g., \"1,3,5-7\"). Default: all pages",
     },
     {
+        "name": "include-header-footer",
+        "python_name": "include_header_footer",
+        "short_name": None,
+        "type": "boolean",
+        "required": False,
+        "default": False,
+        "description": "Include page headers and footers in output",
+    },
+    {
         "name": "hybrid",
         "python_name": "hybrid",
         "short_name": None,

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -28,6 +28,7 @@ def convert(
     image_format: Optional[str] = None,
     image_dir: Optional[str] = None,
     pages: Optional[str] = None,
+    include_header_footer: bool = False,
     hybrid: Optional[str] = None,
     hybrid_mode: Optional[str] = None,
     hybrid_url: Optional[str] = None,
@@ -56,6 +57,7 @@ def convert(
         image_format: Output format for extracted images. Values: png, jpeg. Default: png
         image_dir: Directory for extracted images
         pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages
+        include_header_footer: Include page headers and footers in output
         hybrid: Hybrid backend for AI processing. Values: off (default), docling-fast
         hybrid_mode: Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)
         hybrid_url: Hybrid backend server URL (overrides default)
@@ -112,6 +114,8 @@ def convert(
         args.extend(["--image-dir", image_dir])
     if pages:
         args.extend(["--pages", pages])
+    if include_header_footer:
+        args.append("--include-header-footer")
     if hybrid:
         args.extend(["--hybrid", hybrid])
     if hybrid_mode:


### PR DESCRIPTION
## Summary

- Add new `--include-header-footer` CLI option to include page headers and footers in Markdown, HTML, and Text output
- Previously, detected headers/footers were only serialized to JSON but excluded from other output formats
- Default behavior remains unchanged (headers/footers excluded)

## Changes

- **Config.java**: Add `includeHeaderFooter` field with getter/setter
- **CLIOptions.java**: Add `--include-header-footer` option definition and parsing
- **MarkdownGenerator.java**: Handle `SemanticHeaderOrFooter` when option enabled
- **HtmlGenerator.java**: Handle `SemanticHeaderOrFooter` when option enabled
- **TextGenerator.java**: Handle `SemanticHeaderOrFooter` when option enabled
- Auto-generated Python/Node.js bindings updated via `npm run sync`

## Test Plan

### CLI Test
```bash
# Build
./scripts/build-java.sh

# Without option (default - headers/footers excluded)
java -jar java/opendataloader-pdf-cli/target/opendataloader-pdf-cli-0.0.0.jar \
  --format markdown samples/pdf/1901.03003.pdf -o /tmp/test-no-hf -q

# With option (headers/footers included)
java -jar java/opendataloader-pdf-cli/target/opendataloader-pdf-cli-0.0.0.jar \
  --format markdown --include-header-footer samples/pdf/1901.03003.pdf -o /tmp/test-with-hf -q

# Compare outputs - should show footer page numbers added
diff /tmp/test-no-hf/1901.03003.md /tmp/test-with-hf/1901.03003.md

# Verify footers are present (page numbers 1-15)
grep -n "^###### [0-9]" /tmp/test-with-hf/1901.03003.md
```

### Expected Result
- Default behavior unchanged (no headers/footers in output)
- With `--include-header-footer`, page footers (e.g., page numbers) appear in Markdown output
- JSON output unchanged (already includes headers/footers)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)