### PR TITLE
fix: add Unicode sanitization to hybrid server response

### DIFF
--- a/python/opendataloader-pdf/tests/test_hybrid_server_unicode.py
+++ b/python/opendataloader-pdf/tests/test_hybrid_server_unicode.py
@@ -1,0 +1,86 @@
+"""Tests for Unicode sanitization in hybrid server responses.
+
+Validates that lone surrogates and null characters from Docling OCR output
+are sanitized before JSON serialization to prevent UnicodeEncodeError in
+Starlette's JSONResponse.render().
+"""
+
+import json
+
+import pytest
+
+from opendataloader_pdf.hybrid_server import sanitize_unicode
+
+
+class TestSanitizeUnicode:
+    """Tests for the sanitize_unicode function."""
+
+    def test_lone_surrogate_replaced(self):
+        """Lone surrogates should be replaced with U+FFFD."""
+        data = {"text": "Hello \ud800 World"}
+        result = sanitize_unicode(data)
+        assert "\ud800" not in result["text"]
+        assert "\ufffd" in result["text"]
+
+    def test_all_surrogate_range_replaced(self):
+        """All surrogate code points (U+D800 to U+DFFF) should be replaced."""
+        data = {"text": "\ud800\udbff\udc00\udfff"}
+        result = sanitize_unicode(data)
+        assert result["text"] == "\ufffd" * 4
+
+    def test_null_character_replaced(self):
+        """Null characters should be replaced with U+FFFD."""
+        data = {"text": "Hello\x00World"}
+        result = sanitize_unicode(data)
+        assert "\x00" not in result["text"]
+        assert result["text"] == "Hello\ufffdWorld"
+
+    def test_nested_dict_sanitized(self):
+        """Nested dictionaries should be sanitized recursively."""
+        data = {"level1": {"level2": {"text": "bad\ud800char"}}}
+        result = sanitize_unicode(data)
+        assert "\ud800" not in result["level1"]["level2"]["text"]
+        assert "\ufffd" in result["level1"]["level2"]["text"]
+
+    def test_list_sanitized(self):
+        """Lists within the data should be sanitized."""
+        data = {"items": ["good", "bad\ud800text", "also\x00bad"]}
+        result = sanitize_unicode(data)
+        assert result["items"][0] == "good"
+        assert "\ud800" not in result["items"][1]
+        assert "\x00" not in result["items"][2]
+
+    def test_clean_data_unchanged(self):
+        """Clean data without problematic characters should pass through unchanged."""
+        data = {"text": "Hello World", "number": 42, "flag": True, "nothing": None}
+        result = sanitize_unicode(data)
+        assert result == data
+
+    def test_non_string_values_preserved(self):
+        """Non-string values (int, float, bool, None) should be preserved as-is."""
+        data = {"int": 42, "float": 3.14, "bool": True, "none": None}
+        result = sanitize_unicode(data)
+        assert result == data
+
+    def test_sanitized_output_json_serializable(self):
+        """Sanitized output must survive json.dumps + encode('utf-8') without error."""
+        data = {
+            "status": "success",
+            "document": {
+                "json_content": {
+                    "body": {"text": "OCR text with \ud800 lone surrogate and \x00 null"}
+                }
+            },
+        }
+        result = sanitize_unicode(data)
+        # This is the exact operation that Starlette's JSONResponse.render() performs
+        json_bytes = json.dumps(result, ensure_ascii=False).encode("utf-8")
+        assert isinstance(json_bytes, bytes)
+
+    def test_mixed_valid_and_invalid_unicode(self):
+        """Valid Unicode (including CJK, emoji) should be preserved alongside sanitization."""
+        data = {"text": "Valid \u4e16\u754c \ud800 text"}
+        result = sanitize_unicode(data)
+        assert "\u4e16\u754c" in result["text"]  # CJK preserved
+        assert "\ud800" not in result["text"]  # surrogate removed
+        assert "\ufffd" in result["text"]  # replacement added


### PR DESCRIPTION
## Summary
Fixes #201

- Add `sanitize_unicode()` function that recursively replaces lone surrogates (U+D800-U+DFFF) and null characters with U+FFFD (Unicode replacement character) before JSON serialization
- Apply sanitization to `export_to_dict()` output in the `/v1/convert/file` endpoint to prevent `UnicodeEncodeError` in Starlette's `JSONResponse.render()`
- Improve error messages in exception handler to include exception type and details

## Environment
- Python 3.13.7, macOS Darwin 25.3.0
- Starlette/FastAPI JSONResponse
- Docling OCR producing lone surrogates from PDFs with malformed font encodings

## Reproduction
1. Docling processes a PDF with malformed font encodings, producing text with lone surrogates (`\ud800`-`\udfff`)
2. `json.dumps(data, ensure_ascii=False)` passes lone surrogates through
3. Starlette's `JSONResponse.render()` calls `.encode("utf-8")` which rejects lone surrogates
4. Server returns 500 with `UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' - surrogates not allowed`

## Test
- `tests/test_hybrid_server_unicode.py::TestSanitizeUnicode` (9 tests)
- Verifies: lone surrogates replaced, null chars replaced, recursive dict/list sanitization, clean data unchanged, non-string types preserved, sanitized output is JSON-serializable, valid CJK preserved

## Result
- Before: `UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 100: surrogates not allowed`
- After: All 9 new tests pass, full suite 21/21 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)