### PR TITLE
fix: accept docling as a hybrid backend alias

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClientFactory.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClientFactory.java
@@ -27,12 +27,13 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>Supported backends:
  * <ul>
+ *   <li>{@code docling} - Docling FastAPI server</li>
  *   <li>{@code docling-fast} - Optimized docling SDK server</li>
+ *   <li>{@code hancom} - Hancom document parsing service</li>
  * </ul>
  *
  * <p>Future backends (not yet implemented):
  * <ul>
- *   <li>{@code hancom} - Hancom document parsing service</li>
  *   <li>{@code azure} - Azure Document Intelligence</li>
  *   <li>{@code google} - Google Document AI</li>
  * </ul>
@@ -41,6 +42,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see HybridConfig
  */
 public class HybridClientFactory {
+
+    /** Backend type constant for Docling FastAPI server. */
+    public static final String BACKEND_DOCLING = "docling";
 
     /** Backend type constant for Docling Fast Server. */
     public static final String BACKEND_DOCLING_FAST = "docling-fast";
@@ -87,7 +91,7 @@ public class HybridClientFactory {
      * Creates a new hybrid client instance.
      */
     private static HybridClient createClient(String hybrid, HybridConfig config) {
-        if (BACKEND_DOCLING_FAST.equals(hybrid)) {
+        if (BACKEND_DOCLING.equals(hybrid) || BACKEND_DOCLING_FAST.equals(hybrid)) {
             return new DoclingFastServerClient(config);
         } else if (BACKEND_HANCOM.equals(hybrid)) {
             return new HancomClient(config);
@@ -157,7 +161,9 @@ public class HybridClientFactory {
         }
 
         String lowerHybrid = hybrid.toLowerCase();
-        return BACKEND_DOCLING_FAST.equals(lowerHybrid) || BACKEND_HANCOM.equals(lowerHybrid);
+        return BACKEND_DOCLING.equals(lowerHybrid) ||
+            BACKEND_DOCLING_FAST.equals(lowerHybrid) ||
+            BACKEND_HANCOM.equals(lowerHybrid);
     }
 
     /**
@@ -166,7 +172,7 @@ public class HybridClientFactory {
      * @return A string listing all supported backends.
      */
     public static String getSupportedBackends() {
-        return String.join(", ", BACKEND_DOCLING_FAST, BACKEND_HANCOM);
+        return String.join(", ", BACKEND_DOCLING, BACKEND_DOCLING_FAST, BACKEND_HANCOM);
     }
 
     /**
@@ -175,6 +181,7 @@ public class HybridClientFactory {
      * @return A string listing all known backends.
      */
     public static String getAllKnownBackends() {
-        return String.join(", ", BACKEND_DOCLING_FAST, BACKEND_HANCOM, BACKEND_AZURE, BACKEND_GOOGLE);
+        return String.join(", ", BACKEND_DOCLING, BACKEND_DOCLING_FAST,
+            BACKEND_HANCOM, BACKEND_AZURE, BACKEND_GOOGLE);
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HybridClientFactoryTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HybridClientFactoryTest.java
@@ -27,6 +27,30 @@ import static org.junit.jupiter.api.Assertions.*;
 class HybridClientFactoryTest {
 
     @Test
+    void testCreateDoclingClient() {
+        HybridConfig config = new HybridConfig();
+        HybridClient client = HybridClientFactory.create("docling", config);
+
+        assertNotNull(client);
+        assertInstanceOf(DoclingFastServerClient.class, client);
+
+        ((DoclingFastServerClient) client).shutdown();
+    }
+
+    @Test
+    void testCreateDoclingClientCaseInsensitive() {
+        HybridConfig config = new HybridConfig();
+
+        HybridClient client1 = HybridClientFactory.create("DOCLING", config);
+        assertInstanceOf(DoclingFastServerClient.class, client1);
+        ((DoclingFastServerClient) client1).shutdown();
+
+        HybridClient client2 = HybridClientFactory.create("Docling", config);
+        assertInstanceOf(DoclingFastServerClient.class, client2);
+        ((DoclingFastServerClient) client2).shutdown();
+    }
+
+    @Test
     void testCreateDoclingFastClient() {
         HybridConfig config = new HybridConfig();
         HybridClient client = HybridClientFactory.create("docling-fast", config);
@@ -138,6 +162,13 @@ class HybridClientFactoryTest {
     }
 
     @Test
+    void testIsSupportedDocling() {
+        assertTrue(HybridClientFactory.isSupported("docling"));
+        assertTrue(HybridClientFactory.isSupported("DOCLING"));
+        assertTrue(HybridClientFactory.isSupported("Docling"));
+    }
+
+    @Test
     void testIsSupportedHancom() {
         assertTrue(HybridClientFactory.isSupported("hancom"));
         assertTrue(HybridClientFactory.isSupported("HANCOM"));
@@ -146,7 +177,6 @@ class HybridClientFactoryTest {
 
     @Test
     void testIsSupportedUnsupportedBackends() {
-        assertFalse(HybridClientFactory.isSupported("docling"));
         assertFalse(HybridClientFactory.isSupported("azure"));
         assertFalse(HybridClientFactory.isSupported("google"));
         assertFalse(HybridClientFactory.isSupported("unknown"));
@@ -162,15 +192,16 @@ class HybridClientFactoryTest {
     void testGetSupportedBackends() {
         String supported = HybridClientFactory.getSupportedBackends();
 
+        assertTrue(supported.contains("docling"));
         assertTrue(supported.contains("docling-fast"));
         assertTrue(supported.contains("hancom"));
-        assertFalse(supported.contains("docling,"));
     }
 
     @Test
     void testGetAllKnownBackends() {
         String allKnown = HybridClientFactory.getAllKnownBackends();
 
+        assertTrue(allKnown.contains("docling"));
         assertTrue(allKnown.contains("docling-fast"));
         assertTrue(allKnown.contains("hancom"));
         assertTrue(allKnown.contains("azure"));
@@ -179,6 +210,7 @@ class HybridClientFactoryTest {
 
     @Test
     void testBackendConstants() {
+        assertEquals("docling", HybridClientFactory.BACKEND_DOCLING);
         assertEquals("docling-fast", HybridClientFactory.BACKEND_DOCLING_FAST);
         assertEquals("hancom", HybridClientFactory.BACKEND_HANCOM);
         assertEquals("azure", HybridClientFactory.BACKEND_AZURE);


### PR DESCRIPTION
## Summary
- accept `docling` as a supported alias in `HybridClientFactory`
- route both `docling` and `docling-fast` through the same `DoclingFastServerClient`
- add regression coverage for client creation and support checks so the alias stays wired through the hybrid runtime path

## Why
`Config` and the CLI already accept `--hybrid docling`, and `HybridDocumentProcessor` treats `docling` as a valid backend when selecting the schema transformer. Before this patch, the runtime still failed in `HybridClientFactory` because only `docling-fast` was recognized there.

## Verification
- reviewed the end-to-end call path from `CLIOptions` / `Config` into `HybridDocumentProcessor` and `HybridClientFactory`
- added unit coverage in `HybridClientFactoryTest`
- did not run Maven tests in this shell because Maven is not available on the current PATH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Docling as a newly supported backend option for PDF processing through the hybrid client factory.

* **Tests**
  * Expanded test suite with comprehensive unit tests validating Docling backend support, case-insensitive backend matching, and integration with existing supported backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->