### PR TITLE
fix: recover flattened benchmark tables in markdown output

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -31,9 +31,14 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MarkdownGenerator implements Closeable {
 
@@ -46,6 +51,28 @@ public class MarkdownGenerator implements Closeable {
     protected boolean embedImages = false;
     protected String imageFormat = Config.IMAGE_FORMAT_PNG;
     protected boolean includeHeaderFooter = false;
+    private static final Pattern TABLE_CAPTION_RE = Pattern.compile("^Table\\s+\\d+\\s*\\|\\s+.+", Pattern.CASE_INSENSITIVE);
+    private static final Pattern TABLE_CAPTION_IN_TEXT_RE = Pattern.compile(".*\\b(Table\\s+\\d+\\s*\\|\\s+.+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern YEAR_LABEL_PAIR_RE = Pattern.compile("([A-Za-z][A-Za-z0-9.+\\-]*)\\s+(20\\d{2})");
+    private static final Pattern YEAR_TOKEN_RE = Pattern.compile("^(?:19|20)\\d{2}$");
+    private static final Pattern BENCHMARK_HEADER_HINT_TOKEN_RE = Pattern.compile("^(?:model|aime|math(?:-\\d+)?|gpqa|livecode|codeforces|diamond|bench)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern WIDE_TABLE_VALUE_TOKEN_RE = Pattern.compile("^(?:-|MoE|\\d+(?:\\.\\d+)?%?|\\d+[A-Za-z]+)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern METRIC_TOKEN_RE = Pattern.compile("^(?:pass@\\d+|cons@\\d+|rating|score)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern NUMERIC_TOKEN_RE = Pattern.compile("^-?\\d+(?:\\.\\d+)?%?$");
+    private static final Pattern MODEL_TOKEN_RE = Pattern.compile("^[A-Za-z][A-Za-z0-9._'\\-]*$");
+    private static final int MAX_PARAGRAPHS_FOR_TABLE_RECOVERY = 20;
+    private static final int MAX_TABLE_RECOVERY_LEAD_IN = 8;
+    private static final int MAX_NON_TEXT_GAP_FOR_TABLE_RECOVERY = 8;
+
+    private static class RecoveredTableRow {
+        final String model;
+        final List<String> metrics;
+
+        RecoveredTableRow(String model, List<String> metrics) {
+            this.model = model;
+            this.metrics = metrics;
+        }
+    }
 
     MarkdownGenerator(File inputPdf, Config config) throws IOException {
         String cutPdfFileName = inputPdf.getName();
@@ -62,7 +89,15 @@ public class MarkdownGenerator implements Closeable {
         try {
             for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
                 writePageSeparator(pageNumber);
-                for (IObject content : contents.get(pageNumber)) {
+                List<IObject> pageContents = contents.get(pageNumber);
+                for (int i = 0; i < pageContents.size(); i++) {
+                    int consumed = tryWriteRecoveredFlattenedBenchmarkTable(pageContents, i);
+                    if (consumed > 0) {
+                        i += consumed - 1;
+                        continue;
+                    }
+
+                    IObject content = pageContents.get(i);
                     if (!isSupportedContent(content)) {
                         continue;
                     }
@@ -212,6 +247,829 @@ public class MarkdownGenerator implements Closeable {
                 writeContentsSeparator();
             }
         }
+    }
+
+    private int tryWriteRecoveredFlattenedBenchmarkTable(List<IObject> pageContents, int startIndex) throws IOException {
+        if (startIndex < 0 || startIndex >= pageContents.size()) {
+            return 0;
+        }
+        if (!isRecoverableTableTextNode(pageContents.get(startIndex))) {
+            return 0;
+        }
+
+        String startValue = normalizeSpace(((SemanticTextNode) pageContents.get(startIndex)).getValue());
+        boolean startsWithCaption = TABLE_CAPTION_RE.matcher(startValue).matches();
+        int startMetricCount = countMetricTokens(startValue);
+        boolean startsWithMetricHeader = startMetricCount >= 3;
+        boolean startsWithPreHeader = isLikelyBenchmarkPreHeader(startValue);
+        if (!startsWithCaption && !startsWithMetricHeader && !startsWithPreHeader) {
+            return 0;
+        }
+
+        List<String> paragraphValues = new ArrayList<>();
+        List<Integer> paragraphIndexes = new ArrayList<>();
+        int cursor = startIndex;
+        int nonTextGap = 0;
+
+        while (cursor < pageContents.size() && paragraphValues.size() < MAX_PARAGRAPHS_FOR_TABLE_RECOVERY) {
+            IObject obj = pageContents.get(cursor);
+            if (!isRecoverableTableTextNode(obj)) {
+                if (!paragraphValues.isEmpty()) {
+                    nonTextGap += 1;
+                    if (nonTextGap > MAX_NON_TEXT_GAP_FOR_TABLE_RECOVERY) {
+                        break;
+                    }
+                }
+                cursor += 1;
+                continue;
+            }
+            nonTextGap = 0;
+
+            String value = normalizeSpace(((SemanticTextNode) obj).getValue());
+            if (!value.isEmpty()) {
+                paragraphValues.add(value);
+                paragraphIndexes.add(cursor);
+            }
+
+            cursor += 1;
+        }
+
+        if (paragraphValues.size() < 3) {
+            return 0;
+        }
+
+        if (startsWithPreHeader && !startsWithCaption && !startsWithMetricHeader) {
+            return tryRecoverTableWithLeadingHeader(paragraphValues, paragraphIndexes, startIndex);
+        }
+
+        if (startsWithCaption) {
+            int captionPos = 0;
+            int metricPos = -1;
+            int metricCount = 0;
+            for (int i = 1; i < paragraphValues.size(); i++) {
+                int count = countMetricTokens(paragraphValues.get(i));
+                if (count >= 3) {
+                    metricPos = i;
+                    metricCount = count;
+                    break;
+                }
+                if (i > MAX_TABLE_RECOVERY_LEAD_IN) {
+                    break;
+                }
+            }
+            if (metricPos < 0) {
+                return tryRecoverCaptionWithInlineData(paragraphValues, paragraphIndexes, captionPos, startIndex);
+            }
+
+            List<String> metricColumns = buildMetricColumns(paragraphValues.get(metricPos), metricCount);
+            if (metricColumns.size() < 3) {
+                return 0;
+            }
+
+            StringBuilder dataText = new StringBuilder();
+            List<RecoveredTableRow> rows = new ArrayList<>();
+            int dataEndExclusive = metricPos + 1;
+            for (int i = metricPos + 1; i < paragraphValues.size(); i++) {
+                String line = paragraphValues.get(i);
+                if (TABLE_CAPTION_RE.matcher(line).matches()) {
+                    break;
+                }
+                if (isLikelyProseLine(line) && rows.size() >= 2) {
+                    break;
+                }
+                if (dataText.length() > 0) {
+                    dataText.append(' ');
+                }
+                dataText.append(line);
+                dataEndExclusive = i + 1;
+                rows = recoverBenchmarkRowsFromText(dataText.toString(), metricColumns.size());
+            }
+            if (rows.size() < minimumRecoveredRowCount(metricColumns)) {
+                return 0;
+            }
+
+            markdownWriter.write(getCorrectMarkdownString(paragraphValues.get(captionPos)));
+            writeContentsSeparator();
+            writeRecoveredTable(metricColumns, rows);
+            writeContentsSeparator();
+
+            int lastDataPos = dataEndExclusive - 1;
+            int lastConsumedAbsoluteIndex = paragraphIndexes.get(lastDataPos);
+            return lastConsumedAbsoluteIndex - startIndex + 1;
+        }
+
+        int metricPos = 0;
+        int metricCount = startMetricCount;
+        int captionPos = -1;
+        for (int i = 1; i < paragraphValues.size(); i++) {
+            if (TABLE_CAPTION_RE.matcher(paragraphValues.get(i)).matches()) {
+                captionPos = i;
+                break;
+            }
+        }
+
+        if (metricPos > MAX_TABLE_RECOVERY_LEAD_IN) {
+            return 0;
+        }
+
+        List<String> metricColumns = buildMetricColumns(paragraphValues.get(metricPos), metricCount);
+        if (metricColumns.size() < 3) {
+            return 0;
+        }
+
+        if (captionPos < 0) {
+            StringBuilder dataText = new StringBuilder();
+            List<RecoveredTableRow> rows = new ArrayList<>();
+            int dataEndExclusive = metricPos + 1;
+            for (int i = metricPos + 1; i < paragraphValues.size(); i++) {
+                String line = paragraphValues.get(i);
+                if (TABLE_CAPTION_RE.matcher(line).matches()) {
+                    break;
+                }
+                if (isLikelyProseLine(line) && rows.size() >= 2) {
+                    break;
+                }
+                if (dataText.length() > 0) {
+                    dataText.append(' ');
+                }
+                dataText.append(line);
+                dataEndExclusive = i + 1;
+                rows = recoverBenchmarkRowsFromText(dataText.toString(), metricColumns.size());
+            }
+            if (rows.size() < minimumRecoveredRowCount(metricColumns)) {
+                return 0;
+            }
+
+            String nearbyCaption = findNearbyCaptionBefore(pageContents, startIndex);
+            if (!nearbyCaption.isEmpty()) {
+                markdownWriter.write(getCorrectMarkdownString(nearbyCaption));
+                writeContentsSeparator();
+            }
+            writeRecoveredTable(metricColumns, rows);
+            writeContentsSeparator();
+
+            int lastDataPos = dataEndExclusive - 1;
+            int lastConsumedAbsoluteIndex = paragraphIndexes.get(lastDataPos);
+            return lastConsumedAbsoluteIndex - startIndex + 1;
+        }
+
+        if (captionPos < 2) {
+            return 0;
+        }
+
+        StringBuilder dataText = new StringBuilder();
+        for (int i = metricPos + 1; i < captionPos; i++) {
+            if (dataText.length() > 0) {
+                dataText.append(' ');
+            }
+            dataText.append(paragraphValues.get(i));
+        }
+
+        List<RecoveredTableRow> rows = recoverBenchmarkRowsFromText(dataText.toString(), metricColumns.size());
+        if (rows.size() < minimumRecoveredRowCount(metricColumns)) {
+            return 0;
+        }
+
+        writeRecoveredTable(metricColumns, rows);
+        writeContentsSeparator();
+        markdownWriter.write(getCorrectMarkdownString(paragraphValues.get(captionPos)));
+        writeContentsSeparator();
+
+        int lastConsumedAbsoluteIndex = paragraphIndexes.get(captionPos);
+        return lastConsumedAbsoluteIndex - startIndex + 1;
+    }
+
+    private int tryRecoverTableWithLeadingHeader(List<String> paragraphValues, List<Integer> paragraphIndexes, int startIndex) throws IOException {
+        int metricPos = -1;
+        int metricCount = 0;
+        for (int i = 1; i < paragraphValues.size(); i++) {
+            int count = countMetricTokens(paragraphValues.get(i));
+            if (count >= 3) {
+                metricPos = i;
+                metricCount = count;
+                break;
+            }
+            if (i > MAX_TABLE_RECOVERY_LEAD_IN + 2 && isLikelyProseLine(paragraphValues.get(i))) {
+                return 0;
+            }
+        }
+        if (metricPos < 1) {
+            return tryRecoverWideComparisonTable(paragraphValues, paragraphIndexes, startIndex);
+        }
+
+        List<String> metricColumns = buildMetricColumns(paragraphValues.get(metricPos), metricCount);
+        if (metricColumns.size() < 3) {
+            return 0;
+        }
+
+        int captionPos = -1;
+        for (int i = metricPos + 1; i < paragraphValues.size(); i++) {
+            if (TABLE_CAPTION_RE.matcher(paragraphValues.get(i)).matches()) {
+                captionPos = i;
+                break;
+            }
+        }
+
+        StringBuilder dataText = new StringBuilder();
+        int dataEndExclusive = metricPos + 1;
+        if (captionPos >= 0) {
+            for (int i = metricPos + 1; i < captionPos; i++) {
+                if (dataText.length() > 0) {
+                    dataText.append(' ');
+                }
+                dataText.append(paragraphValues.get(i));
+                dataEndExclusive = i + 1;
+            }
+        } else {
+            List<RecoveredTableRow> rollingRows = new ArrayList<>();
+            for (int i = metricPos + 1; i < paragraphValues.size(); i++) {
+                String line = paragraphValues.get(i);
+                if (TABLE_CAPTION_RE.matcher(line).matches()) {
+                    break;
+                }
+                if (isLikelyProseLine(line) && rollingRows.size() >= 2) {
+                    break;
+                }
+                if (dataText.length() > 0) {
+                    dataText.append(' ');
+                }
+                dataText.append(line);
+                dataEndExclusive = i + 1;
+                rollingRows = recoverBenchmarkRowsFromText(dataText.toString(), metricColumns.size());
+            }
+        }
+
+        List<RecoveredTableRow> rows = recoverBenchmarkRowsFromText(dataText.toString(), metricColumns.size());
+        if (rows.size() < minimumRecoveredRowCount(metricColumns)) {
+            return 0;
+        }
+
+        writeRecoveredTable(metricColumns, rows);
+        writeContentsSeparator();
+
+        if (captionPos >= 0) {
+            markdownWriter.write(getCorrectMarkdownString(paragraphValues.get(captionPos)));
+            writeContentsSeparator();
+            int lastConsumedAbsoluteIndex = paragraphIndexes.get(captionPos);
+            return lastConsumedAbsoluteIndex - startIndex + 1;
+        }
+
+        int lastDataPos = dataEndExclusive - 1;
+        int lastConsumedAbsoluteIndex = paragraphIndexes.get(lastDataPos);
+        return lastConsumedAbsoluteIndex - startIndex + 1;
+    }
+
+    private int tryRecoverWideComparisonTable(List<String> paragraphValues, List<Integer> paragraphIndexes, int startIndex) throws IOException {
+        int captionPos = -1;
+        for (int i = 0; i < paragraphValues.size(); i++) {
+            if (TABLE_CAPTION_RE.matcher(paragraphValues.get(i)).matches()) {
+                captionPos = i;
+                break;
+            }
+        }
+        if (captionPos < 2) {
+            return 0;
+        }
+
+        int columnCount = inferWideTableColumnCount(paragraphValues, captionPos);
+        if (columnCount < 4) {
+            return 0;
+        }
+
+        List<String> metricColumns = buildWideComparisonColumns(paragraphValues, captionPos, columnCount);
+        List<RecoveredTableRow> rows = new ArrayList<>();
+        for (int i = 0; i < captionPos; i++) {
+            String line = paragraphValues.get(i);
+            if (line.equalsIgnoreCase("Model")) {
+                continue;
+            }
+            if (line.equalsIgnoreCase("English") || line.equalsIgnoreCase("Code") || line.equalsIgnoreCase("Math") || line.equalsIgnoreCase("Chinese")) {
+                continue;
+            }
+            RecoveredTableRow row = parseWideComparisonRow(line, columnCount);
+            if (row != null) {
+                rows.add(row);
+            }
+        }
+
+        if (rows.size() < 5) {
+            return 0;
+        }
+
+        writeRecoveredTable(metricColumns, rows);
+        writeContentsSeparator();
+        markdownWriter.write(getCorrectMarkdownString(paragraphValues.get(captionPos)));
+        writeContentsSeparator();
+
+        int lastConsumedAbsoluteIndex = paragraphIndexes.get(captionPos);
+        return lastConsumedAbsoluteIndex - startIndex + 1;
+    }
+
+    private int tryRecoverCaptionWithInlineData(List<String> paragraphValues, List<Integer> paragraphIndexes,
+                                                int captionPos, int startIndex) throws IOException {
+        int inlinePos = -1;
+        int firstModelTokenPos = -1;
+        String[] inlineTokens = null;
+
+        for (int i = captionPos + 1; i < paragraphValues.size(); i++) {
+            String line = paragraphValues.get(i);
+            String[] tokens = normalizeSpace(line).split(" ");
+            int modelPos = findFirstModelTokenIndex(tokens);
+            if (modelPos >= 0) {
+                inlinePos = i;
+                firstModelTokenPos = modelPos;
+                inlineTokens = tokens;
+                break;
+            }
+            if (i > captionPos + MAX_TABLE_RECOVERY_LEAD_IN && isLikelyProseLine(line)) {
+                return 0;
+            }
+        }
+
+        if (inlinePos < 0 || inlineTokens == null) {
+            return 0;
+        }
+
+        String headerPrefix = joinTokens(inlineTokens, 0, firstModelTokenPos);
+        StringBuilder dataText = new StringBuilder(joinTokens(inlineTokens, firstModelTokenPos, inlineTokens.length));
+        int dataEndExclusive = inlinePos + 1;
+
+        int metricCount = inferMetricCountFromDataText(dataText.toString());
+        if (metricCount < 2) {
+            return 0;
+        }
+
+        List<String> metricColumns = buildMetricColumnsFromCaptionOrPrefix(paragraphValues.get(captionPos), headerPrefix, metricCount);
+        List<RecoveredTableRow> rows = recoverBenchmarkRowsFromText(dataText.toString(), metricCount);
+
+        for (int i = inlinePos + 1; i < paragraphValues.size(); i++) {
+            String line = paragraphValues.get(i);
+            if (TABLE_CAPTION_RE.matcher(line).matches()) {
+                break;
+            }
+            if (isLikelyProseLine(line) && rows.size() >= 2) {
+                break;
+            }
+            dataText.append(' ').append(line);
+            dataEndExclusive = i + 1;
+
+            int inferredMetricCount = inferMetricCountFromDataText(dataText.toString());
+            if (inferredMetricCount > metricCount) {
+                metricCount = inferredMetricCount;
+                metricColumns = buildMetricColumnsFromCaptionOrPrefix(paragraphValues.get(captionPos), headerPrefix, metricCount);
+            }
+            rows = recoverBenchmarkRowsFromText(dataText.toString(), metricCount);
+        }
+
+        if (rows.size() < minimumRecoveredRowCount(metricColumns)) {
+            return 0;
+        }
+
+        markdownWriter.write(getCorrectMarkdownString(paragraphValues.get(captionPos)));
+        writeContentsSeparator();
+        writeRecoveredTable(metricColumns, rows);
+        writeContentsSeparator();
+
+        int lastDataPos = dataEndExclusive - 1;
+        int lastConsumedAbsoluteIndex = paragraphIndexes.get(lastDataPos);
+        return lastConsumedAbsoluteIndex - startIndex + 1;
+    }
+
+    private String findNearbyCaptionBefore(List<IObject> pageContents, int startIndex) {
+        int minIndex = Math.max(0, startIndex - MAX_TABLE_RECOVERY_LEAD_IN);
+        for (int i = startIndex - 1; i >= minIndex; i--) {
+            IObject object = pageContents.get(i);
+            if (!isRecoverableTableTextNode(object)) {
+                continue;
+            }
+            String value = normalizeSpace(((SemanticTextNode) object).getValue());
+            if (TABLE_CAPTION_RE.matcher(value).matches()) {
+                return value;
+            }
+            Matcher captionMatcher = TABLE_CAPTION_IN_TEXT_RE.matcher(value);
+            if (captionMatcher.matches()) {
+                return normalizeSpace(captionMatcher.group(1));
+            }
+        }
+        return "";
+    }
+
+    private boolean isRecoverableTableTextNode(IObject object) {
+        return object instanceof SemanticTextNode && !(object instanceof SemanticHeaderOrFooter);
+    }
+
+    private void writeRecoveredTable(List<String> metricColumns, List<RecoveredTableRow> rows) throws IOException {
+        markdownWriter.write(MarkdownSyntax.TABLE_COLUMN_SEPARATOR + " Model " + MarkdownSyntax.TABLE_COLUMN_SEPARATOR);
+        for (String col : metricColumns) {
+            markdownWriter.write(" " + col + " " + MarkdownSyntax.TABLE_COLUMN_SEPARATOR);
+        }
+        markdownWriter.write(MarkdownSyntax.LINE_BREAK);
+
+        markdownWriter.write(MarkdownSyntax.TABLE_COLUMN_SEPARATOR + MarkdownSyntax.TABLE_HEADER_SEPARATOR + MarkdownSyntax.TABLE_COLUMN_SEPARATOR);
+        for (int i = 0; i < metricColumns.size(); i++) {
+            markdownWriter.write(MarkdownSyntax.TABLE_HEADER_SEPARATOR + MarkdownSyntax.TABLE_COLUMN_SEPARATOR);
+        }
+        markdownWriter.write(MarkdownSyntax.LINE_BREAK);
+
+        for (RecoveredTableRow row : rows) {
+            markdownWriter.write(MarkdownSyntax.TABLE_COLUMN_SEPARATOR + " " + row.model + " " + MarkdownSyntax.TABLE_COLUMN_SEPARATOR);
+            for (String value : row.metrics) {
+                markdownWriter.write(" " + value + " " + MarkdownSyntax.TABLE_COLUMN_SEPARATOR);
+            }
+            markdownWriter.write(MarkdownSyntax.LINE_BREAK);
+        }
+    }
+
+    private static List<String> buildMetricColumnsFromCaptionOrPrefix(String caption, String headerPrefix, int metricCount) {
+        List<String> fromCaption = extractYearMetricColumns(caption);
+        if (fromCaption.size() >= metricCount) {
+            return finalizeMetricColumns(fromCaption.subList(fromCaption.size() - metricCount, fromCaption.size()), metricCount);
+        }
+
+        List<String> fromHeader = extractYearMetricColumns(headerPrefix);
+        if (fromHeader.size() >= metricCount) {
+            return finalizeMetricColumns(fromHeader.subList(fromHeader.size() - metricCount, fromHeader.size()), metricCount);
+        }
+
+        return finalizeMetricColumns(new ArrayList<>(), metricCount);
+    }
+
+    private static List<String> extractYearMetricColumns(String text) {
+        List<String> out = new ArrayList<>();
+        if (text == null || text.isBlank()) {
+            return out;
+        }
+        Matcher matcher = YEAR_LABEL_PAIR_RE.matcher(normalizeSpace(text));
+        while (matcher.find()) {
+            out.add(matcher.group(1) + " " + matcher.group(2));
+        }
+        return out;
+    }
+
+    private static String joinTokens(String[] tokens, int startInclusive, int endExclusive) {
+        StringBuilder out = new StringBuilder();
+        for (int i = startInclusive; i < endExclusive && i < tokens.length; i++) {
+            if (out.length() > 0) {
+                out.append(' ');
+            }
+            out.append(tokens[i]);
+        }
+        return out.toString();
+    }
+
+    private static int findFirstModelTokenIndex(String[] tokens) {
+        for (int i = 0; i < tokens.length - 1; i++) {
+            if (!MODEL_TOKEN_RE.matcher(tokens[i]).matches() || !NUMERIC_TOKEN_RE.matcher(tokens[i + 1]).matches()) {
+                continue;
+            }
+            if (isLikelyYearHeaderToken(tokens[i], tokens[i + 1])) {
+                continue;
+            }
+            if (i > 0 && isLikelyYearHeaderToken(tokens[i - 1], tokens[i])) {
+                continue;
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    private static boolean isLikelyYearHeaderToken(String labelToken, String yearToken) {
+        if (!YEAR_TOKEN_RE.matcher(yearToken).matches()) {
+            return false;
+        }
+        return labelToken.matches("^[A-Z]{2,8}$");
+    }
+
+    private static int inferMetricCountFromDataText(String dataText) {
+        if (dataText == null || dataText.isBlank()) {
+            return 0;
+        }
+
+        String[] tokens = normalizeSpace(dataText).split(" ");
+        int maxMetrics = 0;
+        int i = 0;
+        while (i < tokens.length) {
+            if (!MODEL_TOKEN_RE.matcher(tokens[i]).matches()) {
+                i += 1;
+                continue;
+            }
+
+            int j = i + 1;
+            int metricCount = 0;
+            while (j < tokens.length && NUMERIC_TOKEN_RE.matcher(tokens[j]).matches()) {
+                metricCount += 1;
+                j += 1;
+            }
+            maxMetrics = Math.max(maxMetrics, metricCount);
+            i = Math.max(j, i + 1);
+        }
+
+        return maxMetrics;
+    }
+
+    private static int minimumRecoveredRowCount(List<String> metricColumns) {
+        if (metricColumns.isEmpty()) {
+            return 2;
+        }
+        if (metricColumns.get(0).startsWith("metric_")) {
+            return 3;
+        }
+        return 2;
+    }
+
+    private static int inferWideTableColumnCount(List<String> paragraphValues, int captionPos) {
+        int bestColumnCount = 0;
+        int bestRowCount = 0;
+        for (int candidate = 4; candidate <= 8; candidate++) {
+            int rowCount = 0;
+            for (int i = 0; i < captionPos; i++) {
+                if (parseWideComparisonRow(paragraphValues.get(i), candidate) != null) {
+                    rowCount += 1;
+                }
+            }
+            if (rowCount > bestRowCount) {
+                bestRowCount = rowCount;
+                bestColumnCount = candidate;
+            }
+        }
+        if (bestRowCount < 5) {
+            return 0;
+        }
+        return bestColumnCount;
+    }
+
+    private static List<String> buildWideComparisonColumns(List<String> paragraphValues, int captionPos, int columnCount) {
+        int benchmarkPos = -1;
+        for (int i = 0; i < captionPos; i++) {
+            String line = paragraphValues.get(i);
+            if (line.toLowerCase().contains("benchmark") && line.toLowerCase().contains("metric")) {
+                benchmarkPos = i;
+                break;
+            }
+        }
+
+        if (benchmarkPos > 0 && benchmarkPos + 1 < captionPos) {
+            List<String> upper = splitLineTokens(paragraphValues.get(benchmarkPos - 1));
+            List<String> lower = splitLineTokens(paragraphValues.get(benchmarkPos + 1));
+            if (upper.size() == columnCount && lower.size() == columnCount) {
+                List<String> merged = new ArrayList<>();
+                for (int i = 0; i < columnCount; i++) {
+                    merged.add(upper.get(i) + " " + lower.get(i));
+                }
+                return finalizeMetricColumns(merged, columnCount);
+            }
+            if (lower.size() == columnCount) {
+                return finalizeMetricColumns(lower, columnCount);
+            }
+            if (upper.size() == columnCount) {
+                return finalizeMetricColumns(upper, columnCount);
+            }
+        }
+
+        for (int i = 0; i < captionPos; i++) {
+            List<String> tokens = splitLineTokens(paragraphValues.get(i));
+            if (tokens.size() == columnCount && !paragraphValues.get(i).toLowerCase().contains("benchmark")) {
+                return finalizeMetricColumns(tokens, columnCount);
+            }
+        }
+
+        return finalizeMetricColumns(new ArrayList<>(), columnCount);
+    }
+
+    private static RecoveredTableRow parseWideComparisonRow(String line, int columnCount) {
+        List<String> tokens = splitLineTokens(line);
+        if (tokens.size() <= columnCount) {
+            return null;
+        }
+
+        List<String> values = new ArrayList<>();
+        int cursor = tokens.size() - 1;
+        while (cursor >= 0 && values.size() < columnCount && WIDE_TABLE_VALUE_TOKEN_RE.matcher(tokens.get(cursor)).matches()) {
+            values.add(0, tokens.get(cursor));
+            cursor -= 1;
+        }
+        if (values.size() != columnCount) {
+            return null;
+        }
+
+        StringBuilder labelBuilder = new StringBuilder();
+        for (int i = 0; i <= cursor; i++) {
+            if (labelBuilder.length() > 0) {
+                labelBuilder.append(' ');
+            }
+            labelBuilder.append(tokens.get(i));
+        }
+        String label = normalizeSpace(labelBuilder.toString());
+        if (label.isEmpty() || label.equalsIgnoreCase("Model")) {
+            return null;
+        }
+        return new RecoveredTableRow(label, values);
+    }
+
+    private static List<String> splitLineTokens(String line) {
+        List<String> out = new ArrayList<>();
+        String normalized = normalizeSpace(line);
+        if (normalized.isEmpty()) {
+            return out;
+        }
+        String[] tokens = normalized.split(" ");
+        for (String token : tokens) {
+            if (!token.isBlank()) {
+                out.add(token.trim());
+            }
+        }
+        return out;
+    }
+
+    static List<String> buildMetricColumns(String metricLine, int metricCount) {
+        List<String> raw = new ArrayList<>();
+        String[] tokens = normalizeSpace(metricLine).split(" ");
+        for (String token : tokens) {
+            if (METRIC_TOKEN_RE.matcher(token).matches()) {
+                raw.add(token);
+            }
+        }
+        if (raw.size() < metricCount) {
+            raw.clear();
+            for (String token : tokens) {
+                if (!token.isBlank()) {
+                    raw.add(token);
+                }
+            }
+        }
+
+        return finalizeMetricColumns(raw, metricCount);
+    }
+
+    private static List<String> finalizeMetricColumns(List<String> raw, int metricCount) {
+        List<String> out = new ArrayList<>();
+        Map<String, Integer> seen = new HashMap<>();
+        for (String token : raw) {
+            if (out.size() >= metricCount) {
+                break;
+            }
+            String base = token.trim();
+            if (base.isEmpty()) {
+                continue;
+            }
+            int count = seen.getOrDefault(base, 0) + 1;
+            seen.put(base, count);
+            out.add(count == 1 ? base : base + "_" + count);
+        }
+
+        while (out.size() < metricCount) {
+            out.add("metric_" + (out.size() + 1));
+        }
+        return out;
+    }
+
+    static List<RecoveredTableRow> recoverBenchmarkRowsFromText(String dataText, int metricCount) {
+        List<RecoveredTableRow> rows = new ArrayList<>();
+        if (dataText == null || dataText.isBlank() || metricCount <= 0) {
+            return rows;
+        }
+
+        String[] tokens = normalizeSpace(dataText).split(" ");
+        int fullRowCount = 0;
+        int i = 0;
+        while (i < tokens.length) {
+            String model = tokens[i];
+            if (!MODEL_TOKEN_RE.matcher(model).matches()) {
+                i += 1;
+                continue;
+            }
+
+            List<String> metrics = new ArrayList<>();
+            int j = i + 1;
+            while (j < tokens.length && metrics.size() < metricCount && NUMERIC_TOKEN_RE.matcher(tokens[j]).matches()) {
+                metrics.add(tokens[j]);
+                j += 1;
+            }
+
+            if (metrics.size() == metricCount) {
+                rows.add(new RecoveredTableRow(model, metrics));
+                fullRowCount += 1;
+                i = j;
+                continue;
+            }
+
+            int minimumPartialMetrics = Math.max(1, metricCount - 2);
+            boolean nextLooksLikeModel = j < tokens.length && MODEL_TOKEN_RE.matcher(tokens[j]).matches();
+            if (nextLooksLikeModel && metrics.size() >= minimumPartialMetrics) {
+                while (metrics.size() < metricCount) {
+                    metrics.add("");
+                }
+                rows.add(new RecoveredTableRow(model, metrics));
+                i = j;
+                continue;
+            }
+
+            i += 1;
+        }
+
+        if (fullRowCount == 0) {
+            return new ArrayList<>();
+        }
+
+        return rows;
+    }
+
+    static int countMetricTokens(String line) {
+        if (line == null || line.isBlank()) {
+            return 0;
+        }
+        int count = 0;
+        String[] tokens = normalizeSpace(line).split(" ");
+        for (String token : tokens) {
+            if (METRIC_TOKEN_RE.matcher(token).matches()) {
+                count += 1;
+            }
+        }
+        return count;
+    }
+
+    static String normalizeSpace(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("\\s+", " ").trim();
+    }
+
+    private static int countNumericTokens(String line) {
+        if (line == null || line.isBlank()) {
+            return 0;
+        }
+        int count = 0;
+        String[] tokens = normalizeSpace(line).split(" ");
+        for (String token : tokens) {
+            if (NUMERIC_TOKEN_RE.matcher(token).matches()) {
+                count += 1;
+            }
+        }
+        return count;
+    }
+
+    private static boolean isLikelyProseLine(String line) {
+        String normalized = normalizeSpace(line);
+        if (normalized.isEmpty()) {
+            return false;
+        }
+        int tokenCount = normalized.split(" ").length;
+        int numericCount = countNumericTokens(normalized);
+        boolean hasSentencePunctuation = normalized.contains(".") || normalized.contains(";");
+        if (tokenCount >= 14 && hasSentencePunctuation && numericCount <= 4) {
+            return true;
+        }
+        return tokenCount >= 28 && numericCount <= 6;
+    }
+
+    private static boolean isLikelyBenchmarkPreHeader(String line) {
+        String normalized = normalizeSpace(line);
+        if (normalized.isEmpty()) {
+            return false;
+        }
+
+        String lower = normalized.toLowerCase();
+        if (lower.contains("benchmark") && lower.contains("metric")) {
+            return true;
+        }
+
+        if (normalized.equalsIgnoreCase("Model")) {
+            return true;
+        }
+
+        String[] tokens = normalized.split(" ");
+        if (tokens.length > 10) {
+            return false;
+        }
+
+        int hintCount = 0;
+        for (String token : tokens) {
+            String cleaned = token.replaceAll("[^A-Za-z0-9@-]", "");
+            if (cleaned.isEmpty()) {
+                continue;
+            }
+            if (BENCHMARK_HEADER_HINT_TOKEN_RE.matcher(cleaned).matches()) {
+                hintCount += 1;
+            }
+        }
+        if (hintCount >= 2) {
+            return true;
+        }
+
+        int modelLikeCount = 0;
+        for (String token : tokens) {
+            String cleaned = token.replaceAll("[^A-Za-z0-9.-]", "");
+            if (cleaned.isEmpty()) {
+                continue;
+            }
+            boolean hasUppercase = !cleaned.equals(cleaned.toLowerCase());
+            boolean hasDigitOrHyphen = cleaned.matches(".*[0-9-].*");
+            if ((hasUppercase || hasDigitOrHyphen) && cleaned.length() <= 24) {
+                modelLikeCount += 1;
+            }
+        }
+        return tokens.length >= 4 && modelLikeCount >= 3;
     }
 
     protected void writeList(PDFList list) throws IOException {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -77,6 +79,86 @@ public class MarkdownGeneratorTest {
         assertEquals("# ", generateHeadingPrefix(1));
         assertEquals("# ", generateHeadingPrefix(0));
         assertEquals("# ", generateHeadingPrefix(-1));
+    }
+
+    @Test
+    void testBuildMetricColumnsDisambiguatesDuplicates() {
+        List<String> cols = MarkdownGenerator.buildMetricColumns("pass@1 cons@64 pass@1 pass@1 pass@1 rating", 6);
+        assertEquals(List.of("pass@1", "cons@64", "pass@1_2", "pass@1_3", "pass@1_4", "rating"), cols);
+    }
+
+    @Test
+    void testRecoverBenchmarkRowsFromFlattenedText() {
+        String flattened = "GPT-4o-0513 9.3 13.4 74.6 49.9 32.9 759 "
+            + "Claude-3.5-Sonnet-1022 16.0 26.7 78.3 65.0 38.9 717 "
+            + "OpenAI-o1-mini 63.6 80.0 90.0 60.0 53.8 1820";
+        List<?> rows = MarkdownGenerator.recoverBenchmarkRowsFromText(flattened, 6);
+        assertEquals(3, rows.size());
+    }
+
+    @Test
+    void testCountMetricTokensRecognizesDeepSeekHeaderShape() {
+        int count = MarkdownGenerator.countMetricTokens("pass@1 cons@64 pass@1 pass@1 pass@1 rating");
+        assertEquals(6, count);
+    }
+
+    @Test
+    void testRecoverBenchmarkRowsIgnoresProse() {
+        String prose = "This paragraph discusses benchmark trends without structured rows or scores.";
+        List<?> rows = MarkdownGenerator.recoverBenchmarkRowsFromText(prose, 6);
+        assertTrue(rows.isEmpty());
+    }
+
+    @Test
+    void testRecoverBenchmarkRowsSupportsTwoRowTables() {
+        String flattened = "OpenAI-o1-0912 74.4 83.3 96.4 63.6 53.8 1840 "
+            + "DeepSeek-R1 79.8 86.7 97.3 65.9 49.2 2029";
+        List<?> rows = MarkdownGenerator.recoverBenchmarkRowsFromText(flattened, 6);
+        assertEquals(2, rows.size());
+    }
+
+    @Test
+    void testRecoverBenchmarkRowsFromDeepSeekDistillBlock() {
+        String flattened = "GPT-4o-0513 9.3 74.6 49.9 759 Claude-3.5-Sonnet-1022 16.0 26.7 78.3 38.9 717 "
+            + "DeepSeek-R1-Distill-Qwen-1.5B 28.9 52.7 83.9 33.8 16.9 954 "
+            + "DeepSeek-R1-Distill-Qwen-7B 55.5 83.3 92.8 49.1 37.6 1189 "
+            + "DeepSeek-R1-Distill-Qwen-14B 69.7 80.0 93.9 59.1 53.1 1481";
+        List<?> rows = MarkdownGenerator.recoverBenchmarkRowsFromText(flattened, 6);
+        assertTrue(rows.size() >= 2);
+    }
+
+    @Test
+    void testRecoverBenchmarkRowsAllowsPartialWhenAtLeastOneFullRowExists() {
+        String flattened = "QwQ-32B-Preview 50.0 60.0 41.9 "
+            + "Qwen2.5-32B-Zero 47.0 60.0 40.2 "
+            + "DeepSeek-R1-Distill-Qwen-32B 72.6 83.3 94.3 62.1 57.2";
+        List<?> rows = MarkdownGenerator.recoverBenchmarkRowsFromText(flattened, 5);
+        assertEquals(3, rows.size());
+    }
+
+    @Test
+    void testRecoverBenchmarkRowsSkipsPartialWhenNoFullRowsExist() {
+        String flattened = "QwQ-32B-Preview 50.0 60.0 41.9 "
+            + "Qwen2.5-32B-Zero 47.0 60.0 40.2";
+        List<?> rows = MarkdownGenerator.recoverBenchmarkRowsFromText(flattened, 5);
+        assertTrue(rows.isEmpty());
+    }
+
+    @Test
+    void testRecoverBenchmarkRowsSupportsPercentValues() {
+        String flattened = "GPT-4o-0513 9.3% "
+            + "Qwen2-Math-7B-Instruct 7.9% 4.6% "
+            + "Qwen2-Math-7B-Zero 22.3% 18.1%";
+        List<?> rows = MarkdownGenerator.recoverBenchmarkRowsFromText(flattened, 2);
+        assertEquals(3, rows.size());
+    }
+
+    @Test
+    void testRecoverBenchmarkRowsPercentOnlyWithoutFullRowStillSkips() {
+        String flattened = "GPT-4o-0513 9.3% "
+            + "Qwen2-Math-7B-Instruct 7.9%";
+        List<?> rows = MarkdownGenerator.recoverBenchmarkRowsFromText(flattened, 2);
+        assertTrue(rows.isEmpty());
     }
 
     /**


### PR DESCRIPTION
## Summary
- recover DeepSeek-style flattened benchmark tables that are emitted as paragraph runs instead of native table structures
- handle caption-first, metric-first, and benchmark pre-header variants while preventing prose bleed-through and keeping fallback behavior conservative
- add focused MarkdownGeneratorTest coverage for duplicate metric headers, partial row handling, percent values, and multi-row flattened recovery cases

Closes #259.
