### PR TITLE
feat: publish hybrid server Docker image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,15 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/opendataloader-pdf-cli:${{ env.VERSION }}
             ghcr.io/${{ github.repository_owner }}/opendataloader-pdf-cli:latest
 
+      - name: Wait for PyPI package availability
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          for i in $(seq 1 12); do
+            pip index versions opendataloader-pdf 2>/dev/null | grep -q "${{ env.VERSION }}" && exit 0
+            echo "Waiting for PyPI propagation... ($i/12)"; sleep 15
+          done
+          echo "WARNING: PyPI propagation timed out, proceeding anyway"
+
       - name: Build and push Hybrid Server Docker image (CPU)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v5

--- a/content/docs/hybrid-mode.mdx
+++ b/content/docs/hybrid-mode.mdx
@@ -241,9 +241,9 @@ services:
       /input/document.pdf
 ```
 
-### Environment Variables
+### Server Options
 
-Configure the hybrid server via command arguments in Docker:
+Configure the hybrid server via command-line arguments in Docker:
 
 ```bash
 docker run -p 5002:5002 ghcr.io/opendataloader-project/opendataloader-pdf-hybrid \

--- a/python/opendataloader-pdf/Dockerfile.hybrid
+++ b/python/opendataloader-pdf/Dockerfile.hybrid
@@ -1,17 +1,21 @@
 FROM python:3.11-slim
 
 ARG VERSION
+RUN test -n "${VERSION}" || (echo "ERROR: --build-arg VERSION=<ver> is required" && exit 1)
 
 LABEL org.opencontainers.image.title="opendataloader-pdf-hybrid" \
       org.opencontainers.image.description="OpenDataLoader PDF Hybrid Server (CPU)" \
       org.opencontainers.image.vendor="Hancom Inc." \
-      org.opencontainers.image.licenses="MPL-2.0"
+      org.opencontainers.image.licenses="MPL-2.0" \
+      org.opencontainers.image.source="https://github.com/opendataloader-project/opendataloader-pdf" \
+      org.opencontainers.image.version="${VERSION}"
 
+# curl: healthcheck, libgl1/libglib2.0-0: OpenCV dependencies for Docling
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl libgl1 libglib2.0-0 && \
     pip install --no-cache-dir "opendataloader-pdf[hybrid]==${VERSION}" && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    useradd --no-create-home --shell /bin/false appuser
+    useradd --create-home --shell /bin/false appuser
 USER appuser
 
 EXPOSE 5002

--- a/python/opendataloader-pdf/Dockerfile.hybrid-gpu
+++ b/python/opendataloader-pdf/Dockerfile.hybrid-gpu
@@ -1,18 +1,23 @@
 FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
 
 ARG VERSION
+RUN test -n "${VERSION}" || (echo "ERROR: --build-arg VERSION=<ver> is required" && exit 1)
 
 LABEL org.opencontainers.image.title="opendataloader-pdf-hybrid-gpu" \
       org.opencontainers.image.description="OpenDataLoader PDF Hybrid Server (GPU)" \
       org.opencontainers.image.vendor="Hancom Inc." \
-      org.opencontainers.image.licenses="MPL-2.0"
+      org.opencontainers.image.licenses="MPL-2.0" \
+      org.opencontainers.image.source="https://github.com/opendataloader-project/opendataloader-pdf" \
+      org.opencontainers.image.version="${VERSION}"
 
+# curl: healthcheck, libgl1/libglib2.0-0: OpenCV dependencies for Docling
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl libgl1 libglib2.0-0 && \
     pip install --no-cache-dir "opendataloader-pdf[hybrid]==${VERSION}" \
-        --extra-index-url https://download.pytorch.org/whl/cu124 && \
+        --index-url https://download.pytorch.org/whl/cu124 \
+        --extra-index-url https://pypi.org/simple && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    useradd --no-create-home --shell /bin/false appuser
+    useradd --create-home --shell /bin/false appuser
 
 USER appuser
 


### PR DESCRIPTION
## Summary
Fixes #205, Fixes #206

- Add `Dockerfile.hybrid` (CPU): `python:3.11-slim` base, installs `opendataloader-pdf[hybrid]`, exposes port 5002 with health check
- Add `Dockerfile.hybrid-gpu` (GPU): `pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime` base with `--extra-index-url` for PyTorch CUDA index to preserve GPU support
- Add CI steps to `release.yml` to build and push both images to GHCR on tag push
- Version pinned via `ARG VERSION` / `build-args` to ensure image matches the released tag
- Non-root user (`appuser`) for both images
- Add Docker Deployment section to `hybrid-mode.mdx`: quick start, docker-compose (CPU/GPU), environment variables, custom Dockerfile examples

### Image tags
| Variant | Tags |
|---------|------|
| CPU | `:VERSION`, `:latest` |
| GPU | `:VERSION-gpu`, `:latest-gpu` |

## Test plan
- [ ] Verify CPU Dockerfile builds locally: `docker build -f python/opendataloader-pdf/Dockerfile.hybrid --build-arg VERSION=<ver> -t test-hybrid ./python/opendataloader-pdf`
- [ ] Verify GPU Dockerfile builds locally (requires NVIDIA base image pull)
- [ ] Verify release workflow YAML is valid
- [ ] Verify documentation renders correctly on opendataloader.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)