### PR TITLE
fix: prevent StackOverflowError in XYCutPlusPlusSorter

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/readingorder/XYCutPlusPlusSorter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/readingorder/XYCutPlusPlusSorter.java
@@ -368,9 +368,19 @@ public class XYCutPlusPlusSorter {
 
         if (useHorizontalCut) {
             List<List<IObject>> groups = splitByHorizontalCut(objects, horizontalCut.position);
+            // Safety check: if split didn't actually separate objects, fall back to default sort
+            // This prevents infinite recursion when all objects end up in one group
+            if (groups.size() <= 1) {
+                return sortByYThenX(objects);
+            }
             return flatMapRecursive(groups, preferHorizontalFirst);
         } else {
             List<List<IObject>> groups = splitByVerticalCut(objects, verticalCut.position);
+            // Safety check: if split didn't actually separate objects, fall back to default sort
+            // This prevents infinite recursion when all objects end up in one group
+            if (groups.size() <= 1) {
+                return sortByYThenX(objects);
+            }
             return flatMapRecursive(groups, preferHorizontalFirst);
         }
     }


### PR DESCRIPTION
## Summary
- Add progress guarantee check to prevent infinite recursion in `XYCutPlusPlusSorter.recursiveSegment`
- Add 5 regression test cases for edge conditions that could trigger infinite recursion

Fixes #179

## Root Cause
The bug occurred when:
1. Gap detection (using object edges: leftX/rightX, topY/bottomY) found a valid cut position
2. But split operation (using object centers) placed all objects in one group
3. This caused the same gap to be found repeatedly, leading to infinite recursion

## Solution
Added safety check after split operations: if only one group is returned (meaning the split didn't actually separate objects), fall back to `sortByYThenX` instead of recursing.

## Test plan
- [x] All existing unit tests pass (322 tests)
- [x] Added 5 new test cases specifically for infinite recursion prevention
- [x] Benchmark shows no regression (NID=0.9127, TEDS=0.4942, MHS=0.7606)

🤖 Generated with [Claude Code](https://claude.com/claude-code)