### PR TITLE
docs: add annotated PDF hero image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ opendataloader_pdf.convert(
 )
 ```
 
+![OpenDataLoader PDF layout analysis — headings, tables, images detected with bounding boxes](https://raw.githubusercontent.com/opendataloader-project/opendataloader-pdf/main/samples/image/example_annotated_pdf.png)
+
+*Annotated PDF output — each element (heading, paragraph, table, image) detected with bounding boxes and semantic type.*
+
 ## What Problems Does This Solve?
 
 | Problem | Solution | Status |


### PR DESCRIPTION
## Summary
- Adds annotated PDF image between Quick Start and "What Problems Does This Solve?" section
- Shows layout analysis output: bounding boxes over headings, paragraphs, tables, and images
- Uses GitHub raw URL (`raw.githubusercontent.com`) so it renders on PyPI, npm, and Maven Central
- Includes italic caption describing the annotation

## Test plan
- [ ] Verify image renders on GitHub README
- [ ] Verify image renders on PyPI project page
- [ ] Check image sizing is reasonable (not too large/small)

🤖 Generated with [Claude Code](https://claude.com/claude-code)