### PR TITLE
fix: skip hybrid backend checks when no pages remain

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -106,6 +106,11 @@ public class HybridDocumentProcessor {
         int totalPages = StaticContainers.getDocument().getNumberOfPages();
         LOGGER.log(Level.INFO, "Starting hybrid processing for {0} pages", totalPages);
 
+        if (pagesToProcess != null && pagesToProcess.isEmpty()) {
+            LOGGER.log(Level.INFO, "Skipping hybrid processing because no valid pages were selected");
+            return createEmptyContents(totalPages);
+        }
+
         // Phase 0: Check backend availability before any processing.
         // Runs before triage intentionally — if the user explicitly requested hybrid mode,
         // they expect the server to be available regardless of how pages would be routed.
@@ -198,6 +203,14 @@ public class HybridDocumentProcessor {
         // Phase 6: Post-processing (cross-page operations)
         postProcess(contents, config, pagesToProcess, totalPages);
 
+        return contents;
+    }
+
+    private static List<List<IObject>> createEmptyContents(int totalPages) {
+        List<List<IObject>> contents = new ArrayList<>(totalPages);
+        for (int i = 0; i < totalPages; i++) {
+            contents.add(new ArrayList<>());
+        }
         return contents;
     }
 

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PagesOptionIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PagesOptionIntegrationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.hybrid.HybridClientFactory;
 import org.opendataloader.pdf.processors.DocumentProcessor;
 
 import java.io.File;
@@ -30,6 +31,7 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -54,6 +56,7 @@ class PagesOptionIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        HybridClientFactory.shutdown();
         samplePdf = new File(SAMPLE_PDF);
         assumeTrue(samplePdf.exists(), "Sample PDF not found at " + samplePdf.getAbsolutePath());
     }
@@ -219,6 +222,29 @@ class PagesOptionIntegrationTest {
         Set<Integer> pagesInOutput = getPageNumbersFromKids(root);
 
         assertTrue(pagesInOutput.isEmpty(), "No pages should have content when all requested pages don't exist");
+    }
+
+    @Test
+    void testPagesOptionAllPagesExceedDocumentInHybridMode() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setImageOutput(Config.IMAGE_OUTPUT_OFF);
+        config.setHybrid(Config.HYBRID_DOCLING_FAST);
+        config.getHybridConfig().setUrl("http://127.0.0.1:1");
+        config.setPages("100,200"); // All pages don't exist
+
+        assertDoesNotThrow(() -> DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config),
+            "Hybrid mode should not require backend availability when no valid pages remain");
+
+        Path jsonOutput = tempDir.resolve(OUTPUT_BASENAME + JSON_EXT);
+        assertTrue(Files.exists(jsonOutput), JSON_OUTPUT_EXISTS_MSG);
+
+        JsonNode root = parseJson(jsonOutput);
+        Set<Integer> pagesInOutput = getPageNumbersFromKids(root);
+
+        assertTrue(pagesInOutput.isEmpty(),
+            "No pages should have content when all requested pages don't exist, even in hybrid mode");
     }
 
     // ===== Tagged PDF Tests (using struct-tree) =====


### PR DESCRIPTION
## Summary
- return an empty per-page result immediately when page filtering leaves no valid pages
- avoid hitting hybrid health checks and backend initialization for empty work
- add a regression test covering `--pages` with hybrid mode and no valid pages

## Problem
`DocumentProcessor` already collapses invalid page selections into an empty set, but `HybridDocumentProcessor` still checked backend availability before looking at that set. That meant `--hybrid` could fail with a server error even when there were literally zero pages left to process.

This made hybrid mode behave differently from Java-only mode for the same empty-page request.

## Testing
- `org.opendataloader.pdf.PagesOptionIntegrationTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling when no valid pages are selected or requested pages exceed document range; processing now returns empty results immediately instead of continuing with backend checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->