### PR TITLE
Add markdown table output modes

### DIFF
--- a/content/docs/_generated/node-convert-options.mdx
+++ b/content/docs/_generated/node-convert-options.mdx
@@ -18,6 +18,7 @@ description: Options for the Node.js convert function
 | `replaceInvalidChars`   | `string`             | `" "`        | Replacement character for invalid/unrecognized characters. Default: space                                                          |
 | `useStructTree`         | `boolean`            | `false`      | Use PDF structure tree (tagged PDF) for reading order and semantic structure                                                       |
 | `tableMethod`           | `string`             | `"default"`  | Table detection method. Values: default (border-based), cluster (border + cluster). Default: default                               |
+| `markdownTableOutput`   | `string`             | `"full"`     | Markdown table output mode. Values: full, caption\_only, off. Default: full                                                        |
 | `readingOrder`          | `string`             | `"xycut"`    | Reading order algorithm. Values: off, xycut. Default: xycut                                                                        |
 | `markdownPageSeparator` | `string`             | -            | Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none                                      |
 | `textPageSeparator`     | `string`             | -            | Separator between pages in text output. Use %page-number% for page numbers. Default: none                                          |

--- a/content/docs/_generated/python-convert-options.mdx
+++ b/content/docs/_generated/python-convert-options.mdx
@@ -19,6 +19,7 @@ description: Options for the Python convert function
 | `replace_invalid_chars`   | `str`                | `" "`        | Replacement character for invalid/unrecognized characters. Default: space                                                          |
 | `use_struct_tree`         | `bool`               | `False`      | Use PDF structure tree (tagged PDF) for reading order and semantic structure                                                       |
 | `table_method`            | `str`                | `"default"`  | Table detection method. Values: default (border-based), cluster (border + cluster). Default: default                               |
+| `markdown_table_output`   | `str`                | `"full"`     | Markdown table output mode. Values: full, caption\_only, off. Default: full                                                        |
 | `reading_order`           | `str`                | `"xycut"`    | Reading order algorithm. Values: off, xycut. Default: xycut                                                                        |
 | `markdown_page_separator` | `str`                | -            | Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none                                      |
 | `text_page_separator`     | `str`                | -            | Separator between pages in text output. Use %page-number% for page numbers. Default: none                                          |

--- a/content/docs/cli-options-reference.mdx
+++ b/content/docs/cli-options-reference.mdx
@@ -22,6 +22,7 @@ This page documents all available CLI options for opendataloader-pdf.
 | `--replace-invalid-chars`   | -     | `string`  | `" "`        | Replacement character for invalid/unrecognized characters. Default: space                                                          |
 | `--use-struct-tree`         | -     | `boolean` | `false`      | Use PDF structure tree (tagged PDF) for reading order and semantic structure                                                       |
 | `--table-method`            | -     | `string`  | `"default"`  | Table detection method. Values: default (border-based), cluster (border + cluster). Default: default                               |
+| `--markdown-table-output`   | -     | `string`  | `"full"`     | Markdown table output mode. Values: full, caption\_only, off. Default: full                                                        |
 | `--reading-order`           | -     | `string`  | `"xycut"`    | Reading order algorithm. Values: off, xycut. Default: xycut                                                                        |
 | `--markdown-page-separator` | -     | `string`  | -            | Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none                                      |
 | `--text-page-separator`     | -     | `string`  | -            | Separator between pages in text output. Use %page-number% for page numbers. Default: none                                          |

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
@@ -65,6 +65,10 @@ public class CLIOptions {
     private static final String TABLE_METHOD_LONG_OPTION = "table-method";
     private static final String TABLE_METHOD_DESC = "Table detection method. Values: default (border-based), cluster (border + cluster). Default: default";
 
+    // ===== Markdown Table Output =====
+    private static final String MARKDOWN_TABLE_OUTPUT_LONG_OPTION = "markdown-table-output";
+    private static final String MARKDOWN_TABLE_OUTPUT_DESC = "Markdown table output mode. Values: full, caption_only, off. Default: full";
+
     // ===== Reading Order =====
     private static final String READING_ORDER_LONG_OPTION = "reading-order";
     private static final String READING_ORDER_DESC = "Reading order algorithm. Values: off, xycut. Default: xycut";
@@ -145,6 +149,8 @@ public class CLIOptions {
                     true),
             new OptionDefinition(USE_STRUCT_TREE_LONG_OPTION, null, "boolean", false, USE_STRUCT_TREE_DESC, true),
             new OptionDefinition(TABLE_METHOD_LONG_OPTION, null, "string", "default", TABLE_METHOD_DESC, true),
+            new OptionDefinition(MARKDOWN_TABLE_OUTPUT_LONG_OPTION, null, "string", "full", MARKDOWN_TABLE_OUTPUT_DESC,
+                    true),
             new OptionDefinition(READING_ORDER_LONG_OPTION, null, "string", "xycut", READING_ORDER_DESC, true),
             new OptionDefinition(MARKDOWN_PAGE_SEPARATOR_LONG_OPTION, null, "string", null,
                     MARKDOWN_PAGE_SEPARATOR_DESC, true),
@@ -239,6 +245,7 @@ public class CLIOptions {
         applyContentSafetyOption(config, commandLine);
         applyFormatOption(config, commandLine);
         applyTableMethodOption(config, commandLine);
+        applyMarkdownTableOutputOption(config, commandLine);
         applyImageOptions(config, commandLine);
         applyPagesOption(config, commandLine);
         applyHybridOptions(config, commandLine);
@@ -300,6 +307,24 @@ public class CLIOptions {
                                 method, Config.getTableMethodOptions(", ")));
             }
             config.setTableMethod(method);
+        }
+    }
+
+    private static void applyMarkdownTableOutputOption(Config config, CommandLine commandLine) {
+        if (commandLine.hasOption(MARKDOWN_TABLE_OUTPUT_LONG_OPTION)) {
+            String modeValue = commandLine.getOptionValue(MARKDOWN_TABLE_OUTPUT_LONG_OPTION);
+            if (modeValue == null || modeValue.trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                        String.format("Option --markdown-table-output requires a value. Supported values: %s",
+                                Config.getMarkdownTableOutputOptions(", ")));
+            }
+            String mode = modeValue.trim().toLowerCase(Locale.ROOT);
+            if (!Config.isValidMarkdownTableOutput(mode)) {
+                throw new IllegalArgumentException(
+                        String.format("Unsupported markdown table output '%s'. Supported values: %s",
+                                mode, Config.getMarkdownTableOutputOptions(", ")));
+            }
+            config.setMarkdownTableOutput(mode);
         }
     }
 

--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIOptionsTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIOptionsTest.java
@@ -55,6 +55,11 @@ class CLIOptionsTest {
     }
 
     @Test
+    void testDefineOptions_containsMarkdownTableOutputOption() {
+        assertTrue(options.hasOption("markdown-table-output"));
+    }
+
+    @Test
     void testCreateConfig_withImageOutputEmbedded() throws ParseException {
         String[] args = {"--image-output", "embedded", testPdf.getAbsolutePath()};
         CommandLine cmd = parser.parse(options, args);
@@ -224,6 +229,46 @@ class CLIOptionsTest {
         Config config = CLIOptions.createConfigFromCommandLine(cmd);
 
         assertEquals(Config.READING_ORDER_OFF, config.getReadingOrder());
+    }
+
+    @Test
+    void testCreateConfig_defaultMarkdownTableOutput() throws ParseException {
+        String[] args = {testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertEquals(Config.MARKDOWN_TABLE_OUTPUT_FULL, config.getMarkdownTableOutput());
+    }
+
+    @Test
+    void testCreateConfig_withMarkdownTableOutputCaptionOnly() throws ParseException {
+        String[] args = {"--markdown-table-output", "caption_only", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertEquals(Config.MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY, config.getMarkdownTableOutput());
+        assertTrue(config.isMarkdownTableCaptionOnly());
+    }
+
+    @Test
+    void testCreateConfig_withMarkdownTableOutputOff() throws ParseException {
+        String[] args = {"--markdown-table-output", "off", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertEquals(Config.MARKDOWN_TABLE_OUTPUT_OFF, config.getMarkdownTableOutput());
+        assertTrue(config.isMarkdownTableOutputOff());
+    }
+
+    @Test
+    void testCreateConfig_withInvalidMarkdownTableOutput() throws ParseException {
+        String[] args = {"--markdown-table-output", "caption-only", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        assertThrows(IllegalArgumentException.class, () -> CLIOptions.createConfigFromCommandLine(cmd));
     }
 
     // ===== Pages Option Tests =====

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -61,6 +61,7 @@ public class Config {
     private String replaceInvalidChars = " ";
     private String outputFolder;
     private String tableMethod = TABLE_METHOD_DEFAULT;
+    private String markdownTableOutput = MARKDOWN_TABLE_OUTPUT_FULL;
     private String readingOrder = READING_ORDER_XYCUT;
     private String markdownPageSeparator = "";
     private String textPageSeparator = "";
@@ -81,6 +82,14 @@ public class Config {
     public static final String TABLE_METHOD_CLUSTER = "cluster";
     private static Set<String> tableMethodOptions = new HashSet<>();
 
+    /** Markdown table output: include full table body. */
+    public static final String MARKDOWN_TABLE_OUTPUT_FULL = "full";
+    /** Markdown table output: omit table body but keep captions. */
+    public static final String MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY = "caption_only";
+    /** Markdown table output: omit tables from markdown output. */
+    public static final String MARKDOWN_TABLE_OUTPUT_OFF = "off";
+    private static Set<String> markdownTableOutputOptions = new HashSet<>();
+
     /** Image format: PNG. */
     public static final String IMAGE_FORMAT_PNG = "png";
     /** Image format: JPEG. */
@@ -100,6 +109,9 @@ public class Config {
         readingOrderOptions.add(READING_ORDER_XYCUT);
         tableMethodOptions.add(TABLE_METHOD_DEFAULT);
         tableMethodOptions.add(TABLE_METHOD_CLUSTER);
+        markdownTableOutputOptions.add(MARKDOWN_TABLE_OUTPUT_FULL);
+        markdownTableOutputOptions.add(MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY);
+        markdownTableOutputOptions.add(MARKDOWN_TABLE_OUTPUT_OFF);
         imageFormatOptions.add(IMAGE_FORMAT_PNG);
         imageFormatOptions.add(IMAGE_FORMAT_JPEG);
         imageOutputOptions.add(IMAGE_OUTPUT_OFF);
@@ -402,6 +414,70 @@ public class Config {
      */
     public static boolean isValidTableMethod(String method) {
         return method != null && tableMethodOptions.contains(method.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Gets the markdown table output mode.
+     *
+     * @return The markdown table output mode (full, caption_only, or off).
+     */
+    public String getMarkdownTableOutput() {
+        return markdownTableOutput;
+    }
+
+    /**
+     * Sets how tables should be emitted in markdown output.
+     *
+     * @param markdownTableOutput The markdown table output mode.
+     * @throws IllegalArgumentException if the mode is not supported.
+     */
+    public void setMarkdownTableOutput(String markdownTableOutput) {
+        if (markdownTableOutput != null && !isValidMarkdownTableOutput(markdownTableOutput)) {
+            throw new IllegalArgumentException(
+                String.format("Unsupported markdown table output '%s'. Supported values: %s",
+                    markdownTableOutput, getMarkdownTableOutputOptions(", ")));
+        }
+        this.markdownTableOutput = markdownTableOutput != null
+            ? markdownTableOutput.toLowerCase(Locale.ROOT)
+            : MARKDOWN_TABLE_OUTPUT_FULL;
+    }
+
+    /**
+     * Gets the supported markdown table output modes.
+     *
+     * @param delimiter the delimiter to use between options
+     * @return the string with modes separated by the delimiter
+     */
+    public static String getMarkdownTableOutputOptions(CharSequence delimiter) {
+        return String.join(delimiter, markdownTableOutputOptions);
+    }
+
+    /**
+     * Checks if the given markdown table output mode is valid.
+     *
+     * @param mode The mode to check.
+     * @return true if the mode is valid, false otherwise.
+     */
+    public static boolean isValidMarkdownTableOutput(String mode) {
+        return mode != null && markdownTableOutputOptions.contains(mode.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Checks if markdown table bodies should be omitted while preserving captions.
+     *
+     * @return true when markdown should keep captions only.
+     */
+    public boolean isMarkdownTableCaptionOnly() {
+        return MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY.equals(markdownTableOutput);
+    }
+
+    /**
+     * Checks if markdown tables should be omitted completely.
+     *
+     * @return true when markdown should omit tables.
+     */
+    public boolean isMarkdownTableOutputOff() {
+        return MARKDOWN_TABLE_OUTPUT_OFF.equals(markdownTableOutput);
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -65,6 +65,10 @@ public class MarkdownGenerator implements Closeable {
         "^(pass@1|cons@\\d+|rating)(?:\\s+(pass@1|cons@\\d+|rating))+\\s*$",
         Pattern.CASE_INSENSITIVE
     );
+    private static final Pattern FOOTNOTE_PLACEHOLDER_PATTERN = Pattern.compile(
+        "^(?:\\d+https?://\\S+)(?:\\s+\\d+https?://\\S+)*$",
+        Pattern.CASE_INSENSITIVE
+    );
     private static final Pattern BENCHMARK_PATTERN = Pattern.compile(
         "(AIME 2024|MATH-500|CNMO 2024|GPQA(?: Diamond)?|LiveCodeBench|Codeforces|SWE Verified|Aider-Polyglot|MMLU(?:-Redux|-Pro)?|DROP|IF-Eval|SimpleQA|FRAMES|AlpacaEval2\\.0|ArenaHard|CLUEWSC|C-Eval|C-SimpleQA)",
         Pattern.CASE_INSENSITIVE
@@ -88,10 +92,15 @@ public class MarkdownGenerator implements Closeable {
 
     public void writeToMarkdown(List<List<IObject>> contents) {
         try {
+            List<Set<Integer>> pageSkipIndices = new java.util.ArrayList<>(contents.size());
+            for (List<IObject> pageContents : contents) {
+                pageSkipIndices.add(collectTableArtifactIndices(pageContents));
+            }
+            extendCrossPageTableArtifactSkips(contents, pageSkipIndices);
             for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
                 writePageSeparator(pageNumber);
                 List<IObject> pageContents = contents.get(pageNumber);
-                Set<Integer> skipIndices = collectTableArtifactIndices(pageContents);
+                Set<Integer> skipIndices = pageSkipIndices.get(pageNumber);
                 for (int contentIndex = 0; contentIndex < pageContents.size(); contentIndex++) {
                     if (skipIndices.contains(contentIndex)) {
                         continue;
@@ -360,6 +369,26 @@ public class MarkdownGenerator implements Closeable {
         return Config.MARKDOWN_TABLE_OUTPUT_FULL.equals(markdownTableOutput);
     }
 
+    protected void extendCrossPageTableArtifactSkips(List<List<IObject>> contents, List<Set<Integer>> pageSkipIndices) {
+        if (Config.MARKDOWN_TABLE_OUTPUT_FULL.equals(markdownTableOutput)) {
+            return;
+        }
+        for (int pageNumber = 0; pageNumber < contents.size(); pageNumber++) {
+            List<IObject> pageContents = contents.get(pageNumber);
+            Set<Integer> pageSkips = pageSkipIndices.get(pageNumber);
+
+            int firstMeaningful = findFirstMeaningfulContentIndex(pageContents, pageSkips);
+            if (firstMeaningful >= 0 && isTableCaptionText(normalizeContentText(pageContents.get(firstMeaningful))) && pageNumber > 0) {
+                walkTableArtifactRange(contents.get(pageNumber - 1), pageSkipIndices.get(pageNumber - 1), contents.get(pageNumber - 1).size(), -1);
+            }
+
+            int lastMeaningful = findLastMeaningfulContentIndex(pageContents, pageSkips);
+            if (lastMeaningful >= 0 && isTableCaptionText(normalizeContentText(pageContents.get(lastMeaningful))) && pageNumber + 1 < contents.size()) {
+                walkTableArtifactRange(contents.get(pageNumber + 1), pageSkipIndices.get(pageNumber + 1), -1, 1);
+            }
+        }
+    }
+
     protected Set<Integer> collectTableArtifactIndices(List<IObject> pageContents) {
         Set<Integer> skip = new HashSet<>();
         if (Config.MARKDOWN_TABLE_OUTPUT_FULL.equals(markdownTableOutput)) {
@@ -411,6 +440,11 @@ public class MarkdownGenerator implements Closeable {
                 continue;
             }
             if (looksNarrativeText(text)) {
+                if (direction > 0 && shouldSkipDanglingNarrativeFragment(pageContents, index, text)) {
+                    skip.add(index);
+                    index += direction;
+                    continue;
+                }
                 break;
             }
             break;
@@ -421,11 +455,51 @@ public class MarkdownGenerator implements Closeable {
         return content instanceof SemanticHeading;
     }
 
+    protected int findFirstMeaningfulContentIndex(List<IObject> pageContents, Set<Integer> skip) {
+        for (int index = 0; index < pageContents.size(); index++) {
+            if (skip.contains(index)) {
+                continue;
+            }
+            String text = normalizeContentText(pageContents.get(index));
+            if (!text.isEmpty() || pageContents.get(index) instanceof TableBorder) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    protected int findLastMeaningfulContentIndex(List<IObject> pageContents, Set<Integer> skip) {
+        for (int index = pageContents.size() - 1; index >= 0; index--) {
+            if (skip.contains(index)) {
+                continue;
+            }
+            String text = normalizeContentText(pageContents.get(index));
+            if (!text.isEmpty() || pageContents.get(index) instanceof TableBorder) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
     protected boolean isTableOutputOff() {
         return Config.MARKDOWN_TABLE_OUTPUT_OFF.equals(markdownTableOutput);
     }
 
     protected String normalizeContentText(IObject content) {
+        if (content instanceof PDFList) {
+            StringBuilder builder = new StringBuilder();
+            for (ListItem item : ((PDFList) content).getListItems()) {
+                String value = String.valueOf(item).replaceAll("\\s+", " ").trim();
+                if (value.isEmpty()) {
+                    continue;
+                }
+                if (builder.length() > 0) {
+                    builder.append(' ');
+                }
+                builder.append(value);
+            }
+            return builder.toString();
+        }
         if (!(content instanceof SemanticTextNode)) {
             return "";
         }
@@ -466,6 +540,9 @@ public class MarkdownGenerator implements Closeable {
         if (NUMERIC_ONLY_PATTERN.matcher(text).matches()) {
             return true;
         }
+        if (FOOTNOTE_PLACEHOLDER_PATTERN.matcher(text).matches()) {
+            return true;
+        }
         if (TABLE_HEADER_TEXT_PATTERN.matcher(text).matches()) {
             return true;
         }
@@ -502,6 +579,26 @@ public class MarkdownGenerator implements Closeable {
             }
             if (tokens.length >= 4 && modelishTokenCount >= Math.max(3, (int) Math.floor(tokens.length * 0.6))) {
                 return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean shouldSkipDanglingNarrativeFragment(List<IObject> pageContents, int index, String text) {
+        if (text.isEmpty() || !Character.isLowerCase(text.charAt(0))) {
+            return false;
+        }
+        for (int nextIndex = index + 1; nextIndex < pageContents.size(); nextIndex++) {
+            IObject next = pageContents.get(nextIndex);
+            String nextText = normalizeContentText(next);
+            if (nextText.isEmpty()) {
+                continue;
+            }
+            if (isHeadingContent(next) || isTableCaptionText(nextText)) {
+                return true;
+            }
+            if (looksNarrativeText(nextText) && !looksTableArtifactText(nextText)) {
+                return false;
             }
         }
         return false;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -31,9 +31,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public class MarkdownGenerator implements Closeable {
 
@@ -46,6 +49,30 @@ public class MarkdownGenerator implements Closeable {
     protected boolean embedImages = false;
     protected String imageFormat = Config.IMAGE_FORMAT_PNG;
     protected boolean includeHeaderFooter = false;
+    protected String markdownTableOutput = Config.MARKDOWN_TABLE_OUTPUT_FULL;
+    private static final Pattern TABLE_CAPTION_PATTERN = Pattern.compile("^table\\s+\\d+\\s+\\|", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PIPE_ROW_PATTERN = Pattern.compile("^\\|.*\\|\\s*$");
+    private static final Pattern NUMERIC_ONLY_PATTERN = Pattern.compile("^\\d+$");
+    private static final Pattern TABLE_HEADER_TEXT_PATTERN = Pattern.compile(
+        "^(benchmark \\(metric\\)|model|architecture|# activated params|# total params|english|code|math|chinese)$",
+        Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern TABLE_HEADER_PREFIX_PATTERN = Pattern.compile(
+        "^(architecture\\b|#\\s*activated params|#\\s*total params)",
+        Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern PASS_COLUMN_PATTERN = Pattern.compile(
+        "^(pass@1|cons@\\d+|rating)(?:\\s+(pass@1|cons@\\d+|rating))+\\s*$",
+        Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern BENCHMARK_PATTERN = Pattern.compile(
+        "(AIME 2024|MATH-500|CNMO 2024|GPQA(?: Diamond)?|LiveCodeBench|Codeforces|SWE Verified|Aider-Polyglot|MMLU(?:-Redux|-Pro)?|DROP|IF-Eval|SimpleQA|FRAMES|AlpacaEval2\\.0|ArenaHard|CLUEWSC|C-Eval|C-SimpleQA)",
+        Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern MODEL_NAME_PATTERN = Pattern.compile(
+        "^(?:[A-Za-z]+-\\d[\\w.-]*|\\d{3,4}|[A-Z]\\d(?:[\\w.-]+)?|o1-\\d+|R1|V\\d|QwQ-\\d+[A-Za-z-]*|GPT-\\d\\w*|Claude(?:-\\w+)?|Sonnet-\\d+)$"
+    );
+    private static final Pattern MODELISH_LINE_PATTERN = Pattern.compile("(?:DeepSeek|OpenAI|Claude|QwQ|GPT-4o)");
 
     MarkdownGenerator(File inputPdf, Config config) throws IOException {
         String cutPdfFileName = inputPdf.getName();
@@ -56,13 +83,20 @@ public class MarkdownGenerator implements Closeable {
         this.embedImages = config.isEmbedImages();
         this.imageFormat = config.getImageFormat();
         this.includeHeaderFooter = config.isIncludeHeaderFooter();
+        this.markdownTableOutput = config.getMarkdownTableOutput();
     }
 
     public void writeToMarkdown(List<List<IObject>> contents) {
         try {
             for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
                 writePageSeparator(pageNumber);
-                for (IObject content : contents.get(pageNumber)) {
+                List<IObject> pageContents = contents.get(pageNumber);
+                Set<Integer> skipIndices = collectTableArtifactIndices(pageContents);
+                for (int contentIndex = 0; contentIndex < pageContents.size(); contentIndex++) {
+                    if (skipIndices.contains(contentIndex)) {
+                        continue;
+                    }
+                    IObject content = pageContents.get(contentIndex);
                     if (!isSupportedContent(content)) {
                         continue;
                     }
@@ -248,6 +282,9 @@ public class MarkdownGenerator implements Closeable {
     }
 
     protected void writeTable(TableBorder table) throws IOException {
+        if (!shouldWriteTableBody()) {
+            return;
+        }
         enterTable();
         for (TableBorderRow row : table.getRows()) {
             markdownWriter.write(MarkdownSyntax.TABLE_COLUMN_SEPARATOR);
@@ -317,6 +354,157 @@ public class MarkdownGenerator implements Closeable {
 
     protected boolean isInsideTable() {
         return tableNesting > 0;
+    }
+
+    protected boolean shouldWriteTableBody() {
+        return Config.MARKDOWN_TABLE_OUTPUT_FULL.equals(markdownTableOutput);
+    }
+
+    protected Set<Integer> collectTableArtifactIndices(List<IObject> pageContents) {
+        Set<Integer> skip = new HashSet<>();
+        if (Config.MARKDOWN_TABLE_OUTPUT_FULL.equals(markdownTableOutput)) {
+            return skip;
+        }
+
+        for (int index = 0; index < pageContents.size(); index++) {
+            IObject content = pageContents.get(index);
+            String text = normalizeContentText(content);
+
+            if (isTableOutputOff() && isTableCaptionText(text)) {
+                skip.add(index);
+                walkTableArtifactRange(pageContents, skip, index, -1);
+                walkTableArtifactRange(pageContents, skip, index, 1);
+                continue;
+            }
+
+            if (!isTableCaptionText(text)) {
+                continue;
+            }
+            walkTableArtifactRange(pageContents, skip, index, -1);
+            walkTableArtifactRange(pageContents, skip, index, 1);
+        }
+
+        return skip;
+    }
+
+    protected void walkTableArtifactRange(List<IObject> pageContents, Set<Integer> skip, int startIndex, int direction) {
+        int index = startIndex + direction;
+        while (index >= 0 && index < pageContents.size()) {
+            IObject content = pageContents.get(index);
+            String text = normalizeContentText(content);
+
+            if (isHeadingContent(content) || isTableCaptionText(text)) {
+                break;
+            }
+            if (content instanceof TableBorder) {
+                skip.add(index);
+                index += direction;
+                continue;
+            }
+            if (text.isEmpty()) {
+                index += direction;
+                continue;
+            }
+            if (looksTableArtifactText(text)) {
+                skip.add(index);
+                index += direction;
+                continue;
+            }
+            if (looksNarrativeText(text)) {
+                break;
+            }
+            break;
+        }
+    }
+
+    protected boolean isHeadingContent(IObject content) {
+        return content instanceof SemanticHeading;
+    }
+
+    protected boolean isTableOutputOff() {
+        return Config.MARKDOWN_TABLE_OUTPUT_OFF.equals(markdownTableOutput);
+    }
+
+    protected String normalizeContentText(IObject content) {
+        if (!(content instanceof SemanticTextNode)) {
+            return "";
+        }
+        String value = ((SemanticTextNode) content).getValue();
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("\\s+", " ").trim();
+    }
+
+    protected boolean isTableCaptionText(String text) {
+        return TABLE_CAPTION_PATTERN.matcher(text).find();
+    }
+
+    protected boolean looksNarrativeText(String text) {
+        if (text.isEmpty()) {
+            return false;
+        }
+        if (text.matches(".*[.?!][)\"'\\]]?(?:\\s|$).*")) {
+            return true;
+        }
+        int lowerWordCount = 0;
+        for (String token : text.split("\\s+")) {
+            if (token.matches("[a-z]{3,}")) {
+                lowerWordCount++;
+            }
+        }
+        return lowerWordCount >= 6;
+    }
+
+    protected boolean looksTableArtifactText(String text) {
+        if (text.isEmpty() || isTableCaptionText(text)) {
+            return false;
+        }
+        if (PIPE_ROW_PATTERN.matcher(text).matches()) {
+            return true;
+        }
+        if (NUMERIC_ONLY_PATTERN.matcher(text).matches()) {
+            return true;
+        }
+        if (TABLE_HEADER_TEXT_PATTERN.matcher(text).matches()) {
+            return true;
+        }
+        if (TABLE_HEADER_PREFIX_PATTERN.matcher(text).find()) {
+            return true;
+        }
+        if (PASS_COLUMN_PATTERN.matcher(text).matches()) {
+            return true;
+        }
+        int benchmarkMatches = 0;
+        java.util.regex.Matcher matcher = BENCHMARK_PATTERN.matcher(text);
+        while (matcher.find()) {
+            benchmarkMatches++;
+        }
+        if (benchmarkMatches >= 2) {
+            return true;
+        }
+        if (text.matches("(?:.*\\b\\d+(?:\\.\\d+)?\\b.*){4,}") && !looksNarrativeText(text)) {
+            return true;
+        }
+        if (benchmarkMatches >= 1 && !looksNarrativeText(text)) {
+            return true;
+        }
+        if (!looksNarrativeText(text) && MODELISH_LINE_PATTERN.matcher(text).find() && text.matches(".*\\b\\d.*")) {
+            return true;
+        }
+        if (!looksNarrativeText(text)) {
+            String[] tokens = text.split("\\s+");
+            int modelishTokenCount = 0;
+            for (String token : tokens) {
+                if (MODEL_NAME_PATTERN.matcher(token).matches()) {
+                    modelishTokenCount++;
+                }
+            }
+            if (tokens.length >= 4 && modelishTokenCount >= Math.max(3, (int) Math.floor(tokens.length * 0.6))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     protected String getLineBreak() {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownHTMLGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownHTMLGenerator.java
@@ -25,6 +25,9 @@ public class MarkdownHTMLGenerator extends MarkdownGenerator {
 
     @Override
     protected void writeTable(TableBorder table) throws IOException {
+        if (!shouldWriteTableBody()) {
+            return;
+        }
         enterTable();
         markdownWriter.write(MarkdownSyntax.HTML_TABLE_TAG);
         markdownWriter.write(MarkdownSyntax.LINE_BREAK);

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/ConfigTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/ConfigTest.java
@@ -26,7 +26,62 @@ class ConfigTest {
         assertFalse(config.isImageOutputOff());
         assertEquals(Config.IMAGE_OUTPUT_EXTERNAL, config.getImageOutput());
         assertEquals(Config.IMAGE_FORMAT_PNG, config.getImageFormat());
+        assertEquals(Config.MARKDOWN_TABLE_OUTPUT_FULL, config.getMarkdownTableOutput());
         assertEquals(Config.READING_ORDER_XYCUT, config.getReadingOrder());
+    }
+
+    @Test
+    void testSetMarkdownTableOutput() {
+        Config config = new Config();
+
+        config.setMarkdownTableOutput(Config.MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY);
+        assertEquals(Config.MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY, config.getMarkdownTableOutput());
+        assertTrue(config.isMarkdownTableCaptionOnly());
+        assertFalse(config.isMarkdownTableOutputOff());
+
+        config.setMarkdownTableOutput(Config.MARKDOWN_TABLE_OUTPUT_OFF);
+        assertEquals(Config.MARKDOWN_TABLE_OUTPUT_OFF, config.getMarkdownTableOutput());
+        assertFalse(config.isMarkdownTableCaptionOnly());
+        assertTrue(config.isMarkdownTableOutputOff());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"full", "FULL", "caption_only", "CAPTION_ONLY", "off", "OFF"})
+    void testIsValidMarkdownTableOutput_withValidModes(String mode) {
+        assertTrue(Config.isValidMarkdownTableOutput(mode));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"caption-only", "none", "invalid", ""})
+    void testIsValidMarkdownTableOutput_withInvalidModes(String mode) {
+        assertFalse(Config.isValidMarkdownTableOutput(mode));
+    }
+
+    @Test
+    void testSetMarkdownTableOutputNormalizesToLowercase() {
+        Config config = new Config();
+
+        config.setMarkdownTableOutput("CAPTION_ONLY");
+        assertEquals(Config.MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY, config.getMarkdownTableOutput());
+    }
+
+    @Test
+    void testSetMarkdownTableOutputWithNullDefaultsToFull() {
+        Config config = new Config();
+
+        config.setMarkdownTableOutput(null);
+        assertEquals(Config.MARKDOWN_TABLE_OUTPUT_FULL, config.getMarkdownTableOutput());
+    }
+
+    @Test
+    void testSetMarkdownTableOutputThrowsExceptionForInvalidMode() {
+        Config config = new Config();
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config.setMarkdownTableOutput("caption-only")
+        );
+        assertTrue(exception.getMessage().contains("Unsupported markdown table output"));
     }
 
     @Test

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
@@ -7,9 +7,26 @@
  */
 package org.opendataloader.pdf.markdown;
 
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
+import org.verapdf.wcag.algorithms.entities.content.TextChunk;
+import org.verapdf.wcag.algorithms.entities.content.TextLine;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -22,6 +39,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * - Levels < 1 are normalized to 1
  */
 public class MarkdownGeneratorTest {
+
+    @TempDir
+    Path tempDir;
 
     /**
      * Tests that heading levels 1-6 produce the correct number of # symbols.
@@ -79,6 +99,59 @@ public class MarkdownGeneratorTest {
         assertEquals("# ", generateHeadingPrefix(-1));
     }
 
+    @Test
+    void testFullTableOutputWritesCaptionAndTableBody() throws IOException {
+        String markdown = renderCaptionAndTable(Config.MARKDOWN_TABLE_OUTPUT_FULL);
+
+        assertTrue(markdown.contains("Table 1 | Sample results."));
+        assertTrue(markdown.contains("| Col A | Col B |"));
+        assertTrue(markdown.contains("| --- | --- |"));
+        assertTrue(markdown.contains("| 10 | 20 |"));
+    }
+
+    @Test
+    void testCaptionOnlyTableOutputKeepsCaptionAndOmitsTableBody() throws IOException {
+        String markdown = renderCaptionAndTable(Config.MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY);
+
+        assertTrue(markdown.contains("Table 1 | Sample results."));
+        assertFalse(markdown.contains("| Col A | Col B |"));
+        assertFalse(markdown.contains("| 10 | 20 |"));
+    }
+
+    @Test
+    void testOffTableOutputKeepsCaptionAndOmitsTableBody() throws IOException {
+        String markdown = renderCaptionAndTable(Config.MARKDOWN_TABLE_OUTPUT_OFF);
+
+        assertTrue(markdown.contains("Table 1 | Sample results."));
+        assertFalse(markdown.contains("| Col A | Col B |"));
+        assertFalse(markdown.contains("| 10 | 20 |"));
+    }
+
+    @Test
+    void testCaptionOnlySkipsFlattenedTableArtifactsAroundCaption() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setMarkdownTableOutput(Config.MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY);
+        File inputPdf = tempDir.resolve("artifacts.pdf").toFile();
+        Files.writeString(inputPdf.toPath(), "");
+
+        try (TestMarkdownGenerator generator = new TestMarkdownGenerator(inputPdf, config)) {
+            generator.writePage(List.of(
+                createCaption("Benchmark (Metric)"),
+                createCaption("Model"),
+                createCaption("AIME 2024 MATH-500 GPQA Diamond"),
+                createCaption("Table 4 | Comparison between models."),
+                createCaption("This paragraph should remain after the caption because it is narrative.")
+            ));
+        }
+
+        String markdown = Files.readString(tempDir.resolve("artifacts.md"));
+        assertFalse(markdown.contains("Benchmark (Metric)"));
+        assertFalse(markdown.contains("\n\nModel\n\n"));
+        assertTrue(markdown.contains("Table 4 | Comparison between models."));
+        assertTrue(markdown.contains("This paragraph should remain after the caption because it is narrative."));
+    }
+
     /**
      * Helper method that mirrors the heading prefix generation logic in
      * MarkdownGenerator.writeHeading().
@@ -96,5 +169,90 @@ public class MarkdownGeneratorTest {
         }
         sb.append(MarkdownSyntax.SPACE);
         return sb.toString();
+    }
+
+    private String renderCaptionAndTable(String tableOutputMode) throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setMarkdownTableOutput(tableOutputMode);
+        File inputPdf = tempDir.resolve("sample.pdf").toFile();
+        Files.writeString(inputPdf.toPath(), "");
+
+        try (TestMarkdownGenerator generator = new TestMarkdownGenerator(inputPdf, config)) {
+            generator.writeObject(createCaption("Table 1 | Sample results."));
+            generator.writeSeparator();
+            generator.writeObject(createSimpleTable());
+        }
+
+        Path markdownPath = tempDir.resolve("sample.md");
+        return Files.readString(markdownPath);
+    }
+
+    private SemanticParagraph createCaption(String text) {
+        SemanticParagraph paragraph = new SemanticParagraph();
+        paragraph.add(new TextLine(new TextChunk(
+            new BoundingBox(0, 10.0, 10.0, 20.0, 20.0),
+            text,
+            "Font1",
+            10,
+            700,
+            0,
+            20.0,
+            new double[]{0.0},
+            null,
+            0
+        )));
+        return paragraph;
+    }
+
+    private TableBorder createSimpleTable() {
+        TableBorder table = new TableBorder(2, 2);
+
+        TableBorderRow headerRow = new TableBorderRow(0, 2, 0L);
+        headerRow.getCells()[0] = createCell(0, 0, "Col A");
+        headerRow.getCells()[1] = createCell(0, 1, "Col B");
+        table.getRows()[0] = headerRow;
+
+        TableBorderRow dataRow = new TableBorderRow(1, 2, 0L);
+        dataRow.getCells()[0] = createCell(1, 0, "10");
+        dataRow.getCells()[1] = createCell(1, 1, "20");
+        table.getRows()[1] = dataRow;
+
+        return table;
+    }
+
+    private TableBorderCell createCell(int row, int col, String text) {
+        TableBorderCell cell = new TableBorderCell(row, col, 1, 1, 0L);
+        SemanticParagraph paragraph = createCaption(text);
+        List<IObject> contents = cell.getContents();
+        contents.add(paragraph);
+        return cell;
+    }
+
+    private static class TestMarkdownGenerator extends MarkdownGenerator {
+        TestMarkdownGenerator(File inputPdf, Config config) throws IOException {
+            super(inputPdf, config);
+        }
+
+        void writeObject(IObject object) throws IOException {
+            write(object);
+        }
+
+        void writeSeparator() throws IOException {
+            writeContentsSeparator();
+        }
+
+        void writePage(List<IObject> contents) throws IOException {
+            Set<Integer> skip = collectTableArtifactIndices(contents);
+            for (int index = 0; index < contents.size(); index++) {
+                if (skip.contains(index)) {
+                    continue;
+                }
+                write(contents.get(index));
+                if (index < contents.size() - 1) {
+                    writeContentsSeparator();
+                }
+            }
+        }
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
@@ -10,6 +10,7 @@ package org.opendataloader.pdf.markdown;
 import org.junit.jupiter.api.io.TempDir;
 import org.opendataloader.pdf.api.Config;
 import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.SemanticHeading;
 import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
@@ -17,6 +18,8 @@ import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
+import org.verapdf.wcag.algorithms.entities.lists.ListItem;
+import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -152,6 +155,30 @@ public class MarkdownGeneratorTest {
         assertTrue(markdown.contains("This paragraph should remain after the caption because it is narrative."));
     }
 
+    @Test
+    void testCaptionOnlySkipsFootnotePlaceholderListsAndDanglingLowercaseFragments() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setMarkdownTableOutput(Config.MARKDOWN_TABLE_OUTPUT_CAPTION_ONLY);
+        File inputPdf = tempDir.resolve("dangling.pdf").toFile();
+        Files.writeString(inputPdf.toPath(), "");
+
+        try (TestMarkdownGenerator generator = new TestMarkdownGenerator(inputPdf, config)) {
+            generator.writePage(List.of(
+                createFootnoteList("1https://example.com", "2https://example.com"),
+                createCaption("Table 4 | Comparison between models."),
+                createCaption("performance of the model will improve soon."),
+                createHeading("3.2. Distilled Model Evaluation", 5)
+            ));
+        }
+
+        String markdown = Files.readString(tempDir.resolve("dangling.md"));
+        assertFalse(markdown.contains("1https://example.com"));
+        assertFalse(markdown.contains("performance of the model will improve soon."));
+        assertTrue(markdown.contains("Table 4 | Comparison between models."));
+        assertTrue(markdown.contains("##### 3.2. Distilled Model Evaluation"));
+    }
+
     /**
      * Helper method that mirrors the heading prefix generation logic in
      * MarkdownGenerator.writeHeading().
@@ -227,6 +254,33 @@ public class MarkdownGeneratorTest {
         List<IObject> contents = cell.getContents();
         contents.add(paragraph);
         return cell;
+    }
+
+    private SemanticHeading createHeading(String text, int level) {
+        SemanticHeading heading = new SemanticHeading(createCaption(text));
+        heading.setHeadingLevel(level);
+        return heading;
+    }
+
+    private PDFList createFootnoteList(String... items) {
+        PDFList list = new PDFList();
+        for (String itemText : items) {
+            ListItem item = new ListItem(new BoundingBox(), null);
+            item.add(new TextLine(new TextChunk(
+                new BoundingBox(0, 10.0, 10.0, 20.0, 20.0),
+                itemText,
+                "Font1",
+                10,
+                700,
+                0,
+                20.0,
+                new double[]{0.0},
+                null,
+                0
+            )));
+            list.add(item);
+        }
+        return list;
     }
 
     private static class TestMarkdownGenerator extends MarkdownGenerator {

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -16,6 +16,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--replace-invalid-chars <value>', 'Replacement character for invalid/unrecognized characters. Default: space');
   program.option('--use-struct-tree', 'Use PDF structure tree (tagged PDF) for reading order and semantic structure');
   program.option('--table-method <value>', 'Table detection method. Values: default (border-based), cluster (border + cluster). Default: default');
+  program.option('--markdown-table-output <value>', 'Markdown table output mode. Values: full, caption_only, off. Default: full');
   program.option('--reading-order <value>', 'Reading order algorithm. Values: off, xycut. Default: xycut');
   program.option('--markdown-page-separator <value>', 'Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none');
   program.option('--text-page-separator <value>', 'Separator between pages in text output. Use %page-number% for page numbers. Default: none');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -23,6 +23,8 @@ export interface ConvertOptions {
   useStructTree?: boolean;
   /** Table detection method. Values: default (border-based), cluster (border + cluster). Default: default */
   tableMethod?: string;
+  /** Markdown table output mode. Values: full, caption_only, off. Default: full */
+  markdownTableOutput?: string;
   /** Reading order algorithm. Values: off, xycut. Default: xycut */
   readingOrder?: string;
   /** Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none */
@@ -66,6 +68,7 @@ export interface CliOptions {
   replaceInvalidChars?: string;
   useStructTree?: boolean;
   tableMethod?: string;
+  markdownTableOutput?: string;
   readingOrder?: string;
   markdownPageSeparator?: string;
   textPageSeparator?: string;
@@ -114,6 +117,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.tableMethod) {
     convertOptions.tableMethod = cliOptions.tableMethod;
+  }
+  if (cliOptions.markdownTableOutput) {
+    convertOptions.markdownTableOutput = cliOptions.markdownTableOutput;
   }
   if (cliOptions.readingOrder) {
     convertOptions.readingOrder = cliOptions.readingOrder;
@@ -205,6 +211,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.tableMethod) {
     args.push('--table-method', options.tableMethod);
+  }
+  if (options.markdownTableOutput) {
+    args.push('--markdown-table-output', options.markdownTableOutput);
   }
   if (options.readingOrder) {
     args.push('--reading-order', options.readingOrder);

--- a/options.json
+++ b/options.json
@@ -73,6 +73,14 @@
       "description": "Table detection method. Values: default (border-based), cluster (border + cluster). Default: default"
     },
     {
+      "name": "markdown-table-output",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": "full",
+      "description": "Markdown table output mode. Values: full, caption_only, off. Default: full"
+    },
+    {
       "name": "reading-order",
       "shortName": null,
       "type": "string",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -91,6 +91,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "description": "Table detection method. Values: default (border-based), cluster (border + cluster). Default: default",
     },
     {
+        "name": "markdown-table-output",
+        "python_name": "markdown_table_output",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": "full",
+        "description": "Markdown table output mode. Values: full, caption_only, off. Default: full",
+    },
+    {
         "name": "reading-order",
         "python_name": "reading_order",
         "short_name": None,

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -20,6 +20,7 @@ def convert(
     replace_invalid_chars: Optional[str] = None,
     use_struct_tree: bool = False,
     table_method: Optional[str] = None,
+    markdown_table_output: Optional[str] = None,
     reading_order: Optional[str] = None,
     markdown_page_separator: Optional[str] = None,
     text_page_separator: Optional[str] = None,
@@ -49,6 +50,7 @@ def convert(
         replace_invalid_chars: Replacement character for invalid/unrecognized characters. Default: space
         use_struct_tree: Use PDF structure tree (tagged PDF) for reading order and semantic structure
         table_method: Table detection method. Values: default (border-based), cluster (border + cluster). Default: default
+        markdown_table_output: Markdown table output mode. Values: full, caption_only, off. Default: full
         reading_order: Reading order algorithm. Values: off, xycut. Default: xycut
         markdown_page_separator: Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none
         text_page_separator: Separator between pages in text output. Use %page-number% for page numbers. Default: none
@@ -98,6 +100,8 @@ def convert(
         args.append("--use-struct-tree")
     if table_method:
         args.extend(["--table-method", table_method])
+    if markdown_table_output:
+        args.extend(["--markdown-table-output", markdown_table_output])
     if reading_order:
         args.extend(["--reading-order", reading_order])
     if markdown_page_separator:


### PR DESCRIPTION
## Summary
Add native markdown table output modes:
- `full` (current behavior)
- `caption_only`
- `off`

This lets downstream consumers preserve table captions while omitting table bodies from markdown output when they care more about reading order and prose continuity than inline table fidelity.

## Motivation
Complex table regions can degrade nearby markdown output. In voice-first or lightweight reading workflows, caption-only output is often preferable to full table reconstruction.

This PR keeps `full` unchanged and adds safer alternatives for consumers that want to suppress table content during markdown generation rather than stripping it later.

## What changed
- Added `markdownTableOutput` config with `full`, `caption_only`, and `off`
- Added CLI support for `--markdown-table-output`
- Updated markdown generation so:
  - `full` keeps current output
  - `caption_only` keeps captions and omits table bodies
  - `off` omits both table bodies and captions
- Added tests for all three modes
- Added caption-only cleanup for table-adjacent flattened artifacts that can spill across page boundaries in markdown output

## Reproduction
Source PDF:
- `DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning`
- DeepSeek-AI et al.

### Current raw markdown shape in `full`
On `DeepSeek_R1.pdf`, the default markdown output around `Table 4` includes flattened benchmark/table spillover between real subsection headings:

```md
##### 3.1. DeepSeek-R1 Evaluation

- 1https://example.com
- 2https://example.com
- 3https://example.com

Claude-3.5- GPT-4o DeepSeek OpenAI OpenAI DeepSeek
...
Table 4 | Comparison between DeepSeek-R1 and other representative models.
...
performance of DeepSeek-R1 will improve in the next version...

##### 3.2. Distilled Model Evaluation
```

### Expected shape in `caption_only`
```md
##### 3.1. DeepSeek-R1 Evaluation

Table 4 | Comparison between DeepSeek-R1 and other representative models.

##### 3.2. Distilled Model Evaluation
```

### Result with this PR
Using `--markdown-table-output caption_only` on the same PDF yields:

```md
##### 3.1. DeepSeek-R1 Evaluation

Table 4 | Comparison between DeepSeek-R1 and other representative models.

##### 3.2. Distilled Model Evaluation
```

It also preserves later captions like `Table 5 | ...` while omitting the table body.

## Notes
- `full` is intentionally unchanged by design.
- This PR focuses on native output control for markdown consumers.
- It does not try to fully solve default full-fidelity table reconstruction quality.

## Validation
Tested with:
- `mvn -f java/pom.xml -pl opendataloader-pdf-core,opendataloader-pdf-cli -am -DskipTests -DfailIfNoTests=false package`
- `mvn -f java/pom.xml -pl opendataloader-pdf-core,opendataloader-pdf-cli -am test -DfailIfNoTests=false`
- real-doc smoke on `DeepSeek_R1.pdf` with:
  - `--markdown-table-output full`
  - `--markdown-table-output caption_only`
