### PR TITLE
Fix propagate StaticContainers ThreadLocal context for hybrid page workers

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -265,25 +266,42 @@ public class HybridDocumentProcessor {
             new ClusterTableProcessor().processTables(workingContents);
         }
 
-        // Process each page through the standard Java pipeline.
-        // StaticContainers uses ThreadLocal fields, so worker threads must inherit context explicitly.
+        // Stage 1 (sequential): table-border processing mutates shared table-border collections.
+        // Keep it on the main thread to avoid concurrent mutation of shared verapdf state.
+        for (int pageNumber : pageNumbers) {
+            List<IObject> pageContents = workingContents.get(pageNumber);
+            pageContents = TableBorderProcessor.processTableBorders(pageContents, pageNumber);
+            pageContents = pageContents.stream()
+                .filter(x -> !(x instanceof LineChunk))
+                .collect(Collectors.toList());
+            workingContents.set(pageNumber, pageContents);
+        }
+
+        // Stage 2 (parallel): text-line processing with ThreadLocal flag propagation.
+        // Results are collected in a concurrent map instead of mutating ArrayList from worker threads.
         StaticContainersThreadContext.Snapshot threadContext = StaticContainersThreadContext.capture();
+        Map<Integer, List<IObject>> textLineResults = new ConcurrentHashMap<>();
         pageNumbers.parallelStream().forEach(pageNumber -> {
             try {
                 StaticContainersThreadContext.apply(threadContext);
                 List<IObject> pageContents = workingContents.get(pageNumber);
-                pageContents = TableBorderProcessor.processTableBorders(pageContents, pageNumber);
-                pageContents = pageContents.stream()
-                    .filter(x -> !(x instanceof LineChunk))
-                    .collect(Collectors.toList());
                 pageContents = TextLineProcessor.processTextLines(pageContents);
-                pageContents = SpecialTableProcessor.detectSpecialTables(pageContents);
-                workingContents.set(pageNumber, pageContents);
+                textLineResults.put(pageNumber, pageContents);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Error processing page {0}: {1}",
                     new Object[]{pageNumber, e.getMessage()});
+                textLineResults.put(pageNumber, workingContents.get(pageNumber));
+            } finally {
+                StaticContainersThreadContext.clear();
             }
         });
+
+        // Stage 3 (sequential): special-table detection touches table-border structures.
+        for (int pageNumber : pageNumbers) {
+            List<IObject> pageContents = textLineResults.getOrDefault(pageNumber, workingContents.get(pageNumber));
+            pageContents = SpecialTableProcessor.detectSpecialTables(pageContents);
+            workingContents.set(pageNumber, pageContents);
+        }
 
         // Apply cross-page processing for Java pages only
         applyJavaPagePostProcessing(workingContents, pageNumbers);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/StaticContainersThreadContext.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/StaticContainersThreadContext.java
@@ -7,9 +7,9 @@
  */
 package org.opendataloader.pdf.processors;
 
-import org.verapdf.wcag.algorithms.entities.IDocument;
-import org.verapdf.wcag.algorithms.entities.tables.TableBordersCollection;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
+
+import java.util.Objects;
 
 /**
  * Captures and reapplies verapdf StaticContainers ThreadLocal state.
@@ -26,51 +26,55 @@ final class StaticContainersThreadContext {
     }
 
     static Snapshot capture() {
-        return new Snapshot(
+        boolean isIgnoreCharactersWithoutUnicode = Objects.requireNonNull(
             StaticContainers.getIsIgnoreCharactersWithoutUnicode(),
+            "StaticContainers.isIgnoreCharactersWithoutUnicode is not initialized"
+        );
+        boolean isDataLoader = Objects.requireNonNull(
             StaticContainers.getIsDataLoader(),
+            "StaticContainers.isDataLoader is not initialized"
+        );
+        boolean keepLineBreaks = Objects.requireNonNull(
             StaticContainers.isKeepLineBreaks(),
-            StaticContainers.getDocument(),
-            StaticContainers.getTableBordersCollection()
+            "StaticContainers.keepLineBreaks is not initialized"
+        );
+
+        return new Snapshot(
+            isIgnoreCharactersWithoutUnicode,
+            isDataLoader,
+            keepLineBreaks
         );
     }
 
     static void apply(Snapshot snapshot) {
-        if (snapshot.document != null) {
-            StaticContainers.setDocument(snapshot.document);
-        }
-        if (snapshot.tableBordersCollection != null) {
-            StaticContainers.setTableBordersCollection(snapshot.tableBordersCollection);
-        }
-        if (snapshot.keepLineBreaks != null) {
-            StaticContainers.setKeepLineBreaks(snapshot.keepLineBreaks);
-        }
-        if (snapshot.isDataLoader != null) {
-            StaticContainers.setIsDataLoader(snapshot.isDataLoader);
-        }
-        if (snapshot.isIgnoreCharactersWithoutUnicode != null) {
-            StaticContainers.setIsIgnoreCharactersWithoutUnicode(snapshot.isIgnoreCharactersWithoutUnicode);
-        }
+        StaticContainers.setIsIgnoreCharactersWithoutUnicode(snapshot.isIgnoreCharactersWithoutUnicode);
+        StaticContainers.setIsDataLoader(snapshot.isDataLoader);
+        StaticContainers.setKeepLineBreaks(snapshot.keepLineBreaks);
+    }
+
+    /**
+     * Clears worker-thread ThreadLocal values to avoid leaking state across reused pool threads.
+     */
+    static void clear() {
+        StaticContainers.setDocument(null);
+        StaticContainers.setTableBordersCollection(null);
+        StaticContainers.setKeepLineBreaks(false);
+        StaticContainers.setIsDataLoader(false);
+        StaticContainers.setIsIgnoreCharactersWithoutUnicode(false);
     }
 
     static final class Snapshot {
-        private final Boolean isIgnoreCharactersWithoutUnicode;
-        private final Boolean isDataLoader;
-        private final Boolean keepLineBreaks;
-        private final IDocument document;
-        private final TableBordersCollection tableBordersCollection;
+        private final boolean isIgnoreCharactersWithoutUnicode;
+        private final boolean isDataLoader;
+        private final boolean keepLineBreaks;
 
         private Snapshot(
-                Boolean isIgnoreCharactersWithoutUnicode,
-                Boolean isDataLoader,
-                Boolean keepLineBreaks,
-                IDocument document,
-                TableBordersCollection tableBordersCollection) {
+                boolean isIgnoreCharactersWithoutUnicode,
+                boolean isDataLoader,
+                boolean keepLineBreaks) {
             this.isIgnoreCharactersWithoutUnicode = isIgnoreCharactersWithoutUnicode;
             this.isDataLoader = isDataLoader;
             this.keepLineBreaks = keepLineBreaks;
-            this.document = document;
-            this.tableBordersCollection = tableBordersCollection;
         }
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/StaticContainersThreadContextTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/StaticContainersThreadContextTest.java
@@ -25,6 +25,7 @@ class StaticContainersThreadContextTest {
     void shouldApplyStaticContainersContextOnWorkerThread() throws Exception {
         StaticContainers.setIsIgnoreCharactersWithoutUnicode(false);
         StaticContainers.setIsDataLoader(true);
+        StaticContainers.setKeepLineBreaks(false);
 
         StaticContainersThreadContext.Snapshot snapshot = StaticContainersThreadContext.capture();
 
@@ -34,13 +35,26 @@ class StaticContainersThreadContextTest {
 
         try (ForkJoinPool pool = new ForkJoinPool(1)) {
             List<IObject> processed = pool.submit(() -> {
-                StaticContainersThreadContext.apply(snapshot);
-                return TextLineProcessor.processTextLines(contents);
+                try {
+                    StaticContainersThreadContext.apply(snapshot);
+                    return TextLineProcessor.processTextLines(contents);
+                } finally {
+                    StaticContainersThreadContext.clear();
+                }
             }).get();
 
             Assertions.assertEquals(1, processed.size());
             Assertions.assertTrue(processed.get(0) instanceof TextLine);
             Assertions.assertEquals("testtest", ((TextLine) processed.get(0)).getValue());
+
+            Boolean[] residualValues = pool.submit(() -> new Boolean[]{
+                StaticContainers.getIsIgnoreCharactersWithoutUnicode(),
+                StaticContainers.getIsDataLoader(),
+                StaticContainers.isKeepLineBreaks()
+            }).get();
+            Assertions.assertEquals(Boolean.FALSE, residualValues[0]);
+            Assertions.assertEquals(Boolean.FALSE, residualValues[1]);
+            Assertions.assertEquals(Boolean.FALSE, residualValues[2]);
         }
     }
 }


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #264

**Summary of changes:**
- Add `StaticContainersThreadContext` utility to capture/apply verapdf `StaticContainers` ThreadLocal-backed values on worker threads.
- Update `HybridDocumentProcessor.processJavaPath` to process pages via `parallelStream()` and re-apply captured context per worker before table/text processing.
- Add regression test `StaticContainersThreadContextTest` covering worker-thread application before `TextLineProcessor.processTextLines`.

**Validation:**
- Attempted: `mvn -pl opendataloader-pdf-core -Dtest=StaticContainersThreadContextTest,TextLineProcessorTest test`
- Result: build cannot run in this environment because local JDK does not support project-required release target (`error: release version 11 not supported`).

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
