### PR TITLE
fix: correct abnormal short text bounding box width

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
@@ -56,6 +56,7 @@ public class ContentFilterProcessor {
             filterOutOfPageContents(pageNumber, pageContents);
             pageContents = DocumentProcessor.removeNullObjectsFromList(pageContents);
         }
+        fixAbnormalTextChunkBoundingBoxes(pageContents);
         TextProcessor.mergeCloseTextChunks(pageContents);
         pageContents = DocumentProcessor.removeNullObjectsFromList(pageContents);
         TextProcessor.trimTextChunksWhiteSpaces(pageContents);
@@ -97,6 +98,34 @@ public class ContentFilterProcessor {
         for (IObject object : pageContents) {
             if (object instanceof TextChunk) {
                 ((TextChunk) object).compressSpaces();
+            }
+        }
+    }
+
+    private static void fixAbnormalTextChunkBoundingBoxes(List<IObject> pageContents) {
+        for (IObject object : pageContents) {
+            if (!(object instanceof TextChunk)) {
+                continue;
+            }
+            TextChunk textChunk = (TextChunk) object;
+            String value = textChunk.getValue();
+            if (value == null) {
+                continue;
+            }
+            int charCount = value.length();
+            if (charCount < 1 || charCount > 3) {
+                continue;
+            }
+            BoundingBox boundingBox = textChunk.getBoundingBox();
+            double height = boundingBox.getHeight();
+            if (height <= 0) {
+                continue;
+            }
+            double expectedWidth = charCount * height * 0.7;
+            double maxWidth = expectedWidth * 3;
+            if (boundingBox.getWidth() > maxWidth) {
+                boundingBox.setRightX(boundingBox.getLeftX() + expectedWidth);
+                textChunk.adjustSymbolEndsToBoundingBox(null);
             }
         }
     }


### PR DESCRIPTION
Correct short (1–3 char) text chunk bounding boxes when width is wildly inflated relative to height, so table cell assignment no longer spills across columns.

**Issue resolved by this Pull Request:**
Resolves #258

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.