### PR TITLE
docs: fact-check and fix documentation against actual codebase

### DIFF
--- a/content/docs/accessibility-compliance.mdx
+++ b/content/docs/accessibility-compliance.mdx
@@ -61,7 +61,7 @@ This preserves the author's intended reading order and semantic structure.
 If the PDF lacks structure tags, OpenDataLoader falls back to visual heuristics (XY-Cut++ algorithm).
 
 ```bash
-opendataloader-pdf convert document.pdf --output-dir output/ --use-struct-tree
+opendataloader-pdf document.pdf --output-dir output/ --use-struct-tree
 ```
 
 ### 3. Future: Auto-Tagging Engine (Q1 2026)

--- a/content/docs/ai-safety.mdx
+++ b/content/docs/ai-safety.mdx
@@ -57,7 +57,6 @@ Attackers can encode ASCII characters by tweaking the least significant bit (LSB
 | Command                | Description                                      | Example                                     |
 | ---------------------- | ------------------------------------------------ | ------------------------------------------- |
 | `--content-safety-off` | Disable one or more filters (comma-separated).   | `--content-safety-off hidden-text,off-page` |
-| `--exclude-patterns`   | Drop content that matches custom regex patterns. | `--exclude-patterns <regex>`                |
 
 ### Available filters
 
@@ -68,6 +67,7 @@ Attackers can encode ASCII characters by tweaking the least significant bit (LSB
 | `off-page`       | Removes text located outside the visible page bounds.   | ✅          |
 | `tiny`           | Filters extremely small fonts.                          | ✅          |
 | `hidden-ocg`     | Drops content hidden in Optional Content Groups.        | ✅          |
+| `sensitive-data` | Filters emails, IPs, phone numbers, and credit cards.   | ✅          |
 | `patterns`       | Detects repeating visual patterns that encode prompts.  | 🚀 Upcoming |
 | `malicious-font` | Detects manipulated font `cmap` tables.                 | 🚀 Upcoming |
 | `noised-figure`  | Detects steganographic prompts in images.               | 🚀 Upcoming |

--- a/content/docs/faq.mdx
+++ b/content/docs/faq.mdx
@@ -48,7 +48,7 @@ This means: consistent output (same input = same output), no GPU required, faste
 
 - **Java 11 or higher** (must be installed and in PATH)
 - **Python 3.9+** (for Python package)
-- **Node.js 18+** (for Node.js package)
+- **Node.js 20+** (for Node.js package)
 - No GPU required
 - Works on Linux, macOS, and Windows
 
@@ -210,7 +210,7 @@ opendataloader_pdf.convert(
 
 ### Does it work with scanned PDFs?
 
-OCR support for scanned PDFs is **coming soon** (scheduled for December 2025). Currently, OpenDataLoader works best with digital PDFs that have embedded text.
+Yes! OCR for scanned PDFs is available via hybrid mode. Start the hybrid server with `--ocr-lang` to enable multi-language OCR. See [Hybrid Mode](/docs/hybrid-mode) for setup instructions.
 
 ## Tagged PDF
 

--- a/content/docs/quick-start-java.mdx
+++ b/content/docs/quick-start-java.mdx
@@ -21,7 +21,7 @@ java -version
 <dependency>
   <groupId>org.opendataloader</groupId>
   <artifactId>opendataloader-pdf-core</artifactId>
-  <version>1.4.1</version>
+  <version>1.11.0</version>
 </dependency>
 
 <repositories>

--- a/content/docs/quick-start-nodejs.mdx
+++ b/content/docs/quick-start-nodejs.mdx
@@ -7,7 +7,7 @@ The TypeScript package mirrors the Python API and exposes both a programmatic he
 
 ## Requirements
 
-- Node.js 18 or later
+- Node.js 20 or later
 - Java 11+ available on the system `PATH`
 
 Verify Java once before installing:

--- a/content/docs/rag-integration.mdx
+++ b/content/docs/rag-integration.mdx
@@ -394,16 +394,6 @@ See [examples/python/rag/langchain_example.py](https://github.com/opendataloader
 - [GitHub Repository](https://github.com/opendataloader-project/langchain-opendataloader-pdf)
 - [PyPI Package](https://pypi.org/project/langchain-opendataloader-pdf/)
 
-### LlamaIndex (Coming Soon)
-
-```python
-# Future integration
-from llama_index.readers import OpenDataLoaderReader
-
-reader = OpenDataLoaderReader()
-documents = reader.load_data("document.pdf")
-```
-
 ## Best Practices Summary
 
 1. **Always enable reading order** for multi-column documents

--- a/content/docs/reading-order.mdx
+++ b/content/docs/reading-order.mdx
@@ -110,7 +110,6 @@ opendataloader-pdf --reading-order off input.pdf
 
 The algorithm is implemented in:
 - `XYCutPlusPlusSorter.java` — Main algorithm
-- `GapBasedSorter.java` — Gap detection utilities
 
 Key parameters:
 - **Beta threshold** (default: 2.0): Controls cross-layout element detection

--- a/content/docs/tagged-pdf-rag.mdx
+++ b/content/docs/tagged-pdf-rag.mdx
@@ -54,7 +54,7 @@ import opendataloader_pdf
 opendataloader_pdf.convert(
     input_path="document.pdf",
     output_dir="output/",
-    output_formats=["md", "json"],
+    format="json,markdown",
     use_struct_tree=True  # Use tags if present
 )
 ```
@@ -64,18 +64,18 @@ If the PDF lacks structure tags, OpenDataLoader logs a warning and falls back to
 ### CLI Usage
 
 ```bash
-opendataloader-pdf convert document.pdf \
+opendataloader-pdf document.pdf \
   --output-dir output/ \
-  --output-formats md,json \
+  -f json,markdown \
   --use-struct-tree
 ```
 
 ### Docker Usage
 
 ```bash
-docker run -v $(pwd):/data opendataloader/opendataloader-pdf \
-  convert /data/document.pdf \
-  --output-dir /data/output \
+docker run --rm -v "$PWD":/work ghcr.io/opendataloader-project/opendataloader-pdf-cli:latest \
+  /work/document.pdf \
+  --output-dir /work/output \
   --use-struct-tree
 ```
 
@@ -193,7 +193,7 @@ def process_pdf_collection(pdf_dir, output_dir):
             opendataloader_pdf.convert(
                 input_path=os.path.join(pdf_dir, filename),
                 output_dir=output_dir,
-                output_formats=["md", "json"],
+                format="json,markdown",
                 use_struct_tree=True  # Auto-fallback if no tags
             )
 ```
@@ -202,18 +202,6 @@ def process_pdf_collection(pdf_dir, output_dir):
 - If PDF has tags → Uses structure tree (exact)
 - If PDF lacks tags → Falls back to XY-Cut++ (heuristic)
 - Logs indicate which method was used
-
-## Quality Comparison
-
-Based on our benchmarks, tagged PDF extraction significantly outperforms heuristic methods:
-
-| Metric | Tag-Blind | Tag-Aware | Improvement |
-|:-------|:----------|:----------|:------------|
-| **Reading Order (NID)** | 0.82 | 0.98 | +19.5% |
-| **Table Structure (TEDS)** | 0.71 | 0.94 | +32.4% |
-| **Heading Detection (MHS)** | 0.75 | 0.99 | +32.0% |
-
-*NID = Normalized Indel Distance; TEDS = Tree Edit Distance Similarity; MHS = Markdown Heading Similarity*
 
 ## Future: Auto-Tagging Untagged PDFs
 
@@ -235,41 +223,14 @@ This enables RAG-quality extraction even for older documents.
 ### LangChain Integration
 
 ```python
-from langchain.document_loaders import DirectoryLoader
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_opendataloader_pdf import OpenDataLoaderPDFLoader
 
-# First, extract with OpenDataLoader
-import opendataloader_pdf
-
-opendataloader_pdf.convert(
-    input_path="documents/",
-    output_dir="extracted/",
-    output_formats=["md"],
-    use_struct_tree=True
+loader = OpenDataLoaderPDFLoader(
+    file_path=["documents/"],
+    format="text",
+    use_struct_tree=True,
 )
-
-# Then load into LangChain
-loader = DirectoryLoader("extracted/", glob="**/*.md")
 documents = loader.load()
-```
-
-### LlamaIndex Integration
-
-```python
-from llama_index import SimpleDirectoryReader
-
-# Extract with OpenDataLoader first
-import opendataloader_pdf
-
-opendataloader_pdf.convert(
-    input_path="documents/",
-    output_dir="extracted/",
-    output_formats=["md"],
-    use_struct_tree=True
-)
-
-# Load into LlamaIndex
-documents = SimpleDirectoryReader("extracted/").load_data()
 ```
 
 ## Learn More

--- a/content/docs/tagged-pdf.mdx
+++ b/content/docs/tagged-pdf.mdx
@@ -38,7 +38,7 @@ Most PDF parsers ignore structure tags entirely. OpenDataLoader is one of the fe
 ### CLI Usage
 
 ```bash
-opendataloader-pdf convert document.pdf \
+opendataloader-pdf document.pdf \
   --output-dir output/ \
   --use-struct-tree
 ```


### PR DESCRIPTION
## Summary

- Removed references to non-existent CLI flags (`--exclude-patterns`, `convert` subcommand, `--output-formats`) and a non-existent source file (`GapBasedSorter.java`)
- Fixed Python API parameter names (`output_formats` → `format`) and Docker image paths (`opendataloader/opendataloader-pdf` → `ghcr.io/opendataloader-project/opendataloader-pdf-cli`)
- Updated outdated information: OCR status (now available via hybrid mode), Maven version (`1.4.1` → `1.11.0`), Node.js requirement (`18+` → `20+`)
- Added missing `sensitive-data` filter to the AI safety table
- Removed unverified benchmark comparison table and LlamaIndex "Coming Soon" placeholder sections
- Replaced deprecated `langchain.document_loaders` import with official `langchain_opendataloader_pdf` integration

## Test plan

- [x] Verified all CLI flags (`-f`, `--use-struct-tree`, `--reading-order off`, `--content-safety-off`) against `options.json`
- [x] Verified Python API parameters (`format`, `use_struct_tree`, `content_safety_off`, `hybrid`) against `convert_generated.py`
- [x] Ran CLI, Python API, hybrid server, and Docker commands from the updated docs — all passed
- [x] Grepped docs for any remaining references to removed items (`output_formats`, `exclude-patterns`, `convert` subcommand, `GapBasedSorter`, `LlamaIndex`, `Node.js 18`, `1.4.1`) — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)