### PR TITLE
fix: handle Docling PARTIAL_SUCCESS and fallback failed pages to Java

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingFastServerClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingFastServerClient.java
@@ -18,8 +18,11 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -155,10 +158,18 @@ public class DoclingFastServerClient implements HybridClient {
 
         // Check for API error status
         JsonNode statusNode = root.get("status");
-        if (statusNode != null && "failure".equals(statusNode.asText())) {
+        String status = statusNode != null ? statusNode.asText() : "";
+        if ("failure".equals(status)) {
             JsonNode errorsNode = root.get("errors");
             String errorMessage = errorsNode != null ? errorsNode.toString() : "Unknown error";
             throw new IOException("Docling Fast Server processing failed: " + errorMessage);
+        }
+
+        // Log partial_success status
+        if ("partial_success".equals(status)) {
+            JsonNode errorsNode = root.get("errors");
+            LOGGER.log(Level.WARNING, "Backend returned partial_success: {0}",
+                errorsNode != null ? errorsNode.toString() : "no error details");
         }
 
         // Extract document content
@@ -172,7 +183,10 @@ public class DoclingFastServerClient implements HybridClient {
         // Extract per-page content from json_content if available
         Map<Integer, JsonNode> pageContents = extractPageContents(jsonContent);
 
-        return new HybridResponse(null, null, jsonContent, pageContents);
+        // Extract failed pages (1-indexed) from partial_success responses
+        List<Integer> failedPages = extractFailedPages(root);
+
+        return new HybridResponse(null, null, jsonContent, pageContents, failedPages);
     }
 
     /**
@@ -205,6 +219,28 @@ public class DoclingFastServerClient implements HybridClient {
         }
 
         return pageContents;
+    }
+
+    /**
+     * Extracts the list of failed page numbers from the response.
+     *
+     * <p>When the backend returns partial_success, the failed_pages array contains
+     * 1-indexed page numbers that failed during processing (e.g., due to Invalid code point
+     * errors in PDF font encoding).
+     */
+    private List<Integer> extractFailedPages(JsonNode root) {
+        JsonNode failedPagesNode = root.get("failed_pages");
+        if (failedPagesNode == null || !failedPagesNode.isArray() || failedPagesNode.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Integer> failedPages = new ArrayList<>();
+        for (JsonNode pageNode : failedPagesNode) {
+            if (pageNode.isNumber() && pageNode.canConvertToInt()) {
+                failedPages.add(pageNode.asInt());
+            }
+        }
+        return failedPages;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClient.java
@@ -10,9 +10,11 @@ package org.opendataloader.pdf.hybrid;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -176,6 +178,7 @@ public interface HybridClient {
         private final String html;
         private final JsonNode json;
         private final Map<Integer, JsonNode> pageContents;
+        private final List<Integer> failedPages;
 
         /**
          * Creates a new HybridResponse.
@@ -184,12 +187,29 @@ public interface HybridClient {
          * @param html         The HTML representation of the document.
          * @param json         The full structured JSON output (DoclingDocument format).
          * @param pageContents Per-page JSON content, keyed by 1-indexed page number.
+         * @param failedPages  List of 1-indexed page numbers that failed during backend processing.
          */
-        public HybridResponse(String markdown, String html, JsonNode json, Map<Integer, JsonNode> pageContents) {
+        public HybridResponse(String markdown, String html, JsonNode json,
+                              Map<Integer, JsonNode> pageContents, List<Integer> failedPages) {
             this.markdown = markdown != null ? markdown : "";
             this.html = html != null ? html : "";
             this.json = json;
             this.pageContents = pageContents != null ? pageContents : Collections.emptyMap();
+            this.failedPages = failedPages != null
+                ? Collections.unmodifiableList(new ArrayList<>(failedPages))
+                : Collections.emptyList();
+        }
+
+        /**
+         * Creates a new HybridResponse (backward compatible constructor).
+         *
+         * @param markdown     The markdown representation of the document.
+         * @param html         The HTML representation of the document.
+         * @param json         The full structured JSON output (DoclingDocument format).
+         * @param pageContents Per-page JSON content, keyed by 1-indexed page number.
+         */
+        public HybridResponse(String markdown, String html, JsonNode json, Map<Integer, JsonNode> pageContents) {
+            this(markdown, html, json, pageContents, Collections.emptyList());
         }
 
         /**
@@ -200,7 +220,7 @@ public interface HybridClient {
          * @param pageContents Per-page JSON content, keyed by 1-indexed page number.
          */
         public HybridResponse(String markdown, JsonNode json, Map<Integer, JsonNode> pageContents) {
-            this(markdown, "", json, pageContents);
+            this(markdown, "", json, pageContents, Collections.emptyList());
         }
 
         /**
@@ -228,6 +248,28 @@ public interface HybridClient {
             return pageContents;
         }
 
+        /**
+         * Returns the list of 1-indexed page numbers that failed during backend processing.
+         *
+         * <p>When the backend returns partial_success, some pages may have failed due to
+         * issues like invalid code points in PDF font encoding. These pages can be retried
+         * via the Java processing path as a fallback.
+         *
+         * @return List of failed page numbers (1-indexed), or empty list if all pages succeeded.
+         */
+        public List<Integer> getFailedPages() {
+            return failedPages;
+        }
+
+        /**
+         * Returns whether the backend reported any failed pages.
+         *
+         * @return true if at least one page failed during backend processing.
+         */
+        public boolean hasFailedPages() {
+            return !failedPages.isEmpty();
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -236,12 +278,13 @@ public interface HybridClient {
             return Objects.equals(markdown, that.markdown) &&
                 Objects.equals(html, that.html) &&
                 Objects.equals(json, that.json) &&
-                Objects.equals(pageContents, that.pageContents);
+                Objects.equals(pageContents, that.pageContents) &&
+                Objects.equals(failedPages, that.failedPages);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(markdown, html, json, pageContents);
+            return Objects.hash(markdown, html, json, pageContents, failedPages);
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -148,8 +148,9 @@ public class HybridDocumentProcessor {
 
         // Process backend path (synchronous)
         Map<Integer, List<IObject>> backendResults;
+        Set<Integer> backendFailedPages = new HashSet<>();
         try {
-            backendResults = processBackendPath(inputPdfName, backendPages, config);
+            backendResults = processBackendPath(inputPdfName, backendPages, config, backendFailedPages);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Backend processing failed: {0}", e.getMessage());
             if (config.getHybridConfig().isFallbackToJava()) {
@@ -157,6 +158,24 @@ public class HybridDocumentProcessor {
                 backendResults = processJavaPath(filteredContents, backendPages, config, totalPages);
             } else {
                 throw new IOException("Backend processing failed and fallback is disabled", e);
+            }
+        }
+
+        // Fallback: reprocess backend-failed pages through Java path
+        if (!backendFailedPages.isEmpty()) {
+            // Log 1-indexed page numbers for human readability
+            List<Integer> failedPages1Indexed = backendFailedPages.stream()
+                .map(p -> p + 1).sorted().collect(Collectors.toList());
+            if (config.getHybridConfig().isFallbackToJava()) {
+                LOGGER.log(Level.WARNING, "Backend returned partial_success: {0} page(s) failed (pages {1}), falling back to Java path",
+                    new Object[]{backendFailedPages.size(), failedPages1Indexed});
+                Map<Integer, List<IObject>> fallbackResults = processJavaPath(
+                    filteredContents, backendFailedPages, config, totalPages
+                );
+                backendResults.putAll(fallbackResults);
+            } else {
+                LOGGER.log(Level.WARNING, "Backend returned partial_success: {0} page(s) failed (pages {1}), fallback disabled — skipping failed pages",
+                    new Object[]{backendFailedPages.size(), failedPages1Indexed});
             }
         }
 
@@ -289,11 +308,21 @@ public class HybridDocumentProcessor {
 
     /**
      * Processes pages using the external backend.
+     *
+     * @param inputPdfName     The path to the input PDF file.
+     * @param pageNumbers      Set of 0-indexed page numbers to process.
+     * @param config           The configuration settings.
+     * @param backendFailedPages Output parameter: populated with 0-indexed page numbers that
+     *                           failed during backend processing (e.g., due to Invalid code point).
+     *                           These pages can be retried via the Java processing path.
+     * @return Map of page number to IObject list for successfully processed pages.
+     * @throws IOException If an error occurs during processing.
      */
     private static Map<Integer, List<IObject>> processBackendPath(
             String inputPdfName,
             Set<Integer> pageNumbers,
-            Config config) throws IOException {
+            Config config,
+            Set<Integer> backendFailedPages) throws IOException {
 
         if (pageNumbers.isEmpty()) {
             return new HashMap<>();
@@ -315,6 +344,17 @@ public class HybridDocumentProcessor {
         HybridRequest request = HybridRequest.allPages(pdfBytes, outputFormats);
         HybridResponse response = client.convert(request);
 
+        // Collect failed pages (convert from 1-indexed to 0-indexed)
+        if (response.hasFailedPages()) {
+            for (int failedPage1Indexed : response.getFailedPages()) {
+                int failedPage0Indexed = failedPage1Indexed - 1;
+                if (pageNumbers.contains(failedPage0Indexed)) {
+                    backendFailedPages.add(failedPage0Indexed);
+                }
+            }
+            // Logged by caller when initiating fallback
+        }
+
         // Get page heights for coordinate transformation
         Map<Integer, Double> pageHeights = getPageHeights(pageNumbers);
 
@@ -322,9 +362,12 @@ public class HybridDocumentProcessor {
         HybridSchemaTransformer transformer = createTransformer(config);
         List<List<IObject>> transformedContents = transformer.transform(response, pageHeights);
 
-        // Extract results for requested pages
+        // Extract results for requested pages (excluding failed pages)
         Map<Integer, List<IObject>> results = new HashMap<>();
         for (int pageNumber : pageNumbers) {
+            if (backendFailedPages.contains(pageNumber)) {
+                continue; // Skip failed pages — they will be retried via Java path
+            }
             if (pageNumber < transformedContents.size()) {
                 List<IObject> pageContents = transformedContents.get(pageNumber);
                 // Apply --replace-invalid-chars to backend results (not applied during filterAllPages

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DoclingFastServerClientTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DoclingFastServerClientTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2025 Hancom Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opendataloader.pdf.hybrid.HybridClient.HybridRequest;
+import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for DoclingFastServerClient partial_success handling.
+ */
+class DoclingFastServerClientTest {
+
+    private MockWebServer server;
+    private DoclingFastServerClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        String baseUrl = server.url("").toString();
+        // Remove trailing slash
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        client = new DoclingFastServerClient(baseUrl, new OkHttpClient(), new ObjectMapper());
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        client.shutdown();
+        server.shutdown();
+    }
+
+    @Test
+    void testSuccessResponseHasNoFailedPages() throws IOException {
+        String responseJson = "{"
+            + "\"status\": \"success\","
+            + "\"document\": {\"json_content\": {\"pages\": {\"1\": {}, \"2\": {}, \"3\": {}}}},"
+            + "\"processing_time\": 1.5,"
+            + "\"errors\": [],"
+            + "\"failed_pages\": []"
+            + "}";
+
+        server.enqueue(new MockResponse()
+            .setBody(responseJson)
+            .addHeader("Content-Type", "application/json"));
+
+        HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
+        HybridResponse response = client.convert(request);
+
+        assertFalse(response.hasFailedPages());
+        assertEquals(Collections.emptyList(), response.getFailedPages());
+    }
+
+    @Test
+    void testPartialSuccessResponseWithFailedPages() throws IOException {
+        String responseJson = "{"
+            + "\"status\": \"partial_success\","
+            + "\"document\": {\"json_content\": {\"pages\": {\"1\": {}, \"2\": {}, \"4\": {}, \"5\": {}}}},"
+            + "\"processing_time\": 2.0,"
+            + "\"errors\": [\"Unknown page: pipeline terminated early\"],"
+            + "\"failed_pages\": [3]"
+            + "}";
+
+        server.enqueue(new MockResponse()
+            .setBody(responseJson)
+            .addHeader("Content-Type", "application/json"));
+
+        HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
+        HybridResponse response = client.convert(request);
+
+        assertTrue(response.hasFailedPages());
+        assertEquals(Collections.singletonList(3), response.getFailedPages());
+    }
+
+    @Test
+    void testPartialSuccessMultipleFailedPages() throws IOException {
+        String responseJson = "{"
+            + "\"status\": \"partial_success\","
+            + "\"document\": {\"json_content\": {\"pages\": {\"1\": {}, \"3\": {}, \"5\": {}}}},"
+            + "\"processing_time\": 3.0,"
+            + "\"errors\": [\"Unknown page: pipeline terminated early\", \"Unknown page: pipeline terminated early\"],"
+            + "\"failed_pages\": [2, 4]"
+            + "}";
+
+        server.enqueue(new MockResponse()
+            .setBody(responseJson)
+            .addHeader("Content-Type", "application/json"));
+
+        HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
+        HybridResponse response = client.convert(request);
+
+        assertTrue(response.hasFailedPages());
+        assertEquals(Arrays.asList(2, 4), response.getFailedPages());
+    }
+
+    @Test
+    void testFailureResponseThrowsIOException() {
+        String responseJson = "{"
+            + "\"status\": \"failure\","
+            + "\"errors\": [\"PDF conversion failed: ValueError: corrupted file\"]"
+            + "}";
+
+        server.enqueue(new MockResponse()
+            .setBody(responseJson)
+            .addHeader("Content-Type", "application/json"));
+
+        HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
+
+        IOException exception = assertThrows(IOException.class, () -> client.convert(request));
+        assertTrue(exception.getMessage().contains("processing failed"));
+    }
+
+    @Test
+    void testLegacyResponseWithoutFailedPagesField() throws IOException {
+        // Older server versions may not include failed_pages field
+        String responseJson = "{"
+            + "\"status\": \"success\","
+            + "\"document\": {\"json_content\": {\"pages\": {\"1\": {}, \"2\": {}}}},"
+            + "\"processing_time\": 1.0"
+            + "}";
+
+        server.enqueue(new MockResponse()
+            .setBody(responseJson)
+            .addHeader("Content-Type", "application/json"));
+
+        HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
+        HybridResponse response = client.convert(request);
+
+        assertFalse(response.hasFailedPages());
+        assertEquals(Collections.emptyList(), response.getFailedPages());
+    }
+
+    @Test
+    void testMalformedFailedPagesValues() throws IOException {
+        // Server returns mixed valid/invalid values in failed_pages array
+        String responseJson = "{"
+            + "\"status\": \"partial_success\","
+            + "\"document\": {\"json_content\": {\"pages\": {\"1\": {}, \"2\": {}}}},"
+            + "\"processing_time\": 1.0,"
+            + "\"errors\": [\"error\"],"
+            + "\"failed_pages\": [3, \"bad\", null, 5]"
+            + "}";
+
+        server.enqueue(new MockResponse()
+            .setBody(responseJson)
+            .addHeader("Content-Type", "application/json"));
+
+        HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
+        HybridResponse response = client.convert(request);
+
+        assertTrue(response.hasFailedPages());
+        // Only valid integer values should be extracted
+        assertEquals(Arrays.asList(3, 5), response.getFailedPages());
+    }
+
+    @Test
+    void testPartialSuccessAllPagesFailed() throws IOException {
+        String responseJson = "{"
+            + "\"status\": \"partial_success\","
+            + "\"document\": {\"json_content\": {\"pages\": {}}},"
+            + "\"processing_time\": 2.0,"
+            + "\"errors\": [\"error1\", \"error2\", \"error3\"],"
+            + "\"failed_pages\": [1, 2, 3]"
+            + "}";
+
+        server.enqueue(new MockResponse()
+            .setBody(responseJson)
+            .addHeader("Content-Type", "application/json"));
+
+        HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
+        HybridResponse response = client.convert(request);
+
+        assertTrue(response.hasFailedPages());
+        assertEquals(Arrays.asList(1, 2, 3), response.getFailedPages());
+    }
+}

--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -70,6 +70,73 @@ converter = None
 _INVALID_UNICODE_RE = re.compile(r"[\ud800-\udfff\x00]")
 
 
+def build_conversion_response(
+    status_value: str,
+    json_content: dict,
+    processing_time: float,
+    errors: list[str],
+    requested_pages: tuple[int, int] | None,
+    total_pages: int | None = None,
+) -> dict:
+    """Build a structured conversion response with status and failed page info.
+
+    When Docling encounters errors (e.g., Invalid code point in PDF font encoding),
+    it skips the affected pages and returns PARTIAL_SUCCESS. This function detects
+    which pages failed by comparing the requested page range against pages present
+    in the output.
+
+    Args:
+        status_value: Docling ConversionStatus value as string (e.g., "success", "partial_success").
+        json_content: The exported document dict from Docling.
+        processing_time: Time taken for conversion in seconds.
+        errors: List of error message strings from Docling.
+        requested_pages: Tuple of (start, end) 1-indexed page range, or None for all pages.
+        total_pages: Total page count of the input document (from Docling InputDocument).
+                     Used to detect boundary page failures when requested_pages is None.
+
+    Returns:
+        Response dict with status, document, errors, failed_pages, and processing_time.
+    """
+    failed_pages: list[int] = []
+
+    if status_value == "partial_success":
+        # Detect failed pages by finding gaps in the pages dict
+        pages_dict = json_content.get("pages", {})
+        present_pages = set()
+        for k in pages_dict.keys():
+            try:
+                present_pages.add(int(k))
+            except (ValueError, TypeError):
+                logger.warning("Unexpected non-integer page key in Docling output: %r", k)
+
+        if requested_pages:
+            expected_pages = set(range(requested_pages[0], requested_pages[1] + 1))
+        elif total_pages is not None:
+            expected_pages = set(range(1, total_pages + 1))
+        elif present_pages:
+            # Fallback: infer range from min to max of present pages
+            logger.warning(
+                "No page range or total_pages available; boundary page failures cannot be detected"
+            )
+            expected_pages = set(range(min(present_pages), max(present_pages) + 1))
+        else:
+            expected_pages = set()
+
+        failed_pages = sorted(expected_pages - present_pages)
+
+    response: dict[str, Any] = {
+        "status": status_value,
+        "document": {
+            "json_content": json_content,
+        },
+        "processing_time": processing_time,
+        "errors": errors,
+        "failed_pages": failed_pages,
+    }
+
+    return response
+
+
 def sanitize_unicode(data: Any) -> Any:
     """Recursively replace lone surrogates and null characters with U+FFFD.
 
@@ -313,14 +380,29 @@ def create_app(
             # UnicodeEncodeError in Starlette's JSONResponse.render()
             json_content = sanitize_unicode(json_content)
 
-            # Build response compatible with docling-serve format
-            response = {
-                "status": "success",
-                "document": {
-                    "json_content": json_content,
-                },
-                "processing_time": processing_time,
-            }
+            # Extract status and errors from Docling ConversionResult
+            from docling.datamodel.base_models import ConversionStatus
+
+            status_value = result.status.value if hasattr(result.status, "value") else str(result.status)
+            errors = [getattr(e, "error_message", str(e)) for e in result.errors] if result.errors else []
+
+            # Get total page count for accurate failed-page detection
+            input_page_count = getattr(result.input, "page_count", None) if result.input else None
+
+            if result.status == ConversionStatus.PARTIAL_SUCCESS:
+                logger.warning(
+                    "Docling returned partial_success: %d error(s), failed_pages will be reported",
+                    len(errors),
+                )
+
+            response = build_conversion_response(
+                status_value=status_value,
+                json_content=json_content,
+                processing_time=processing_time,
+                errors=errors,
+                requested_pages=page_range_tuple,
+                total_pages=input_page_count,
+            )
 
             return JSONResponse(response)
 

--- a/python/opendataloader-pdf/tests/test_hybrid_server_partial_success.py
+++ b/python/opendataloader-pdf/tests/test_hybrid_server_partial_success.py
@@ -1,0 +1,175 @@
+"""Tests for PARTIAL_SUCCESS handling in hybrid server responses.
+
+Validates that when Docling encounters errors during PDF preprocessing
+(e.g., Invalid code point), the hybrid server correctly reports:
+- partial_success status instead of success
+- list of failed page numbers
+- error messages from Docling
+"""
+
+from opendataloader_pdf.hybrid_server import build_conversion_response
+
+
+class TestBuildConversionResponse:
+    """Tests for the build_conversion_response function."""
+
+    def test_success_status(self):
+        """Fully successful conversion should return status=success."""
+        response = build_conversion_response(
+            status_value="success",
+            json_content={"pages": {"1": {}, "2": {}, "3": {}}},
+            processing_time=1.5,
+            errors=[],
+            requested_pages=None,
+        )
+        assert response["status"] == "success"
+        assert response["failed_pages"] == []
+        assert response["processing_time"] == 1.5
+
+    def test_partial_success_status(self):
+        """PARTIAL_SUCCESS should return status=partial_success with failed pages."""
+        response = build_conversion_response(
+            status_value="partial_success",
+            json_content={"pages": {"1": {}, "2": {}, "4": {}, "5": {}}},
+            processing_time=2.0,
+            errors=["Unknown page: pipeline terminated early"],
+            requested_pages=(1, 5),
+        )
+        assert response["status"] == "partial_success"
+        assert response["failed_pages"] == [3]
+        assert response["errors"] == ["Unknown page: pipeline terminated early"]
+
+    def test_partial_success_multiple_failed_pages(self):
+        """Multiple failed pages should all be reported."""
+        response = build_conversion_response(
+            status_value="partial_success",
+            json_content={"pages": {"1": {}, "3": {}, "5": {}}},
+            processing_time=3.0,
+            errors=[
+                "Unknown page: pipeline terminated early",
+                "Unknown page: pipeline terminated early",
+            ],
+            requested_pages=(1, 5),
+        )
+        assert response["status"] == "partial_success"
+        assert sorted(response["failed_pages"]) == [2, 4]
+
+    def test_partial_success_no_page_range_with_total_pages(self):
+        """When total_pages is provided, boundary page failures are detected."""
+        # 5-page document, page 1 (first) and page 5 (last) failed
+        response = build_conversion_response(
+            status_value="partial_success",
+            json_content={"pages": {"2": {}, "3": {}, "4": {}}},
+            processing_time=2.0,
+            errors=["error1", "error2"],
+            requested_pages=None,
+            total_pages=5,
+        )
+        assert response["status"] == "partial_success"
+        assert response["failed_pages"] == [1, 5]
+
+    def test_partial_success_no_page_range_fallback(self):
+        """When no page range or total_pages, interior gaps are still detected."""
+        response = build_conversion_response(
+            status_value="partial_success",
+            json_content={"pages": {"1": {}, "2": {}, "4": {}, "5": {}}},
+            processing_time=2.0,
+            errors=["Unknown page: pipeline terminated early"],
+            requested_pages=None,
+        )
+        assert response["status"] == "partial_success"
+        assert response["failed_pages"] == [3]
+
+    def test_success_no_errors_field(self):
+        """Successful conversion should have empty errors list."""
+        response = build_conversion_response(
+            status_value="success",
+            json_content={"pages": {"1": {}, "2": {}}},
+            processing_time=1.0,
+            errors=[],
+            requested_pages=None,
+        )
+        assert response["errors"] == []
+
+    def test_document_field_present(self):
+        """Response should contain document.json_content."""
+        json_content = {"pages": {"1": {}}, "body": {"text": "hello"}}
+        response = build_conversion_response(
+            status_value="success",
+            json_content=json_content,
+            processing_time=1.0,
+            errors=[],
+            requested_pages=None,
+        )
+        assert response["document"]["json_content"] == json_content
+
+    def test_partial_success_first_page_failed_with_page_range(self):
+        """First page failure should be detected when page range is specified."""
+        response = build_conversion_response(
+            status_value="partial_success",
+            json_content={"pages": {"2": {}, "3": {}}},
+            processing_time=1.0,
+            errors=["error"],
+            requested_pages=(1, 3),
+        )
+        assert response["failed_pages"] == [1]
+
+    def test_partial_success_last_page_failed_with_page_range(self):
+        """Last page failure should be detected when page range is specified."""
+        response = build_conversion_response(
+            status_value="partial_success",
+            json_content={"pages": {"1": {}, "2": {}}},
+            processing_time=1.0,
+            errors=["error"],
+            requested_pages=(1, 3),
+        )
+        assert response["failed_pages"] == [3]
+
+    def test_partial_success_all_pages_failed(self):
+        """All pages failing should report every page in failed_pages."""
+        response = build_conversion_response(
+            status_value="partial_success",
+            json_content={"pages": {}},
+            processing_time=2.0,
+            errors=["error1", "error2", "error3"],
+            requested_pages=(1, 3),
+        )
+        assert response["status"] == "partial_success"
+        assert response["failed_pages"] == [1, 2, 3]
+
+    def test_partial_success_all_pages_failed_with_total_pages(self):
+        """All pages failing with total_pages should report every page."""
+        response = build_conversion_response(
+            status_value="partial_success",
+            json_content={"pages": {}},
+            processing_time=2.0,
+            errors=["error1", "error2"],
+            requested_pages=None,
+            total_pages=3,
+        )
+        assert response["status"] == "partial_success"
+        assert response["failed_pages"] == [1, 2, 3]
+
+    def test_failure_status_no_failed_pages_detection(self):
+        """Failure status should not trigger failed page detection."""
+        response = build_conversion_response(
+            status_value="failure",
+            json_content={"pages": {"1": {}}},
+            processing_time=1.0,
+            errors=["PDF conversion failed"],
+            requested_pages=(1, 3),
+        )
+        assert response["status"] == "failure"
+        assert response["failed_pages"] == []
+
+    def test_partial_success_missing_pages_key(self):
+        """json_content without 'pages' key should produce empty failed_pages."""
+        response = build_conversion_response(
+            status_value="partial_success",
+            json_content={"body": {"text": "hello"}},
+            processing_time=1.0,
+            errors=["error"],
+            requested_pages=(1, 3),
+        )
+        assert response["status"] == "partial_success"
+        assert response["failed_pages"] == [1, 2, 3]


### PR DESCRIPTION
## Summary
Fixes #215 (derived from #198 Issue 2: Invalid Code Point Error)

- Python hybrid server now reports actual Docling conversion status (`partial_success`) instead of always `success`
- Java client parses `failed_pages` array from backend response
- Java processor automatically falls back to Java processing for pages that failed in the Docling backend

## Problem
When Docling encounters malformed Unicode in a PDF's font encoding during preprocessing, it raises `Invalid code point` and skips the affected pages, returning `PARTIAL_SUCCESS`. The hybrid server previously ignored this status, always reporting `"success"` — causing the Java client to silently drop failed pages with no content.

## Changes
- `hybrid_server.py` — New `build_conversion_response()` function that detects failed pages by comparing expected vs present page numbers; reports `status`, `errors`, and `failed_pages` in the response
- `HybridClient.java` — Added `failedPages` field to `HybridResponse` with backward-compatible constructors
- `DoclingFastServerClient.java` — Parses `partial_success` status and `failed_pages` array; logs warnings
- `HybridDocumentProcessor.java` — Converts failed page numbers from 1-indexed to 0-indexed, then falls back to Java processing path for those pages

## How to reproduce
```bash
# Using test PDF "1218_간질환정보집_최종본.pdf" (pages 1-10, page 7 fails)
opendataloader-pdf-hybrid  # start server
opendataloader-pdf --hybrid docling-fast --hybrid-mode full input.pdf
# Before fix: page 7 silently dropped
# After fix: page 7 falls back to Java processing
```

## How to test
```bash
# Java tests
cd java && mvn test -Dtest=DoclingFastServerClientTest

# Python tests
cd python/opendataloader-pdf && python -m pytest tests/test_hybrid_server_partial_success.py -v

# Full suite
./scripts/test-java.sh
cd python/opendataloader-pdf && python -m pytest tests/ -v
```

## Breaking changes
None. The response format is additive (new `errors`, `failed_pages` fields). Older Java clients that don't parse these fields continue to work. The `HybridResponse` class maintains backward-compatible constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)