### PR TITLE
docs: add Arabic language support documentation

### DIFF
--- a/content/docs/hybrid-mode.mdx
+++ b/content/docs/hybrid-mode.mdx
@@ -184,7 +184,15 @@ For non-English documents, specify the OCR language:
 opendataloader-pdf-hybrid --port 5002 --force-ocr --ocr-lang "ko,en"
 ```
 
-Supported language codes include: `en`, `ko`, `ja`, `ch_sim` (Simplified Chinese), `ch_tra` (Traditional Chinese), `de`, `fr`, and more. Multiple languages can be combined with commas.
+Supported language codes include: `en`, `ko`, `ja`, `ch_sim` (Simplified Chinese), `ch_tra` (Traditional Chinese), `de`, `fr`, `ar` (Arabic), and more. Multiple languages can be combined with commas.
+
+For Arabic documents:
+
+```bash
+opendataloader-pdf-hybrid --port 5002 --force-ocr --ocr-lang "ar,en"
+```
+
+> **Note for Arabic and other RTL scripts**: Character recognition works via EasyOCR's `ar` model. The current reading order algorithm processes text based on coordinates and does not perform RTL shaping or visual reordering, so text strings may appear in visual order rather than logical order. This limitation applies to all right-to-left scripts.
 
 ### Python
 


### PR DESCRIPTION
## Summary

Fixes #229

- Explicitly document `ar` language code for Arabic OCR in the hybrid-mode guide
- Add a usage example (`--ocr-lang "ar,en"`)
- Add a note about current RTL text handling limitation (visual vs. logical order)

## Changes

- `content/docs/hybrid-mode.mdx` — added `ar` to the supported language codes list, Arabic example, and RTL limitation note

## How to test

Review the rendered docs change. No code changes.