### PR TITLE
fix: resolve minimatch ReDoS vulnerability

### DIFF
--- a/node/opendataloader-pdf/package.json
+++ b/node/opendataloader-pdf/package.json
@@ -68,6 +68,11 @@
     "vite": "^7.3.1",
     "vitest": "^4.0.18"
   },
+  "pnpm": {
+    "overrides": {
+      "minimatch@<10.2.1": ">=10.2.1"
+    }
+  },
   "files": [
     "dist",
     "lib",

--- a/node/opendataloader-pdf/pnpm-lock.yaml
+++ b/node/opendataloader-pdf/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  minimatch@<10.2.1: '>=10.2.1'
+
 importers:
 
   .:
@@ -933,10 +936,6 @@ packages:
     resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@9.0.6:
-    resolution: {integrity: sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1642,7 +1641,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
-      minimatch: 9.0.6
+      minimatch: 10.2.2
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -1994,10 +1993,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   minimatch@10.2.2:
-    dependencies:
-      brace-expansion: 5.0.3
-
-  minimatch@9.0.6:
     dependencies:
       brace-expansion: 5.0.3
 


### PR DESCRIPTION
## Summary
- Add `pnpm.overrides` to force `minimatch@<10.2.1` → `>=10.2.1`, resolving CVE-2026-26996 (ReDoS)
- Vulnerable `minimatch 9.0.6` was a transitive dependency via `@typescript-eslint/typescript-estree`
- All minimatch instances now resolve to `10.2.2`
- Fixes Dependabot alert #12

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)