### PR TITLE
fix: keep hybrid health checks responsive during conversion

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -47,6 +47,7 @@ import logging
 import os
 import re
 import tempfile
+import threading
 import time
 import traceback
 from contextlib import asynccontextmanager
@@ -65,6 +66,7 @@ MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB max file size
 
 # Global converter instance (initialized on startup with CLI options)
 converter = None
+_CONVERSION_LOCK = threading.Lock()
 
 # Regex matching lone surrogates (U+D800..U+DFFF) and null characters
 _INVALID_UNICODE_RE = re.compile(r"[\ud800-\udfff\x00]")
@@ -161,6 +163,23 @@ def sanitize_unicode(data: Any) -> Any:
     if isinstance(data, list):
         return [sanitize_unicode(item) for item in data]
     return data
+
+
+def convert_document(
+    input_path: str, requested_pages: tuple[int, int] | None
+):
+    """Run a single Docling conversion while keeping converter access serialized.
+
+    The FastAPI endpoint offloads this work to a worker thread so health checks stay
+    responsive during long-running conversions. Access to the singleton converter
+    remains serialized because Docling's DocumentConverter is reused across requests.
+    """
+    global converter
+
+    with _CONVERSION_LOCK:
+        if requested_pages:
+            return converter.convert(input_path, page_range=requested_pages)
+        return converter.convert(input_path)
 
 
 def _check_dependencies():
@@ -270,6 +289,7 @@ def create_app(
     """
     from fastapi import FastAPI, File, Form, UploadFile
     from fastapi.responses import JSONResponse
+    from starlette.concurrency import run_in_threadpool
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
@@ -367,10 +387,7 @@ def create_app(
 
         try:
             start = time.perf_counter()
-            if page_range_tuple:
-                result = converter.convert(tmp_path, page_range=page_range_tuple)
-            else:
-                result = converter.convert(tmp_path)
+            result = await run_in_threadpool(convert_document, tmp_path, page_range_tuple)
             processing_time = time.perf_counter() - start
 
             # Export to JSON (DoclingDocument format)

--- a/python/opendataloader-pdf/tests/test_hybrid_server_concurrency.py
+++ b/python/opendataloader-pdf/tests/test_hybrid_server_concurrency.py
@@ -1,0 +1,87 @@
+"""Concurrency tests for the hybrid FastAPI server."""
+
+from __future__ import annotations
+
+import sys
+import threading
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from opendataloader_pdf import hybrid_server
+
+
+def _successful_result():
+    return SimpleNamespace(
+        status=SimpleNamespace(value="success"),
+        errors=[],
+        input=SimpleNamespace(page_count=1),
+        document=SimpleNamespace(export_to_dict=lambda: {"pages": {"1": {}}}),
+    )
+
+
+class BlockingConverter:
+    """Test double that blocks until the test releases the conversion."""
+
+    def __init__(self, started: threading.Event, release: threading.Event):
+        self.started = started
+        self.release = release
+
+    def convert(self, input_path, page_range=None):  # noqa: ANN001
+        self.started.set()
+        if not self.release.wait(timeout=5):
+            raise TimeoutError("Timed out waiting for test to release conversion")
+        return _successful_result()
+
+
+def test_health_check_stays_responsive_during_conversion(monkeypatch):
+    """Long-running conversion requests should not block /health."""
+    started = threading.Event()
+    release = threading.Event()
+    fake_status = SimpleNamespace(PARTIAL_SUCCESS=object())
+
+    monkeypatch.setitem(
+        sys.modules,
+        "docling.datamodel.base_models",
+        SimpleNamespace(ConversionStatus=fake_status),
+    )
+
+    monkeypatch.setattr(
+        hybrid_server,
+        "create_converter",
+        lambda **_: BlockingConverter(started, release),
+    )
+
+    app = hybrid_server.create_app()
+    files = {"files": ("sample.pdf", b"%PDF-1.4", "application/pdf")}
+    results = {}
+
+    with TestClient(app) as client:
+        convert_thread = threading.Thread(
+            target=lambda: results.setdefault(
+                "convert", client.post("/v1/convert/file", files=files)
+            )
+        )
+        health_done = threading.Event()
+
+        def request_health():
+            results["health"] = client.get("/health")
+            health_done.set()
+
+        health_thread = threading.Thread(target=request_health)
+
+        convert_thread.start()
+        assert started.wait(timeout=1), "Conversion request never reached the converter"
+
+        try:
+            health_thread.start()
+            assert health_done.wait(
+                timeout=1
+            ), "/health should remain responsive while conversion is running"
+            assert results["health"].status_code == 200
+        finally:
+            release.set()
+            convert_thread.join(timeout=5)
+            health_thread.join(timeout=5)
+
+    assert results["convert"].status_code == 200


### PR DESCRIPTION
## Summary
- move docling conversion work off the FastAPI event loop with `run_in_threadpool`
- serialize access to the singleton `DocumentConverter` with a lock
- add a concurrency regression test proving `/health` stays responsive during an in-flight conversion

## Why
`/v1/convert/file` currently calls `converter.convert(...)` directly inside an `async` route. A long conversion can block the event loop and make `/health` time out even though the server process is still running. This matches the behavior reported in #301.

## Testing
- `PYTHONPATH=src C:\Temp\odp-py310\Scripts\python.exe -m pytest tests/test_hybrid_server.py tests/test_hybrid_server_partial_success.py tests/test_hybrid_server_unicode.py tests/test_hybrid_server_concurrency.py -q`