### PR TITLE
fix: make npm Java scripts work without bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "description": "OpenDataLoader PDF - Monorepo workspace",
   "scripts": {
-    "build-java": "bash scripts/build-java.sh",
-    "export-options": "npm run build-java && java -jar java/opendataloader-pdf-cli/target/opendataloader-pdf-cli-0.0.0.jar --export-options > options.json",
+    "build-java": "node scripts/build-java.mjs",
+    "export-options": "npm run build-java && node scripts/export-options.mjs",
     "generate-options": "node scripts/generate-options.mjs",
     "sync-options": "npm run export-options && npm run generate-options",
     "generate-schema": "node scripts/generate-schema.mjs",

--- a/scripts/build-java.mjs
+++ b/scripts/build-java.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..');
+const PACKAGE_DIR = join(ROOT_DIR, 'java');
+const result = process.platform === 'win32'
+  ? spawnSync('cmd.exe', ['/d', '/s', '/c', 'mvn -B clean package -P release'], {
+      cwd: PACKAGE_DIR,
+      stdio: 'inherit',
+    })
+  : spawnSync('mvn', ['-B', 'clean', 'package', '-P', 'release'], {
+      cwd: PACKAGE_DIR,
+      stdio: 'inherit',
+    });
+
+if (result.error) {
+  if (result.error.code === 'ENOENT') {
+    console.error('Error: Maven not found in PATH');
+  } else {
+    console.error(result.error.message);
+  }
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/export-options.mjs
+++ b/scripts/export-options.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..');
+const CLI_TARGET_DIR = join(ROOT_DIR, 'java', 'opendataloader-pdf-cli', 'target');
+const OPTIONS_PATH = join(ROOT_DIR, 'options.json');
+const javaCommand = process.platform === 'win32' ? 'java.exe' : 'java';
+
+export function findCliJar(targetDir) {
+  const candidates = readdirSync(targetDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) =>
+      name.startsWith('opendataloader-pdf-cli-') &&
+      name.endsWith('.jar') &&
+      !name.includes('-sources') &&
+      !name.includes('-javadoc') &&
+      !name.startsWith('original-'));
+
+  if (candidates.length === 0) {
+    throw new Error(`No CLI jar found in ${targetDir}. Run "npm run build-java" first.`);
+  }
+
+  if (candidates.length > 1) {
+    throw new Error(`Multiple CLI jars found in ${targetDir}: ${candidates.join(', ')}`);
+  }
+
+  return join(targetDir, candidates[0]);
+}
+
+export function exportOptions() {
+  let cliJarPath;
+  try {
+    cliJarPath = findCliJar(CLI_TARGET_DIR);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+
+  try {
+    const optionsJson = execFileSync(javaCommand, ['-jar', cliJarPath, '--export-options'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf8',
+    });
+    writeFileSync(OPTIONS_PATH, optionsJson);
+    console.log(`Exported options to ${OPTIONS_PATH}`);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(`Error: ${javaCommand} not found in PATH`);
+    } else if (typeof error.stderr === 'string' && error.stderr.trim()) {
+      console.error(error.stderr.trim());
+    } else {
+      console.error(error.message);
+    }
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  exportOptions();
+}


### PR DESCRIPTION
## Summary
- replace the npm Java build wrapper with a Node-based launcher so `npm run build-java` does not depend on bash
- resolve the CLI jar dynamically when exporting options instead of hardcoding `opendataloader-pdf-cli-0.0.0.jar`
- keep the existing shell scripts for CI and Unix workflows while making the workspace npm scripts safer on Windows

## Verification
- verified `npm run build-java` with a temporary `mvn.cmd` stub and confirmed it forwards `-B clean package -P release`
- verified `scripts/export-options.mjs` selects the versioned CLI jar while ignoring `original-*` and `*-sources.jar`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored build system and export workflow to use Node.js scripts instead of shell-based and direct Java command invocations. Build and export functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->