### PR TITLE
fix: key hybrid client cache by backend config

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClientFactory.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClientFactory.java
@@ -54,7 +54,7 @@ public class HybridClientFactory {
     /** Backend type constant for Google (not yet implemented). */
     public static final String BACKEND_GOOGLE = "google";
 
-    /** Cache of created clients, keyed by backend type. */
+    /** Cache of created clients, keyed by backend type and client-affecting config. */
     private static final Map<String, HybridClient> CLIENT_CACHE = new ConcurrentHashMap<>();
 
     private HybridClientFactory() {
@@ -79,8 +79,21 @@ public class HybridClientFactory {
         }
 
         String lowerHybrid = hybrid.toLowerCase();
+        String cacheKey = buildCacheKey(lowerHybrid, config);
 
-        return CLIENT_CACHE.computeIfAbsent(lowerHybrid, key -> createClient(key, config));
+        return CLIENT_CACHE.computeIfAbsent(cacheKey, key -> createClient(lowerHybrid, config));
+    }
+
+    private static String buildCacheKey(String hybrid, HybridConfig config) {
+        String effectiveUrl = config != null ? config.getEffectiveUrl(hybrid) : null;
+        return hybrid + "|" + normalizeUrl(effectiveUrl) + "|" + (config != null ? config.getTimeoutMs() : 0);
+    }
+
+    private static String normalizeUrl(String url) {
+        if (url != null && url.endsWith("/")) {
+            return url.substring(0, url.length() - 1);
+        }
+        return url;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HybridClientFactoryTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HybridClientFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package org.opendataloader.pdf.hybrid;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,6 +27,11 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class HybridClientFactoryTest {
 
+    @AfterEach
+    void tearDown() {
+        HybridClientFactory.shutdown();
+    }
+
     @Test
     void testCreateDoclingFastClient() {
         HybridConfig config = new HybridConfig();
@@ -33,9 +39,6 @@ class HybridClientFactoryTest {
 
         assertNotNull(client);
         assertInstanceOf(DoclingFastServerClient.class, client);
-
-        // Cleanup
-        ((DoclingFastServerClient) client).shutdown();
     }
 
     @Test
@@ -44,11 +47,10 @@ class HybridClientFactoryTest {
 
         HybridClient client1 = HybridClientFactory.create("DOCLING-FAST", config);
         assertInstanceOf(DoclingFastServerClient.class, client1);
-        ((DoclingFastServerClient) client1).shutdown();
 
         HybridClient client2 = HybridClientFactory.create("Docling-Fast", config);
         assertInstanceOf(DoclingFastServerClient.class, client2);
-        ((DoclingFastServerClient) client2).shutdown();
+        assertSame(client1, client2);
     }
 
     @Test
@@ -58,9 +60,6 @@ class HybridClientFactoryTest {
 
         assertNotNull(client);
         assertInstanceOf(HancomClient.class, client);
-
-        // Cleanup
-        ((HancomClient) client).shutdown();
     }
 
     @Test
@@ -69,11 +68,57 @@ class HybridClientFactoryTest {
 
         HybridClient client1 = HybridClientFactory.create("HANCOM", config);
         assertInstanceOf(HancomClient.class, client1);
-        ((HancomClient) client1).shutdown();
 
         HybridClient client2 = HybridClientFactory.create("Hancom", config);
         assertInstanceOf(HancomClient.class, client2);
-        ((HancomClient) client2).shutdown();
+        assertSame(client1, client2);
+    }
+
+    @Test
+    void testGetOrCreateReusesClientForSameDoclingConfig() {
+        HybridConfig config1 = new HybridConfig();
+        config1.setUrl("http://localhost:5002");
+
+        HybridConfig config2 = new HybridConfig();
+        config2.setUrl("http://localhost:5002/");
+
+        HybridClient client1 = HybridClientFactory.getOrCreate("docling-fast", config1);
+        HybridClient client2 = HybridClientFactory.getOrCreate("docling-fast", config2);
+
+        assertSame(client1, client2, "Equivalent docling URLs should reuse the same cached client");
+        assertEquals("http://localhost:5002", ((DoclingFastServerClient) client1).getBaseUrl());
+    }
+
+    @Test
+    void testGetOrCreateCreatesDifferentDoclingClientsForDifferentUrls() {
+        HybridConfig config1 = new HybridConfig();
+        config1.setUrl("http://localhost:5002");
+
+        HybridConfig config2 = new HybridConfig();
+        config2.setUrl("http://localhost:5003");
+
+        HybridClient client1 = HybridClientFactory.getOrCreate("docling-fast", config1);
+        HybridClient client2 = HybridClientFactory.getOrCreate("docling-fast", config2);
+
+        assertNotSame(client1, client2, "Different docling URLs must not share the same cached client");
+        assertEquals("http://localhost:5002", ((DoclingFastServerClient) client1).getBaseUrl());
+        assertEquals("http://localhost:5003", ((DoclingFastServerClient) client2).getBaseUrl());
+    }
+
+    @Test
+    void testGetOrCreateCreatesDifferentDoclingClientsForDifferentTimeouts() {
+        HybridConfig config1 = new HybridConfig();
+        config1.setUrl("http://localhost:5002");
+        config1.setTimeoutMs(5_000);
+
+        HybridConfig config2 = new HybridConfig();
+        config2.setUrl("http://localhost:5002");
+        config2.setTimeoutMs(10_000);
+
+        HybridClient client1 = HybridClientFactory.getOrCreate("docling-fast", config1);
+        HybridClient client2 = HybridClientFactory.getOrCreate("docling-fast", config2);
+
+        assertNotSame(client1, client2, "Different timeouts must not reuse the same cached client");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- key `HybridClientFactory` cache entries by backend URL and timeout instead of backend name alone
- preserve client reuse for equivalent config values
- add tests that lock both behaviors: same config reuses, different config does not

## Problem
`HybridClientFactory.getOrCreate()` was caching clients only by backend type.

That means a long-lived JVM could process one document with `docling-fast` at one URL, then process another document with a different `--hybrid-url` or timeout and still reuse the old client. In practice, the second request could be sent to the wrong backend server with the wrong network settings.

## Validation
- compiled `HybridClientFactory` and `HybridClientFactoryTest`
- ran `org.opendataloader.pdf.hybrid.HybridClientFactoryTest`