### PR TITLE
fix: guard against NullPointerException in hybrid mode when textColor is null

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -357,9 +357,15 @@ public class DocumentProcessor {
      * @return a string with font, size, color, and content information
      */
     public static String getContentsValueForTextNode(SemanticTextNode textNode) {
+        double[] textColor = null;
+        try {
+            textColor = textNode.getTextColor();
+        } catch (NullPointerException e) {
+            // textColor not available for hybrid mode generated content
+        }
         return String.format("%s: font %s, text size %.2f, text color %s, text content \"%s\"",
                 textNode.getSemanticType().getValue(), textNode.getFontName(),
-                textNode.getFontSize(), Arrays.toString(textNode.getTextColor()),
+                textNode.getFontSize(), Arrays.toString(textColor),
                 textNode.getValue().length() > 15 ? textNode.getValue().substring(0, 15) + "..." : textNode.getValue());
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HeadingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HeadingProcessor.java
@@ -68,7 +68,13 @@ public class HeadingProcessor {
             }
             SemanticTextNode prevNode = index != 0 ? textNodes.get(index - 1) : null;
             SemanticTextNode nextNode = index + 1 < textNodesCount ? textNodes.get(index + 1) : null;
-            double probability = NodeUtils.headingProbability(textNode, prevNode, nextNode, textNode);
+            double probability;
+            try {
+                probability = NodeUtils.headingProbability(textNode, prevNode, nextNode, textNode);
+            } catch (NullPointerException e) {
+                // textColor not available for hybrid mode generated content
+                continue;
+            }
 
             probability += textNodeStatistics.fontSizeRarityBoost(textNode);
             probability += textNodeStatistics.fontWeightRarityBoost(textNode);
@@ -192,7 +198,13 @@ public class HeadingProcessor {
         SortedMap<TextStyle, Set<SemanticHeading>> map = new TreeMap<>();
         List<SemanticHeading> headings = StaticLayoutContainers.getHeadings();
         for (SemanticHeading heading : headings) {
-            TextStyle textStyle = TextStyle.getTextStyle(heading);
+            TextStyle textStyle;
+            try {
+                textStyle = TextStyle.getTextStyle(heading);
+            } catch (NullPointerException e) {
+                // textColor not available for hybrid mode generated content
+                continue;
+            }
             map.computeIfAbsent(textStyle, k -> new HashSet<>()).add(heading);
         }
         int level = 1;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TextLineProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TextLineProcessor.java
@@ -47,7 +47,13 @@ public class TextLineProcessor {
                     continue;
                 }
                 TextLine currentLine = new TextLine(textChunk);
-                double oneLineProbability = ChunksMergeUtils.countOneLineProbability(new SemanticTextNode(), previousLine, currentLine);
+                double oneLineProbability;
+                try {
+                    oneLineProbability = ChunksMergeUtils.countOneLineProbability(new SemanticTextNode(), previousLine, currentLine);
+                } catch (NullPointerException e) {
+                    // textColor not available for hybrid mode generated content
+                    oneLineProbability = 0;
+                }
                 isSeparateLine |= (oneLineProbability < ONE_LINE_PROBABILITY) || previousLine.isHiddenText() != currentLine.isHiddenText();
                 if (isSeparateLine) {
                     previousLine.setBoundingBox(new BoundingBox(previousLine.getBoundingBox()));


### PR DESCRIPTION
## Summary

- Wrap verapdf library calls that internally access `SemanticTextNode.getTextColor()` with try-catch for `NullPointerException` in `HeadingProcessor`, `DocumentProcessor`, and `TextLineProcessor`
- The Docling backend returns text nodes without color array data, causing `calculateTextColor()` → `Arrays.stream(null)` crash during post-processing
- Follows the existing defensive pattern established in `SerializerUtil` (line 48-55) and `ListProcessor` (line 152-164)

## Changed files

| File | Change |
|------|--------|
| `HeadingProcessor.java` | Guard `NodeUtils.headingProbability()` and `TextStyle.getTextStyle()` — skip node on NPE |
| `DocumentProcessor.java` | Guard `textNode.getTextColor()` in debug formatter — show null on NPE |
| `TextLineProcessor.java` | Guard `ChunksMergeUtils.countOneLineProbability()` — treat as separate line on NPE |

## Upstream note

cc @MaximPlusov — `SemanticTextNode.calculateTextColor()` in verapdf calls `Arrays.stream(null)` when the color array is not populated. A defensive null check in verapdf itself would prevent this class of issues across all consumers.

Closes #319

## Test plan

- [ ] `mvn compile` passes
- [ ] Unit tests pass with null textColor (regression tests for both crash paths)
- [ ] Manual: `opendataloader-pdf --hybrid docling-fast <ppt-to-pdf>` completes without NPE
- [ ] Manual: `opendataloader-pdf --hybrid docling-fast <complex-gov-form>` completes without NPE

🤖 Generated with [Claude Code](https://claude.com/claude-code)