### PR TITLE
docs: add scanned PDF, images/charts guidance and mode selection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Building RAG pipelines? You've probably hit these problems:
 
 <br/>
 
+## Which Mode Should I Use?
+
+| Your Document | Mode | Setup |
+|---------------|------|-------|
+| Standard digital PDF | Fast (default) | `pip install opendataloader-pdf` |
+| Complex or nested tables | Hybrid | + start hybrid server |
+| Scanned / image-based PDF | Hybrid + OCR | + `--force-ocr` on server |
+| Charts / figures needing text description | Hybrid + picture description | + `--enrich-picture-description` on server |
+| Mathematical formulas (LaTeX) | Hybrid + formula | + `--enrich-formula` on server |
+
+<br/>
+
 ## Output Formats
 
 | Format | Use Case |
@@ -258,6 +270,26 @@ Output in HTML (MathJax/KaTeX compatible):
 
 > **Note**: Formula extraction requires `--hybrid-mode full` to route all pages to the backend where the formula enrichment model runs.
 
+### Scanned PDFs (OCR)
+
+For image-based or scanned PDFs that contain no selectable text, enable OCR on the hybrid backend:
+
+```bash
+# Start backend with OCR enabled
+opendataloader-pdf-hybrid --port 5002 --force-ocr
+
+# Process scanned PDF
+opendataloader-pdf --hybrid docling-fast input-scanned.pdf
+```
+
+For non-English documents, specify the OCR language:
+
+```bash
+opendataloader-pdf-hybrid --port 5002 --ocr-lang "ko,en"
+```
+
+> **Note**: Standard digital PDFs do not need `--force-ocr`. Use it only for scanned or image-based PDFs.
+
 ### Picture / Chart Description (Alt Text)
 
 Generate AI-powered descriptions for images and charts in your PDFs. Useful for accessibility (alt text) and making visual content searchable in RAG pipelines.
@@ -408,6 +440,64 @@ This means: consistent output (same input = same output), no GPU required, faste
 ### How do I get better accuracy for complex tables?
 
 Enable hybrid mode with `pip install -U "opendataloader-pdf[hybrid]"`. This routes pages with complex tables to an AI backend (like docling-serve) while keeping simple pages fast and local. Table accuracy improves from 0.49 to 0.93 — matching or exceeding dedicated AI parsers while remaining faster and more cost-effective.
+
+### Does it work with scanned PDFs?
+
+Yes, via hybrid mode with OCR. Start the backend server with `--force-ocr`:
+
+Terminal 1: Start backend with OCR enabled
+
+```bash
+opendataloader-pdf-hybrid --port 5002 --force-ocr
+```
+
+Terminal 2: Process scanned PDF
+
+```bash
+opendataloader-pdf --hybrid docling-fast input-scanned.pdf
+```
+
+Or use in Python:
+
+```python
+opendataloader_pdf.convert(
+    input_path="scanned.pdf",
+    output_dir="output/",
+    hybrid="docling-fast"
+)
+```
+
+(Start the backend with `--force-ocr` before running.)
+
+For non-English documents, add `--ocr-lang`:
+
+```bash
+opendataloader-pdf-hybrid --port 5002 --ocr-lang "ko,en"
+```
+
+### Does it work with images and charts?
+
+Two levels of support:
+
+1. **Image extraction** (all modes): Embedded images are extracted to the output folder with bounding boxes. Use `--image-output external` (the default):
+
+```python
+opendataloader_pdf.convert(
+    input_path="document.pdf",
+    output_dir="output/",
+    image_output="external"  # Saves images as files with bounding boxes in JSON
+)
+```
+
+2. **AI chart descriptions** (hybrid only): Generate natural language descriptions of charts and figures for RAG search:
+
+```bash
+# Start backend with picture description enabled
+opendataloader-pdf-hybrid --port 5002 --enrich-picture-description
+
+# Process with full backend mode (required for picture description)
+opendataloader-pdf --hybrid docling-fast --hybrid-mode full input.pdf
+```
 
 <br/>
 

--- a/content/docs/faq.mdx
+++ b/content/docs/faq.mdx
@@ -210,7 +210,66 @@ opendataloader_pdf.convert(
 
 ### Does it work with scanned PDFs?
 
-Yes! OCR for scanned PDFs is available via hybrid mode. Start the hybrid server with `--ocr-lang` to enable multi-language OCR. See [Hybrid Mode](/docs/hybrid-mode) for setup instructions.
+Yes, via hybrid mode with OCR. Install the hybrid extra, then start the backend with `--force-ocr`:
+
+Terminal 1: Start backend with OCR enabled
+
+```bash
+pip install -U "opendataloader-pdf[hybrid]"
+opendataloader-pdf-hybrid --port 5002 --force-ocr
+```
+
+Terminal 2: Process scanned PDF
+
+```bash
+opendataloader-pdf --hybrid docling-fast input-scanned.pdf
+```
+
+Or use in Python:
+
+```python
+import opendataloader_pdf
+
+opendataloader_pdf.convert(
+    input_path="scanned.pdf",
+    output_dir="output/",
+    hybrid="docling-fast"
+)
+```
+
+For non-English scanned documents, specify the OCR language:
+
+```bash
+opendataloader-pdf-hybrid --port 5002 --ocr-lang "ko,en"
+```
+
+See [Hybrid Mode → Scanned PDFs (OCR)](/docs/hybrid-mode#scanned-pdfs-ocr) for details.
+
+### Does it work with images and charts?
+
+Two levels of support:
+
+1. **Image extraction** (all modes): Embedded images are extracted with bounding boxes. Enable with `image_output="external"` (the default):
+
+```python
+opendataloader_pdf.convert(
+    input_path="document.pdf",
+    output_dir="output/",
+    image_output="external"  # Saves images as files; bounding boxes in JSON
+)
+```
+
+2. **AI chart descriptions** (hybrid only): Generate natural language descriptions of charts and figures, useful for RAG pipelines where visual content needs to be searchable:
+
+```bash
+# Start backend with picture description enabled
+opendataloader-pdf-hybrid --port 5002 --enrich-picture-description
+
+# Process with full backend mode (required for picture description)
+opendataloader-pdf --hybrid docling-fast --hybrid-mode full input.pdf
+```
+
+The description appears in the JSON output under `"description"` and as a caption in Markdown. See [Hybrid Mode → Chart and Image Description](/docs/hybrid-mode#chart-and-image-description) for details.
 
 ## Tagged PDF
 

--- a/content/docs/hybrid-mode.mdx
+++ b/content/docs/hybrid-mode.mdx
@@ -160,6 +160,118 @@ Hybrid mode is designed with privacy in mind:
 | Maximum accuracy priority | **Hybrid mode** |
 | Air-gapped environments | Hybrid with local Docker backend |
 
+## Scanned PDFs (OCR)
+
+For image-based or scanned PDFs that contain no selectable text, enable OCR on the hybrid backend with `--force-ocr`.
+
+### CLI
+
+Terminal 1: Start backend with OCR enabled
+
+```bash
+opendataloader-pdf-hybrid --port 5002 --force-ocr
+```
+
+Terminal 2: Process scanned PDF
+
+```bash
+opendataloader-pdf --hybrid docling-fast input-scanned.pdf
+```
+
+For non-English documents, specify the OCR language:
+
+```bash
+opendataloader-pdf-hybrid --port 5002 --ocr-lang "ko,en"
+```
+
+Supported language codes include: `en`, `ko`, `ja`, `zh_sim` (Simplified Chinese), `zh_tra` (Traditional Chinese), `de`, `fr`, and more. Multiple languages can be combined with commas.
+
+### Python
+
+```python
+import opendataloader_pdf
+
+opendataloader_pdf.convert(
+    input_path="scanned.pdf",
+    output_dir="output/",
+    hybrid="docling-fast"
+)
+```
+
+Start the backend server with `--force-ocr` before running the Python conversion.
+
+### Docker
+
+```bash
+docker run -p 5002:5002 ghcr.io/opendataloader-project/opendataloader-pdf-hybrid \
+  opendataloader-pdf-hybrid --port 5002 --host 0.0.0.0 --force-ocr --ocr-lang "ko,en"
+```
+
+> **Note**: Standard digital PDFs do not need `--force-ocr`. Use it only for scanned or image-based PDFs where text cannot be selected.
+
+## Chart and Image Description
+
+Generate AI-powered natural language descriptions for images and charts in your PDFs. This makes visual content searchable in RAG pipelines and produces alt text for accessibility.
+
+> **Important**: Picture description requires `--hybrid-mode full` on the client side. Without it, the enrichment runs on the backend but the descriptions are not included in the output.
+
+### CLI
+
+Terminal 1: Start backend with picture description enabled
+
+```bash
+opendataloader-pdf-hybrid --port 5002 --enrich-picture-description
+```
+
+Terminal 2: Process with full backend mode
+
+```bash
+opendataloader-pdf --hybrid docling-fast --hybrid-mode full input.pdf
+```
+
+### Python
+
+```python
+import opendataloader_pdf
+
+opendataloader_pdf.convert(
+    input_path="document.pdf",
+    output_dir="output/",
+    hybrid="docling-fast",
+    hybrid_mode="full"  # Required for picture description
+)
+```
+
+Start the backend server with `--enrich-picture-description` before running.
+
+### Output
+
+The description appears in the JSON output under `"description"` and as an italic caption in Markdown:
+
+```json
+{
+  "type": "picture",
+  "page number": 1,
+  "bounding box": [72.0, 400.0, 540.0, 650.0],
+  "description": "A bar chart showing waste generation by region from 2016 to 2030..."
+}
+```
+
+```markdown
+![image 1](document_images/imageFile1.png)
+
+*A bar chart showing waste generation by region from 2016 to 2030...*
+```
+
+You can customize the prompt for specific document types:
+
+```bash
+opendataloader-pdf-hybrid --enrich-picture-description \
+  --picture-description-prompt "Describe this scientific figure in detail, including axis labels and data trends."
+```
+
+> **Note**: Picture description uses SmolVLM (256M), a lightweight vision model. Results are suitable for general context but may not capture precise data values from complex charts.
+
 ## Docker Deployment
 
 ### Quick Start


### PR DESCRIPTION
## Summary

Addresses the top three recurring questions identified in the X post analysis (`docs/feedbacks/2026-02-26_x-post-analysis.md`):

- **"Works with scanned PDFs?"** — Expanded 1-line answer into full working examples (CLI + Python + `--force-ocr` / `--ocr-lang`)
- **"Works with images and graphs?"** — New Q&A added to both README and faq.mdx, clearly distinguishing image extraction (all modes) from AI chart descriptions (hybrid only)
- **"How do I know which mode to use?"** — New "Which Mode Should I Use?" decision table at the top of README

## Changes

| File | Changes |
|------|---------|
| `README.md` | + "Which Mode Should I Use?" table; + Scanned PDFs (OCR) subsection; + 2 FAQ items |
| `content/docs/faq.mdx` | Expanded scanned PDFs answer with code; + images/charts Q&A |
| `content/docs/hybrid-mode.mdx` | + Scanned PDFs (OCR) section; + Chart and Image Description section |

## Test plan

- [ ] Verify `--force-ocr`, `--ocr-lang`, `--enrich-picture-description` CLI flags match `hybrid-mode.mdx` Server Options table
- [ ] Verify `--hybrid-mode full` gotcha is visible in Chart and Image Description section
- [ ] Verify image extraction (all modes) vs AI descriptions (hybrid only) distinction is clear in faq.mdx and README

🤖 Generated with [Claude Code](https://claude.com/claude-code)