### PR TITLE
Skip malformed cluster tables to avoid full job crash

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ClusterTableProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ClusterTableProcessor.java
@@ -26,12 +26,16 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.utils.TextChunkUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Table processor that uses clustering algorithms to detect tables.
  * Identifies tables by analyzing spatial relationships between text chunks.
  */
 public class ClusterTableProcessor extends AbstractTableProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(ClusterTableProcessor.class.getCanonicalName());
 
     @Override
     protected List<List<TableBorder>> getTables(List<List<IObject>> contents, List<Integer> pageNumbers) {
@@ -67,11 +71,19 @@ public class ClusterTableProcessor extends AbstractTableProcessor {
             }
         }
         clusterTableConsumer.processEnd();
+        return collectTableBorders(clusterTableConsumer.getTables());
+    }
+
+    static List<TableBorder> collectTableBorders(List<Table> tables) {
         List<TableBorder> result = new ArrayList<>();
-        for (Table table : clusterTableConsumer.getTables()) {
-            TableBorder tableBorder = table.createTableBorderFromTable();
-            if (tableBorder != null) {
-                result.add(tableBorder);
+        for (Table table : tables) {
+            try {
+                TableBorder tableBorder = table.createTableBorderFromTable();
+                if (tableBorder != null) {
+                    result.add(tableBorder);
+                }
+            } catch (IndexOutOfBoundsException exception) {
+                LOGGER.log(Level.WARNING, () -> "Skipping malformed cluster-detected table: " + exception.getMessage());
             }
         }
         return result;

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ClusterTableProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ClusterTableProcessorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Hancom Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.opendataloader.pdf.processors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.verapdf.wcag.algorithms.entities.tables.Table;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ClusterTableProcessorTest {
+
+    @Test
+    public void testCollectTableBordersSkipsMalformedTableAndContinues() {
+        Table malformedTable = new Table(Collections.emptyList()) {
+            @Override
+            public TableBorder createTableBorderFromTable() {
+                throw new IndexOutOfBoundsException("Index 2 out of bounds for length 2");
+            }
+        };
+
+        TableBorder expectedBorder = new TableBorder(1, 1);
+        Table validTable = new Table(Collections.emptyList()) {
+            @Override
+            public TableBorder createTableBorderFromTable() {
+                return expectedBorder;
+            }
+        };
+
+        List<TableBorder> result = ClusterTableProcessor.collectTableBorders(List.of(malformedTable, validTable));
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertSame(expectedBorder, result.get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- prevent a single malformed cluster-detected table from aborting the whole page/document flow
- wrap `table.createTableBorderFromTable()` in `ClusterTableProcessor` with an `IndexOutOfBoundsException` guard
- log a warning and continue processing remaining detected tables
- add `ClusterTableProcessorTest` to verify malformed tables are skipped while valid tables are still emitted

## Why
Issue #238 reports `IndexOutOfBoundsException` from `Table.createTableBorderFromTable()` crashing conversion jobs when `table_method="cluster"` is used on large PDFs.

This change keeps processing resilient by skipping only the bad table instance instead of failing the entire run.

Closes #238

## Validation
- Added focused unit test: `ClusterTableProcessorTest#testCollectTableBordersSkipsMalformedTableAndContinues`
- Local Maven execution was not possible in this environment (`mvn` is unavailable).
