### PR TITLE
fix: avoid cluster table crash on malformed border data

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ClusterTableProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ClusterTableProcessor.java
@@ -18,12 +18,16 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.utils.TextChunkUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Table processor that uses clustering algorithms to detect tables.
  * Identifies tables by analyzing spatial relationships between text chunks.
  */
 public class ClusterTableProcessor extends AbstractTableProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(ClusterTableProcessor.class.getCanonicalName());
 
     @Override
     protected List<List<TableBorder>> getTables(List<List<IObject>> contents, List<Integer> pageNumbers) {
@@ -61,9 +65,14 @@ public class ClusterTableProcessor extends AbstractTableProcessor {
         clusterTableConsumer.processEnd();
         List<TableBorder> result = new ArrayList<>();
         for (Table table : clusterTableConsumer.getTables()) {
-            TableBorder tableBorder = table.createTableBorderFromTable();
-            if (tableBorder != null) {
-                result.add(tableBorder);
+            try {
+                TableBorder tableBorder = table.createTableBorderFromTable();
+                if (tableBorder != null) {
+                    result.add(tableBorder);
+                }
+            } catch (IndexOutOfBoundsException ex) {
+                LOGGER.log(Level.WARNING,
+                    "Skipping malformed cluster-detected table due to invalid border index access", ex);
             }
         }
         return result;


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #238

This change hardens cluster table extraction so a single malformed detected table no longer aborts full document processing:
- Wrap `table.createTableBorderFromTable()` in `ClusterTableProcessor` with an `IndexOutOfBoundsException` guard.
- Skip only the malformed table and continue processing remaining detected tables/pages.
- Emit a warning log entry for observability when malformed table geometry is encountered.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.

Validation attempted:
- `mvn -pl opendataloader-pdf-core -DskipITs -Dtest=SpecialTableProcessorTest test` *(fails in this environment because `javac` is unavailable; compiler cannot satisfy the module build target without a JDK)*