### PR TITLE
fix: skip Claude Code Review workflow for fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Skip for fork PRs (secrets not available)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add condition to skip Claude Code Review job when PR comes from a fork
- Fork PRs will show as "skipped" instead of "failed"
- Internal PRs continue to run Claude Code Review normally

## Problem
GitHub does not expose secrets to workflows triggered by fork PRs (security policy). This causes the workflow to fail because `CLAUDE_CODE_OAUTH_TOKEN` is empty, resulting in a red X on external contributor PRs.

## Solution
Add `if: github.event.pull_request.head.repo.full_name == github.repository` condition to skip the job for fork PRs.

## Test plan
- [ ] Create an internal PR and verify Claude Code Review runs
- [ ] Verify fork PRs show "skipped" status (can be tested after merge by external contributor)

Closes #185

🤖 Generated with [Claude Code](https://claude.ai/code)