### PR TITLE
chore: update flatted to 3.4.1 (security fix)

### DIFF
--- a/node/opendataloader-pdf/pnpm-lock.yaml
+++ b/node/opendataloader-pdf/pnpm-lock.yaml
@@ -844,8 +844,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.4:
-    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1920,10 +1920,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.4
+      flatted: 3.4.1
       keyv: 4.5.4
 
-  flatted@3.3.4: {}
+  flatted@3.4.1: {}
 
   fsevents@2.3.3:
     optional: true


### PR DESCRIPTION
## Summary
Resolves Dependabot alert #16.

- `flatted` < 3.4.0 is vulnerable to unbounded recursion DoS in `parse()` revive phase
- Updated transitive dependency `flatted` from 3.3.4 to 3.4.1 via `flat-cache@4.0.1`

## Changes
- `node/opendataloader-pdf/pnpm-lock.yaml` — lockfile updated

## Test plan
- [ ] Verify `pnpm install` succeeds
- [ ] Verify Dependabot alert #16 auto-closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)