### PR TITLE
fix: prevent stack trace exposure in hybrid server

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -329,7 +329,7 @@ def create_app(
             return JSONResponse(
                 {
                     "status": "failure",
-                    "errors": [f"PDF conversion failed: {type(e).__name__}: {e}"],
+                    "errors": ["PDF conversion failed. Check server logs for details."],
                 },
                 status_code=500,
             )


### PR DESCRIPTION
## Summary
- Return a generic error message in the hybrid server's error response instead of exposing exception type/message to external users
- Full stack trace remains logged server-side for debugging
- Fixes code scanning alert #28 (`py/stack-trace-exposure`, CWE-209)

## Test plan
- [ ] Send a request that triggers a server error and verify the response contains only a generic message
- [ ] Verify server logs still contain the full stack trace for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)