### PR TITLE
fix: change hybrid_fallback default to false for fail-fast behavior

### DIFF
--- a/content/docs/_generated/node-convert-options.mdx
+++ b/content/docs/_generated/node-convert-options.mdx
@@ -32,4 +32,4 @@ description: Options for the Node.js convert function
 | `hybridMode`            | `string`             | `"auto"`     | Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)                               |
 | `hybridUrl`             | `string`             | -            | Hybrid backend server URL (overrides default)                                                                                      |
 | `hybridTimeout`         | `string`             | `"30000"`    | Hybrid backend request timeout in milliseconds. Default: 30000                                                                     |
-| `hybridFallback`        | `boolean`            | `true`       | Fallback to Java processing on hybrid backend error. Default: true                                                                 |
+| `hybridFallback`        | `boolean`            | `false`      | Opt in to Java fallback on hybrid backend error (default: disabled)                                                                |

--- a/content/docs/_generated/python-convert-options.mdx
+++ b/content/docs/_generated/python-convert-options.mdx
@@ -33,4 +33,4 @@ description: Options for the Python convert function
 | `hybrid_mode`             | `str`                | `"auto"`     | Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)                               |
 | `hybrid_url`              | `str`                | -            | Hybrid backend server URL (overrides default)                                                                                      |
 | `hybrid_timeout`          | `str`                | `"30000"`    | Hybrid backend request timeout in milliseconds. Default: 30000                                                                     |
-| `hybrid_fallback`         | `bool`               | `True`       | Fallback to Java processing on hybrid backend error. Default: true                                                                 |
+| `hybrid_fallback`         | `bool`               | `False`      | Opt in to Java fallback on hybrid backend error (default: disabled)                                                                |

--- a/content/docs/cli-options-reference.mdx
+++ b/content/docs/cli-options-reference.mdx
@@ -36,7 +36,7 @@ This page documents all available CLI options for opendataloader-pdf.
 | `--hybrid-mode`             | -     | `string`  | `"auto"`     | Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)                               |
 | `--hybrid-url`              | -     | `string`  | -            | Hybrid backend server URL (overrides default)                                                                                      |
 | `--hybrid-timeout`          | -     | `string`  | `"30000"`    | Hybrid backend request timeout in milliseconds. Default: 30000                                                                     |
-| `--hybrid-fallback`         | -     | `boolean` | `true`       | Fallback to Java processing on hybrid backend error. Default: true                                                                 |
+| `--hybrid-fallback`         | -     | `boolean` | `false`      | Opt in to Java fallback on hybrid backend error (default: disabled)                                                                |
 
 ## Examples
 

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
@@ -128,7 +128,7 @@ public class CLIOptions {
     private static final String HYBRID_TIMEOUT_DESC = "Hybrid backend request timeout in milliseconds. Default: 30000";
 
     private static final String HYBRID_FALLBACK_LONG_OPTION = "hybrid-fallback";
-    private static final String HYBRID_FALLBACK_DESC = "Fallback to Java processing on hybrid backend error. Default: true";
+    private static final String HYBRID_FALLBACK_DESC = "Opt in to Java fallback on hybrid backend error (default: disabled)";
 
     // ===== Export Options (internal) =====
     public static final String EXPORT_OPTIONS_LONG_OPTION = "export-options";
@@ -174,7 +174,7 @@ public class CLIOptions {
             new OptionDefinition(HYBRID_MODE_LONG_OPTION, null, "string", "auto", HYBRID_MODE_DESC, true),
             new OptionDefinition(HYBRID_URL_LONG_OPTION, null, "string", null, HYBRID_URL_DESC, true),
             new OptionDefinition(HYBRID_TIMEOUT_LONG_OPTION, null, "string", "30000", HYBRID_TIMEOUT_DESC, true),
-            new OptionDefinition(HYBRID_FALLBACK_LONG_OPTION, null, "boolean", true, HYBRID_FALLBACK_DESC, true),
+            new OptionDefinition(HYBRID_FALLBACK_LONG_OPTION, null, "boolean", false, HYBRID_FALLBACK_DESC, true),
             new OptionDefinition(EXPORT_OPTIONS_LONG_OPTION, null, "boolean", null, null, false),
 
             // Legacy options (not exported, for backward compatibility)

--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIOptionsTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIOptionsTest.java
@@ -442,4 +442,26 @@ class CLIOptionsTest {
         assertEquals("docling", config.getHybrid());
         assertTrue(config.isHybridEnabled());
     }
+
+    @Test
+    void testCreateConfig_defaultHybridFallbackIsFalse() throws ParseException {
+        String[] args = {"--hybrid", "docling", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertFalse(config.getHybridConfig().isFallbackToJava(),
+            "hybrid fallback should be disabled by default to fail-fast when server is unavailable");
+    }
+
+    @Test
+    void testCreateConfig_withHybridFallbackExplicit() throws ParseException {
+        String[] args = {"--hybrid", "docling", "--hybrid-fallback", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertTrue(config.getHybridConfig().isFallbackToJava(),
+            "hybrid fallback should be enabled when explicitly passed");
+    }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
@@ -40,7 +40,7 @@ public class HybridConfig {
 
     private String url;
     private int timeoutMs = DEFAULT_TIMEOUT_MS;
-    private boolean fallbackToJava = true;
+    private boolean fallbackToJava = false;
     private int maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS;
     /** Hybrid triage mode: auto (dynamic triage based on page content). */
     public static final String MODE_AUTO = "auto";

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DoclingFastServerClientTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DoclingFastServerClientTest.java
@@ -182,6 +182,32 @@ class DoclingFastServerClientTest {
     }
 
     @Test
+    void testCheckAvailabilitySucceeds() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+        // Should not throw
+        client.checkAvailability();
+    }
+
+    @Test
+    void testCheckAvailabilityFailsWhenServerUnavailable() throws IOException {
+        // Shut down the server to simulate unavailability
+        server.shutdown();
+
+        IOException exception = assertThrows(IOException.class, () -> client.checkAvailability());
+        assertTrue(exception.getMessage().contains("Hybrid server is not available"));
+    }
+
+    @Test
+    void testCheckAvailabilityFailsOnUnhealthyServer() {
+        server.enqueue(new MockResponse().setResponseCode(503));
+
+        IOException exception = assertThrows(IOException.class, () -> client.checkAvailability());
+        assertTrue(exception.getMessage().contains("returned HTTP 503"));
+        assertTrue(exception.getMessage().contains("starting up or unhealthy"));
+    }
+
+    @Test
     void testPartialSuccessAllPagesFailed() throws IOException {
         String responseJson = "{"
             + "\"status\": \"partial_success\","

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
@@ -71,7 +71,7 @@ public class HybridDocumentProcessorTest {
 
         Assertions.assertEquals(HybridConfig.DEFAULT_TIMEOUT_MS, config.getTimeoutMs());
         Assertions.assertEquals(HybridConfig.DEFAULT_MAX_CONCURRENT_REQUESTS, config.getMaxConcurrentRequests());
-        Assertions.assertTrue(config.isFallbackToJava());
+        Assertions.assertFalse(config.isFallbackToJava(), "fallback should be disabled by default to fail-fast when hybrid server is unavailable");
         Assertions.assertNull(config.getUrl());
     }
 
@@ -199,17 +199,17 @@ public class HybridDocumentProcessorTest {
     }
 
     @Test
-    public void testHybridConfigFallback() {
+    public void testHybridConfigFallbackToggle() {
         HybridConfig config = new HybridConfig();
 
-        // Default is true
-        Assertions.assertTrue(config.isFallbackToJava());
-
-        config.setFallbackToJava(false);
+        // Default is false (fail-fast when hybrid server is unavailable)
         Assertions.assertFalse(config.isFallbackToJava());
 
         config.setFallbackToJava(true);
         Assertions.assertTrue(config.isFallbackToJava());
+
+        config.setFallbackToJava(false);
+        Assertions.assertFalse(config.isFallbackToJava());
     }
 
     // Helper method matching HybridDocumentProcessor logic

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -30,5 +30,5 @@ export function registerCliOptions(program: Command): void {
   program.option('--hybrid-mode <value>', 'Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)');
   program.option('--hybrid-url <value>', 'Hybrid backend server URL (overrides default)');
   program.option('--hybrid-timeout <value>', 'Hybrid backend request timeout in milliseconds. Default: 30000');
-  program.option('--hybrid-fallback', 'Fallback to Java processing on hybrid backend error. Default: true');
+  program.option('--hybrid-fallback', 'Opt in to Java fallback on hybrid backend error (default: disabled)');
 }

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -51,7 +51,7 @@ export interface ConvertOptions {
   hybridUrl?: string;
   /** Hybrid backend request timeout in milliseconds. Default: 30000 */
   hybridTimeout?: string;
-  /** Fallback to Java processing on hybrid backend error. Default: true */
+  /** Opt in to Java fallback on hybrid backend error (default: disabled) */
   hybridFallback?: boolean;
 }
 

--- a/options.json
+++ b/options.json
@@ -189,8 +189,8 @@
       "shortName": null,
       "type": "boolean",
       "required": false,
-      "default": true,
-      "description": "Fallback to Java processing on hybrid backend error. Default: true"
+      "default": false,
+      "description": "Opt in to Java fallback on hybrid backend error (default: disabled)"
     }
   ]
 }

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -222,8 +222,8 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "short_name": None,
         "type": "boolean",
         "required": False,
-        "default": True,
-        "description": "Fallback to Java processing on hybrid backend error. Default: true",
+        "default": False,
+        "description": "Opt in to Java fallback on hybrid backend error (default: disabled)",
     },
 ]
 

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -34,7 +34,7 @@ def convert(
     hybrid_mode: Optional[str] = None,
     hybrid_url: Optional[str] = None,
     hybrid_timeout: Optional[str] = None,
-    hybrid_fallback: bool = True,
+    hybrid_fallback: bool = False,
 ) -> None:
     """
     Convert PDF(s) into the requested output format(s).
@@ -64,7 +64,7 @@ def convert(
         hybrid_mode: Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)
         hybrid_url: Hybrid backend server URL (overrides default)
         hybrid_timeout: Hybrid backend request timeout in milliseconds. Default: 30000
-        hybrid_fallback: Fallback to Java processing on hybrid backend error. Default: true
+        hybrid_fallback: Opt in to Java fallback on hybrid backend error (default: disabled)
     """
     args: List[str] = []
 


### PR DESCRIPTION
## Summary
- Change `hybrid_fallback` default from `true` to `false` across all layers (Java, Python, Node.js, CLI)
- When `--hybrid` is requested but the server is unavailable, execution now **fails with an error** instead of silently falling back to Java-only processing
- Users who want graceful degradation can explicitly opt in with `--hybrid-fallback`

Fixes #277

## Problem
When `--hybrid docling-fast` was specified without an available backend server, the system silently fell back to Java-only processing and returned success. This made it impossible for users and automated pipelines to detect that hybrid processing was not actually performed.

## Changes
- `HybridConfig.java` — `fallbackToJava` default: `true` → `false`
- `CLIOptions.java` — option description updated
- `options.json` — source of truth default updated
- Auto-generated bindings (Python, Node.js, docs) regenerated via `npm run sync`
- Tests added for `checkAvailability()` error paths (server unavailable, unhealthy server)
- Existing tests updated to verify new default behavior

## How to test
```bash
# Without --hybrid-fallback (default): should fail if server is down
opendataloader-pdf --hybrid docling-fast test.pdf
# Expected: error "Hybrid server is not available at http://localhost:5002"

# With explicit --hybrid-fallback: graceful degradation (previous behavior)
opendataloader-pdf --hybrid docling-fast --hybrid-fallback test.pdf
# Expected: processes with Java fallback, logs warning
```

## Breaking changes
Users relying on silent fallback behavior will now get errors when the hybrid server is unavailable. Add `--hybrid-fallback` to restore previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)