### PR TITLE
docs: add PDF/UA keyword to README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ key-differentiators: [benchmark #1 PDF parser, deterministic output, bounding bo
 
 # OpenDataLoader PDF
 
-**PDF Parser for AI-ready data. Automate PDF accessibility. Open-source.**
+**PDF Parser for AI-ready data. Automate PDF/UA accessibility. Open-source.**
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/opendataloader-project/opendataloader-pdf/blob/main/LICENSE)
 [![PyPI version](https://img.shields.io/pypi/v/opendataloader-pdf.svg)](https://pypi.org/project/opendataloader-pdf/)


### PR DESCRIPTION
## Summary
- Adds "PDF/UA" keyword to the README tagline for better SEO and discoverability
- Change: "Automate PDF accessibility" → "Automate PDF/UA accessibility"
- Targets accessibility professionals searching for PDF/UA (ISO 14289) tooling

## Test plan
- [ ] Verify tagline renders correctly on GitHub
- [ ] Check that the tagline is not too long for GitHub's repository description

🤖 Generated with [Claude Code](https://claude.com/claude-code)