### PR TITLE
fix: use asyncio event loop on Windows to avoid uvloop error

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -46,6 +46,7 @@ import argparse
 import logging
 import os
 import re
+import sys
 import tempfile
 import time
 import traceback
@@ -161,6 +162,17 @@ def sanitize_unicode(data: Any) -> Any:
     if isinstance(data, list):
         return [sanitize_unicode(item) for item in data]
     return data
+
+
+def _get_loop_setting() -> str:
+    """Return the uvicorn event loop setting appropriate for the current platform.
+
+    uvloop is not supported on Windows, so we force 'asyncio' there.
+    On other platforms, 'auto' lets uvicorn use uvloop if available.
+    """
+    if sys.platform == "win32":
+        return "asyncio"
+    return "auto"
 
 
 def _check_dependencies():
@@ -527,6 +539,7 @@ def main():
         host=args.host,
         port=args.port,
         log_level=args.log_level,
+        loop=_get_loop_setting(),
     )
 
 

--- a/python/opendataloader-pdf/tests/test_hybrid_server.py
+++ b/python/opendataloader-pdf/tests/test_hybrid_server.py
@@ -1,6 +1,7 @@
-"""Tests for hybrid_server GPU detection logging."""
+"""Tests for hybrid_server."""
 
 import logging
+import sys
 from unittest.mock import MagicMock, patch
 
 
@@ -69,3 +70,22 @@ def test_no_pytorch_logging(caplog):
                 )
 
     assert "No GPU detected, using CPU. (PyTorch not installed)" in caplog.text
+
+
+def test_get_loop_setting_returns_asyncio_on_windows():
+    """On Windows, should return 'asyncio' to avoid uvloop errors (#323)."""
+    from opendataloader_pdf.hybrid_server import _get_loop_setting
+
+    with patch("sys.platform", "win32"):
+        assert _get_loop_setting() == "asyncio"
+
+
+def test_get_loop_setting_returns_auto_on_non_windows():
+    """On non-Windows platforms, should return 'auto' (uvloop if available)."""
+    from opendataloader_pdf.hybrid_server import _get_loop_setting
+
+    with patch("sys.platform", "darwin"):
+        assert _get_loop_setting() == "auto"
+
+    with patch("sys.platform", "linux"):
+        assert _get_loop_setting() == "auto"


### PR DESCRIPTION
## Summary
Fixes #323

- Detect Windows platform and pass `loop="asyncio"` to `uvicorn.run()` instead of the default `"auto"` which tries to use uvloop
- uvloop is not supported on Windows, causing `AttributeError: module 'uvloop' has no attribute 'EventLoopPolicy'`

## Problem
`uvicorn` defaults to `loop="auto"`, which uses `uvloop` if installed. On Windows, `uvloop` can be installed as a dependency but lacks `EventLoopPolicy`, causing a runtime crash when starting the hybrid server.

## Changes
- `hybrid_server.py`: Add `_get_loop_setting()` that returns `"asyncio"` on Windows, `"auto"` elsewhere
- `test_hybrid_server.py`: Add tests for both Windows and non-Windows platform detection

## How to reproduce
```bash
# On Windows:
pip install opendataloader-pdf[hybrid]
opendataloader-pdf-hybrid --port 5002
# → AttributeError: module 'uvloop' has no attribute 'EventLoopPolicy'
```

## How to test
```bash
# Unit tests (any platform):
pytest python/opendataloader-pdf/tests/test_hybrid_server.py -v

# Manual verification on Windows:
pip install git+https://github.com/opendataloader-project/opendataloader-pdf.git@issue/323-windows-uvloop-fix#subdirectory=python/opendataloader-pdf[hybrid]
opendataloader-pdf-hybrid --port 5002
curl http://localhost:5002/health
# → {"status":"ok"}
```

## Breaking changes
None