### PR TITLE
fix(markdown): preserve split for fused numbered heading subtitles

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -34,6 +34,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MarkdownGenerator implements Closeable {
 
@@ -46,6 +48,9 @@ public class MarkdownGenerator implements Closeable {
     protected boolean embedImages = false;
     protected String imageFormat = Config.IMAGE_FORMAT_PNG;
     protected boolean includeHeaderFooter = false;
+    private static final Pattern NUMBERED_HEADING_RE = Pattern.compile("^(\\d+(?:\\.\\d+)+\\.?)\\s+(.+)$");
+    private static final Pattern FUSED_SUBTITLE_RE =
+        Pattern.compile("^(.+?)\\s+([A-Z][A-Za-z0-9]+(?:-[A-Za-z0-9]+)+:\\s+.+)$");
 
     MarkdownGenerator(File inputPdf, Config config) throws IOException {
         String cutPdfFileName = inputPdf.getName();
@@ -294,6 +299,17 @@ public class MarkdownGenerator implements Closeable {
     }
 
     protected void writeHeading(SemanticHeading heading) throws IOException {
+        String value = heading.getValue();
+        if (StaticContainers.isKeepLineBreaks()) {
+            value = value.replace(MarkdownSyntax.LINE_BREAK, MarkdownSyntax.SPACE);
+        } else if (isInsideTable()) {
+            value = value.replace(MarkdownSyntax.LINE_BREAK, MarkdownSyntax.SPACE);
+        }
+
+        String[] headingParts = splitFusedNumberedHeadingSubtitle(value);
+        String headingText = headingParts[0] == null ? "" : headingParts[0];
+        String subtitleText = headingParts[1];
+
         if (!isInsideTable()) {
             // Cap heading level to 1-6 per Markdown specification
             int headingLevel = Math.min(6, Math.max(1, heading.getHeadingLevel()));
@@ -302,7 +318,51 @@ public class MarkdownGenerator implements Closeable {
             }
             markdownWriter.write(MarkdownSyntax.SPACE);
         }
-        writeSemanticTextNode(heading);
+
+        markdownWriter.write(getCorrectMarkdownString(headingText));
+
+        // Preserve a likely subtitle that was fused into the same heading line during extraction
+        // (e.g. "1.1. ContributionsPost-Training: ..." in some academic PDFs).
+        if (!isInsideTable() && subtitleText != null && !subtitleText.isEmpty()) {
+            writeLineBreak();
+            writeLineBreak();
+            markdownWriter.write(getCorrectMarkdownString(subtitleText));
+        }
+    }
+
+    static String[] splitFusedNumberedHeadingSubtitle(String input) {
+        String text = input == null ? "" : input.replaceAll("\\s+", " ").trim();
+        if (text.isEmpty()) {
+            return new String[]{text, null};
+        }
+
+        Matcher numbered = NUMBERED_HEADING_RE.matcher(text);
+        if (!numbered.matches()) {
+            return new String[]{text, null};
+        }
+
+        String sectionNumber = numbered.group(1).trim();
+        String remainder = numbered.group(2)
+            .replaceAll("([a-z])(Post|Pre|Self|Co)-", "$1 $2-")
+            .trim();
+
+        Matcher fused = FUSED_SUBTITLE_RE.matcher(remainder);
+        if (!fused.matches()) {
+            return new String[]{text, null};
+        }
+
+        String headingTail = fused.group(1).trim();
+        String subtitle = fused.group(2).trim();
+        if (headingTail.isEmpty() || subtitle.length() < 10 || subtitle.length() > 240) {
+            return new String[]{text, null};
+        }
+
+        int headingWordCount = headingTail.split("\\s+").length;
+        if (headingWordCount < 1 || headingWordCount > 4) {
+            return new String[]{text, null};
+        }
+
+        return new String[]{sectionNumber + " " + headingTail, subtitle};
     }
 
     protected void enterTable() {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
@@ -79,6 +79,24 @@ public class MarkdownGeneratorTest {
         assertEquals("# ", generateHeadingPrefix(-1));
     }
 
+    @Test
+    void testSplitFusedNumberedHeadingSubtitle() {
+        String input = "1.1. ContributionsPost-Training: Large-Scale Reinforcement Learning on the Base Model";
+        String[] split = MarkdownGenerator.splitFusedNumberedHeadingSubtitle(input);
+
+        assertEquals("1.1. Contributions", split[0]);
+        assertEquals("Post-Training: Large-Scale Reinforcement Learning on the Base Model", split[1]);
+    }
+
+    @Test
+    void testSplitFusedNumberedHeadingSubtitleNoSplitForNormalHeading() {
+        String input = "2.2.1 Reinforcement Learning Algorithm";
+        String[] split = MarkdownGenerator.splitFusedNumberedHeadingSubtitle(input);
+
+        assertEquals(input, split[0]);
+        assertNull(split[1]);
+    }
+
     /**
      * Helper method that mirrors the heading prefix generation logic in
      * MarkdownGenerator.writeHeading().


### PR DESCRIPTION
## Summary
- add a targeted split for fused numbered heading + hyphenated subtitle patterns in markdown generation
- handle cases like 1.1. ContributionsPost-Training: ... by emitting:
  - heading: 1.1. Contributions
  - following line: Post-Training: ...
- add unit tests for split and non-split cases

## Notes
- verified on DeepSeek-R1 sample where source layout had a visible line break but markdown heading was fused
- no behavior change for normal numbered headings (e.g. 2.2.1 Reinforcement Learning Algorithm)

Closes #254