### PR TITLE
Fix abnormal bounding boxes for short text chunks

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
@@ -38,6 +38,9 @@ import java.util.logging.Logger;
 public class ContentFilterProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(ContentFilterProcessor.class.getCanonicalName());
+    private static final int MAX_SHORT_TEXT_LENGTH = 3;
+    private static final double SHORT_TEXT_WIDTH_FACTOR = 0.7;
+    private static final double ABNORMAL_WIDTH_THRESHOLD_MULTIPLIER = 3.0;
 
     /**
      * Filters and cleans page contents based on configuration.
@@ -64,6 +67,7 @@ public class ContentFilterProcessor {
             filterOutOfPageContents(pageNumber, pageContents);
             pageContents = DocumentProcessor.removeNullObjectsFromList(pageContents);
         }
+        fixAbnormalShortTextBoundingBoxes(pageContents);
         TextProcessor.mergeCloseTextChunks(pageContents);
         pageContents = DocumentProcessor.removeNullObjectsFromList(pageContents);
         TextProcessor.trimTextChunksWhiteSpaces(pageContents);
@@ -107,6 +111,42 @@ public class ContentFilterProcessor {
                 ((TextChunk) object).compressSpaces();
             }
         }
+    }
+
+    static void fixAbnormalShortTextBoundingBoxes(List<IObject> contents) {
+        for (IObject object : contents) {
+            if (object instanceof TextChunk) {
+                fixAbnormalShortTextBoundingBox((TextChunk) object);
+            }
+        }
+    }
+
+    private static void fixAbnormalShortTextBoundingBox(TextChunk textChunk) {
+        if (!textChunk.isHorizontalText()) {
+            return;
+        }
+        BoundingBox boundingBox = textChunk.getBoundingBox();
+        String value = textChunk.getValue();
+        if (boundingBox == null || value == null || boundingBox.getHeight() <= 0) {
+            return;
+        }
+        int visibleCharacters = (int) value.codePoints()
+            .filter(ch -> !Character.isWhitespace(ch))
+            .count();
+        if (visibleCharacters == 0 || visibleCharacters > MAX_SHORT_TEXT_LENGTH) {
+            return;
+        }
+        double expectedMaxWidth = visibleCharacters * boundingBox.getHeight() * SHORT_TEXT_WIDTH_FACTOR *
+            ABNORMAL_WIDTH_THRESHOLD_MULTIPLIER;
+        if (boundingBox.getWidth() <= expectedMaxWidth) {
+            return;
+        }
+        if (textChunk.isRightLeftHorizontalText()) {
+            boundingBox.setLeftX(boundingBox.getRightX() - expectedMaxWidth);
+        } else {
+            boundingBox.setRightX(boundingBox.getLeftX() + expectedMaxWidth);
+        }
+        textChunk.adjustSymbolEndsToBoundingBox(null);
     }
 
     private static boolean isBackground(IObject content, BoundingBox pageBoundingBox) {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ContentFilterProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ContentFilterProcessorTest.java
@@ -51,15 +51,16 @@ public class ContentFilterProcessorTest {
             new BoundingBox(0, leftX, 100.0, abnormalRightX, 100.0 + height),
             "4", height, 100.0);
 
-        double actualWidth = textChunk.getBoundingBox().getWidth();
         double expectedMaxWidth = 1 * height * 0.7 * 3; // char_count * height * 0.7 * threshold(3x)
+        List<IObject> contents = new ArrayList<>();
+        contents.add(textChunk);
 
-        // This assertion documents the bug: the width is abnormally large
-        // When fixAbnormalTextChunkBoundingBoxes() is implemented, this should be corrected
-        Assertions.assertTrue(actualWidth > expectedMaxWidth,
-            "This test documents that the bounding box width (" + actualWidth +
-            ") is abnormally large compared to expected max (" + expectedMaxWidth +
-            ") for a single character. A fix should correct this.");
+        ContentFilterProcessor.fixAbnormalShortTextBoundingBoxes(contents);
+
+        Assertions.assertEquals(expectedMaxWidth, textChunk.getBoundingBox().getWidth(), 0.01,
+            "Abnormally wide short text should be clamped to the expected maximum width");
+        Assertions.assertEquals(leftX, textChunk.getBoundingBox().getLeftX(), 0.01,
+            "Width correction should preserve the original left edge for left-to-right text");
     }
 
     /**
@@ -78,13 +79,16 @@ public class ContentFilterProcessorTest {
             new BoundingBox(0, leftX, 100.0, normalRightX, 100.0 + height),
             "AB", height, 100.0);
 
-        double actualWidth = textChunk.getBoundingBox().getWidth();
+        List<IObject> contents = new ArrayList<>();
+        contents.add(textChunk);
         double expectedMaxWidth = 2 * height * 0.7 * 3; // char_count * height * 0.7 * threshold(3x)
 
-        // Normal width should be within expected range
-        Assertions.assertTrue(actualWidth <= expectedMaxWidth,
-            "Normal text chunk width (" + actualWidth + ") should not exceed threshold (" +
-            expectedMaxWidth + ")");
+        ContentFilterProcessor.fixAbnormalShortTextBoundingBoxes(contents);
+
+        Assertions.assertEquals(15.0, textChunk.getBoundingBox().getWidth(), 0.01,
+            "Normal text chunk width should remain unchanged");
+        Assertions.assertTrue(textChunk.getBoundingBox().getWidth() <= expectedMaxWidth,
+            "Normal text chunk width should still be within the abnormal-width threshold");
     }
 
     /**
@@ -102,6 +106,11 @@ public class ContentFilterProcessorTest {
         TextChunk textChunk = new TextChunk(
             new BoundingBox(0, leftX, 100.0, rightX, 100.0 + height),
             "Hello", height, 100.0);
+
+        List<IObject> contents = new ArrayList<>();
+        contents.add(textChunk);
+
+        ContentFilterProcessor.fixAbnormalShortTextBoundingBoxes(contents);
 
         // For text with more than 3 characters, the fix should not apply
         // regardless of the width-to-height ratio


### PR DESCRIPTION
## Summary
- clamp abnormally wide bounding boxes for short horizontal text chunks before merge processing
- preserve normal-width and longer text chunks unchanged
- convert the issue #150 regression tests into positive assertions for the new behavior

## Testing
- mvn -q -pl opendataloader-pdf-core test-compile org.apache.maven.plugins:maven-surefire-plugin:3.5.4:test '-Dtest=ContentFilterProcessorTest,TextLineProcessorTest,TextProcessorTest'