### PR TITLE
docs: fix docling backend name in design doc

### DIFF
--- a/docs/hybrid/hybrid-mode-design.md
+++ b/docs/hybrid/hybrid-mode-design.md
@@ -48,7 +48,7 @@ opendataloader-pdf --hybrid hancom input.pdf
 | Backend | Status | Description |
 |---------|--------|-------------|
 | `off` | ✅ Default | Java-only, no external calls |
-| `docling` | 🔄 Planned | docling-serve (local) |
+| `docling-fast` | ✅ Available | docling-serve (local) |
 | `hancom` | 📋 Future (Priority) | Hancom Document AI |
 | `azure` | 📋 Future | Azure Document Intelligence |
 | `google` | 📋 Future | Google Document AI |


### PR DESCRIPTION
## Summary

- Update `docs/hybrid/hybrid-mode-design.md` backend table: `docling` (Planned) → `docling-fast` (Available)
- Aligns internal design doc with the actual implementation and public docs (`content/docs/hybrid-mode.mdx`)

Spotted during review of #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)