### PR TITLE
docs: fix hybrid_timeout type and hybrid_fallback default

### DIFF
--- a/content/docs/hybrid-mode.mdx
+++ b/content/docs/hybrid-mode.mdx
@@ -105,8 +105,8 @@ The triage processor uses a **conservative strategy**: it routes uncertain pages
 |:-------|:-----|:--------|:------------|
 | `hybrid` | string | `"off"` | Backend name: `off`, `docling-fast` |
 | `hybrid_url` | string | auto | Backend server URL |
-| `hybrid_timeout` | int | 30000 | Request timeout in milliseconds |
-| `hybrid_fallback` | bool | true | Fallback to Java on backend error |
+| `hybrid_timeout` | str | `"30000"` | Request timeout in milliseconds |
+| `hybrid_fallback` | bool | false | Fallback to Java on backend error |
 
 ### Python Options
 
@@ -117,8 +117,8 @@ opendataloader_pdf.convert(
     output_dir="output/",
     hybrid="docling-fast",
     hybrid_url="http://localhost:5002",  # Custom backend URL
-    hybrid_timeout=60000,                 # 60 second timeout
-    hybrid_fallback=True                  # Fallback to Java on error
+    hybrid_timeout="60000",               # 60 second timeout
+    hybrid_fallback=True                  # Opt in to Java fallback on error
 )
 ```
 


### PR DESCRIPTION
## Summary
- `hybrid_timeout` type documented as `int` but Python wrapper signature is `Optional[str]` → fixed to `str`
- `hybrid_fallback` default documented as `true` but changed to `false` in b317050 → fixed
- Python example used `hybrid_timeout=60000` (int literal) → fixed to `hybrid_timeout="60000"`

## Test plan
- [ ] Verify `content/docs/hybrid-mode.mdx` renders correctly on docs site
- [ ] Cross-check with `python-convert-options.mdx` (already shows `str` type — consistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)