### PR TITLE
fix(python): keep hybrid health checks responsive during conversion

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -47,6 +47,7 @@ import logging
 import os
 import re
 import tempfile
+import threading
 import time
 import traceback
 from contextlib import asynccontextmanager
@@ -65,6 +66,7 @@ MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB max file size
 
 # Global converter instance (initialized on startup with CLI options)
 converter = None
+_CONVERSION_LOCK = threading.Lock()
 
 # Regex matching lone surrogates (U+D800..U+DFFF) and null characters
 _INVALID_UNICODE_RE = re.compile(r"[\ud800-\udfff\x00]")
@@ -270,6 +272,7 @@ def create_app(
     """
     from fastapi import FastAPI, File, Form, UploadFile
     from fastapi.responses import JSONResponse
+    from starlette.concurrency import run_in_threadpool
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
@@ -307,6 +310,20 @@ def create_app(
         version="1.0.0",
         lifespan=lifespan,
     )
+
+    def convert_document(input_path: str, requested_pages: tuple[int, int] | None):
+        """Run a single Docling conversion while keeping converter access serialized.
+
+        The FastAPI endpoint offloads this work to a worker thread so health checks stay
+        responsive during long-running conversions. Access to the singleton converter
+        remains serialized because Docling's DocumentConverter is reused across requests.
+        """
+        global converter
+
+        with _CONVERSION_LOCK:
+            if requested_pages:
+                return converter.convert(input_path, page_range=requested_pages)
+            return converter.convert(input_path)
 
     @app.get("/health")
     def health():
@@ -367,10 +384,7 @@ def create_app(
 
         try:
             start = time.perf_counter()
-            if page_range_tuple:
-                result = converter.convert(tmp_path, page_range=page_range_tuple)
-            else:
-                result = converter.convert(tmp_path)
+            result = await run_in_threadpool(convert_document, tmp_path, page_range_tuple)
             processing_time = time.perf_counter() - start
 
             # Export to JSON (DoclingDocument format)


### PR DESCRIPTION
## Context

Fixes issue where the hybrid server's `/health` endpoint becomes unresponsive during long-running PDF conversions, causing the Java CLI to timeout with "Hybrid server is not available" error even though the server process is running.

## Problem

The `/v1/convert/file` endpoint was calling `converter.convert()` directly on the FastAPI event loop. When a conversion takes 40+ seconds (e.g., for complex PDFs with OCR), it blocks the event loop completely, making the `/health` endpoint unable to respond.

Timeline from issue #301:
1. Server starts and health check works
2. First PDF converts successfully (5.45s)
3. Second PDF converts successfully (81.48s) 
4. Java CLI tries to process a third PDF - health check times out after 3 seconds

## Technical Decision

The fix uses `run_in_threadpool` to offload the blocking `converter.convert()` call to a worker thread, freeing the event loop to handle other requests including health checks.

A lock serializes access to the singleton `DocumentConverter` because Docling's converter is not thread-safe for concurrent conversions.

## Changes

- Added `threading` import and `_CONVERSION_LOCK` to serialize converter access
- Created `convert_document()` function that acquires the lock before calling `converter.convert()`
- Changed `convert_file` endpoint to use `await run_in_threadpool(convert_document, tmp_path, page_range_tuple)`

## Verification

- Syntax validation passed
- Change is minimal and focused on the specific issue
- Related PR #314 has concurrency test validating this approach

## Related

- Issue: #301
- Related PR: #314 (same fix, different branch)