### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       # 1. SETUP
       # =================================================================
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize VERSION
         run: |
@@ -31,7 +31,7 @@ jobs:
           fi
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -43,7 +43,7 @@ jobs:
           gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -51,7 +51,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Set up Node.js and pnpm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -27,7 +27,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Push to homepage repo
         # Pinned to v1.7.3 for security - verify before updating

--- a/.github/workflows/test-benchmark.yml
+++ b/.github/workflows/test-benchmark.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -31,7 +31,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -49,7 +49,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: java-build
           path: java/opendataloader-pdf-cli/target/*.jar
@@ -60,18 +60,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: java-build
           path: java/opendataloader-pdf-cli/target/
@@ -92,7 +92,7 @@ jobs:
 
       - name: Comment benchmark results on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -161,7 +161,7 @@ jobs:
             });
 
       - name: Upload evaluation results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: benchmark-results


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@v4, actions/setup-java@v4, actions/setup-node@v4, actions/upload-artifact@v4, actions/download-artifact@v4, actions/github-script@v7.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Diff](https://github.com/actions/checkout/compare/v4...v6) | claude-code-review.yml, claude.yml, release.yml, sync-docs.yml, test-benchmark.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v8`](https://github.com/actions/download-artifact/releases/tag/v8) | [Diff](https://github.com/actions/download-artifact/compare/v4...v8) | test-benchmark.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Diff](https://github.com/actions/github-script/compare/v7...v8) | test-benchmark.yml |
| `actions/setup-java` | [`v4`](https://github.com/actions/setup-java/releases/tag/v4) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Diff](https://github.com/actions/setup-java/compare/v4...v5) | release.yml, test-benchmark.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Diff](https://github.com/actions/setup-node/compare/v4...v6) | release.yml, test-benchmark.yml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Diff](https://github.com/actions/setup-python/compare/v5...v6) | release.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/upload-artifact/releases/tag/v7) | [Diff](https://github.com/actions/upload-artifact/compare/v4...v7) | test-benchmark.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure automation tool versions to enhance build reliability and consistency across testing, benchmarking, and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->