### PR TITLE
fix: split sparse docling page selections into backend ranges

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -356,6 +357,10 @@ public class HybridDocumentProcessor {
         // Determine required output formats based on config
         Set<OutputFormat> outputFormats = determineOutputFormats(config);
 
+        if (usesDoclingBackend(config)) {
+            return processDoclingBackendPath(client, pdfBytes, pageNumbers, config, backendFailedPages, outputFormats);
+        }
+
         // Make API request for all pages (avoids per-chunk overhead)
         HybridRequest request = HybridRequest.allPages(pdfBytes, outputFormats);
         HybridResponse response = client.convert(request);
@@ -401,6 +406,110 @@ public class HybridDocumentProcessor {
         // HybridClientFactory.shutdown() should be called at CLI exit.
 
         return results;
+    }
+
+    private static Map<Integer, List<IObject>> processDoclingBackendPath(
+            HybridClient client,
+            byte[] pdfBytes,
+            Set<Integer> pageNumbers,
+            Config config,
+            Set<Integer> backendFailedPages,
+            Set<OutputFormat> outputFormats) throws IOException {
+
+        Map<Integer, List<IObject>> results = new HashMap<>();
+        for (Set<Integer> contiguousPages : splitIntoContiguousRanges(pageNumbers)) {
+            Set<Integer> oneIndexedPages = toOneIndexedPages(contiguousPages);
+            HybridRequest request = HybridRequest.forPages(pdfBytes, oneIndexedPages, outputFormats);
+            HybridResponse response = client.convert(request);
+            results.putAll(extractBackendResults(response, contiguousPages, config, backendFailedPages));
+        }
+        return results;
+    }
+
+    private static Map<Integer, List<IObject>> extractBackendResults(
+            HybridResponse response,
+            Set<Integer> pageNumbers,
+            Config config,
+            Set<Integer> backendFailedPages) {
+
+        collectFailedPages(response, pageNumbers, backendFailedPages);
+
+        Map<Integer, Double> pageHeights = getPageHeights(pageNumbers);
+        HybridSchemaTransformer transformer = createTransformer(config);
+        List<List<IObject>> transformedContents = transformer.transform(response, pageHeights);
+
+        Map<Integer, List<IObject>> results = new HashMap<>();
+        for (int pageNumber : pageNumbers) {
+            if (backendFailedPages.contains(pageNumber)) {
+                continue;
+            }
+            if (pageNumber < transformedContents.size()) {
+                List<IObject> pageContents = transformedContents.get(pageNumber);
+                TextProcessor.replaceUndefinedCharacters(pageContents, config.getReplaceInvalidChars());
+                DocumentProcessor.setIDs(pageContents);
+                results.put(pageNumber, pageContents);
+            } else {
+                results.put(pageNumber, new ArrayList<>());
+            }
+        }
+
+        return results;
+    }
+
+    private static void collectFailedPages(
+            HybridResponse response,
+            Set<Integer> requestedPages,
+            Set<Integer> backendFailedPages) {
+
+        if (!response.hasFailedPages()) {
+            return;
+        }
+
+        for (int failedPage1Indexed : response.getFailedPages()) {
+            int failedPage0Indexed = failedPage1Indexed - 1;
+            if (requestedPages.contains(failedPage0Indexed)) {
+                backendFailedPages.add(failedPage0Indexed);
+            }
+        }
+    }
+
+    private static boolean usesDoclingBackend(Config config) {
+        return Config.HYBRID_DOCLING.equals(config.getHybrid())
+            || Config.HYBRID_DOCLING_FAST.equals(config.getHybrid());
+    }
+
+    private static Set<Integer> toOneIndexedPages(Set<Integer> zeroIndexedPages) {
+        Set<Integer> oneIndexedPages = new LinkedHashSet<>();
+        for (int pageNumber : zeroIndexedPages) {
+            oneIndexedPages.add(pageNumber + 1);
+        }
+        return oneIndexedPages;
+    }
+
+    private static List<Set<Integer>> splitIntoContiguousRanges(Set<Integer> pageNumbers) {
+        List<Integer> sortedPages = pageNumbers.stream().sorted().collect(Collectors.toList());
+        List<Set<Integer>> ranges = new ArrayList<>();
+        if (sortedPages.isEmpty()) {
+            return ranges;
+        }
+
+        Set<Integer> currentRange = new LinkedHashSet<>();
+        currentRange.add(sortedPages.get(0));
+
+        for (int i = 1; i < sortedPages.size(); i++) {
+            int previous = sortedPages.get(i - 1);
+            int current = sortedPages.get(i);
+            if (current == previous + 1) {
+                currentRange.add(current);
+            } else {
+                ranges.add(currentRange);
+                currentRange = new LinkedHashSet<>();
+                currentRange.add(current);
+            }
+        }
+
+        ranges.add(currentRange);
+        return ranges;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridPageRangeIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridPageRangeIntegrationTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.hybrid.HybridClientFactory;
+import org.opendataloader.pdf.hybrid.HybridConfig;
+import org.opendataloader.pdf.processors.DocumentProcessor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration tests for hybrid page filtering with docling backends.
+ */
+class HybridPageRangeIntegrationTest {
+
+    private static final String SAMPLE_PDF = "../../samples/pdf/1901.03003.pdf";
+    private static final String OUTPUT_BASENAME = "1901.03003";
+
+    @TempDir
+    Path tempDir;
+
+    private MockWebServer server;
+    private File samplePdf;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        HybridClientFactory.shutdown();
+        server = new MockWebServer();
+        server.start();
+        samplePdf = new File(SAMPLE_PDF);
+        assumeTrue(samplePdf.exists(), "Sample PDF not found at " + samplePdf.getAbsolutePath());
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        HybridClientFactory.shutdown();
+        server.shutdown();
+    }
+
+    @Test
+    void testHybridFullModeSplitsSparsePageSelectionIntoContiguousBackendRanges() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+        server.enqueue(new MockResponse()
+            .setBody(buildTextResponse(1, "page one from backend"))
+            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse()
+            .setBody(buildTextResponse(3, "page three from backend"))
+            .addHeader("Content-Type", "application/json"));
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setImageOutput(Config.IMAGE_OUTPUT_OFF);
+        config.setHybrid(Config.HYBRID_DOCLING_FAST);
+        config.getHybridConfig().setMode(HybridConfig.MODE_FULL);
+        config.getHybridConfig().setUrl(getBaseUrl());
+        config.setPages("1,3");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path jsonOutput = tempDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output should exist");
+
+        JsonNode root = new ObjectMapper().readTree(Files.newInputStream(jsonOutput));
+        assertEquals(Set.of(1, 3), getPageNumbersFromKids(root),
+            "Only selected pages should be populated from backend responses");
+
+        assertEquals(3, server.getRequestCount(), "Expected one health check and one convert call per contiguous range");
+
+        RecordedRequest healthRequest = server.takeRequest();
+        RecordedRequest firstConvertRequest = server.takeRequest();
+        RecordedRequest secondConvertRequest = server.takeRequest();
+
+        assertNotNull(healthRequest);
+        assertNotNull(firstConvertRequest);
+        assertNotNull(secondConvertRequest);
+        assertEquals("/health", healthRequest.getPath());
+        assertTrue(firstConvertRequest.getBody().readUtf8().contains("1-1"));
+        assertTrue(secondConvertRequest.getBody().readUtf8().contains("3-3"));
+    }
+
+    private String getBaseUrl() {
+        String baseUrl = server.url("").toString();
+        if (baseUrl.endsWith("/")) {
+            return baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        return baseUrl;
+    }
+
+    private String buildTextResponse(int pageNo, String text) {
+        return "{"
+            + "\"status\":\"success\","
+            + "\"document\":{"
+            + "\"json_content\":{"
+            + "\"pages\":{\"" + pageNo + "\":{}},"
+            + "\"texts\":[{"
+            + "\"label\":\"text\","
+            + "\"text\":\"" + text + "\","
+            + "\"prov\":[{"
+            + "\"page_no\":" + pageNo + ","
+            + "\"bbox\":{"
+            + "\"l\":72.0,"
+            + "\"t\":720.0,"
+            + "\"r\":300.0,"
+            + "\"b\":740.0,"
+            + "\"coord_origin\":\"BOTTOMLEFT\""
+            + "}"
+            + "}]"
+            + "}]"
+            + "}"
+            + "}"
+            + "}";
+    }
+
+    private Set<Integer> getPageNumbersFromKids(JsonNode root) {
+        Set<Integer> pageNumbers = new HashSet<>();
+        JsonNode kids = root.get("kids");
+        if (kids != null && kids.isArray()) {
+            for (JsonNode kid : kids) {
+                JsonNode pageNumber = kid.get("page number");
+                if (pageNumber != null && pageNumber.isInt()) {
+                    pageNumbers.add(pageNumber.asInt());
+                }
+            }
+        }
+        return pageNumbers;
+    }
+}


### PR DESCRIPTION
## Summary
- split sparse page selections into contiguous backend requests for docling backends
- keep non-docling backends on the existing full-document request path
- add an integration test that proves `--pages=1,3` produces two backend convert calls instead of widening to `1-3`

## Problem
`HybridDocumentProcessor` was passing sparse backend page sets straight into `HybridRequest`. `DoclingFastServerClient` serializes requested pages as a single `min-max` range, so a sparse selection like pages 1 and 3 was widened to `1-3` and page 2 was still sent to docling.

That means page filtering was not actually honored on the docling backend path, and users could still pay the backend cost for skipped pages.

## Validation
- compiled `HybridDocumentProcessor` and `HybridPageRangeIntegrationTest`
- ran `org.opendataloader.pdf.HybridPageRangeIntegrationTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced PDF document processing with optimized page range handling
  * Improved support for selective page processing, automatically organizing non-contiguous page selections into efficient backend conversion batches
  * Better performance when processing specific document pages in hybrid conversion workflows

* **Tests**
  * Added comprehensive integration testing for page-range filtering validation in document conversion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->