### PR TITLE
fix: remove fallback 0 for missing thresholds in step summary

### DIFF
--- a/.github/workflows/test-benchmark.yml
+++ b/.github/workflows/test-benchmark.yml
@@ -120,32 +120,21 @@ jobs:
           table_detection = eval_data.get("table_detection", {})
           speed = eval_data.get("speed", {})
           triage = eval_data.get("triage", {})
+          tol = thresholds.get("regression_tolerance", 0)
 
           rows = []
 
-          nid = scores.get("nid_mean")
-          if nid is not None:
-              t = thresholds.get("nid", 0)
-              status = "✅" if nid >= t else "❌"
-              rows.append(f"| NID | {nid:.4f} | ≥ {t} | {status} |")
-
-          teds = scores.get("teds_mean")
-          if teds is not None:
-              t = thresholds.get("teds", 0)
-              status = "✅" if teds >= t else "❌"
-              rows.append(f"| TEDS | {teds:.4f} | ≥ {t} | {status} |")
-
-          mhs = scores.get("mhs_mean")
-          if mhs is not None:
-              t = thresholds.get("mhs", 0)
-              status = "✅" if mhs >= t else "❌"
-              rows.append(f"| MHS | {mhs:.4f} | ≥ {t} | {status} |")
-
-          td_f1 = table_detection.get("f1")
-          if td_f1 is not None:
-              t = thresholds.get("table_detection_f1", 0)
-              status = "✅" if td_f1 >= t else "❌"
-              rows.append(f"| Table Detection F1 | {td_f1:.4f} | ≥ {t} | {status} |")
+          for key, label, src in [
+              ("nid", "NID", scores.get("nid_mean")),
+              ("teds", "TEDS", scores.get("teds_mean")),
+              ("mhs", "MHS", scores.get("mhs_mean")),
+              ("table_detection_f1", "Table Detection F1", table_detection.get("f1")),
+          ]:
+              t = thresholds.get(key)
+              if src is not None and t is not None:
+                  effective = t - tol
+                  status = "✅" if src >= effective else "❌"
+                  rows.append(f"| {label} | {src:.4f} | ≥ {effective:.2f} | {status} |")
 
           elapsed = speed.get("elapsed_per_doc")
           elapsed_thresh = thresholds.get("elapsed_per_doc")
@@ -155,10 +144,11 @@ jobs:
 
           if triage:
               tr_recall = triage.get("recall")
-              if tr_recall is not None:
-                  t = thresholds.get("triage_recall", 0)
-                  status = "✅" if tr_recall >= t else "❌"
-                  rows.append(f"| Triage Recall | {tr_recall:.4f} | ≥ {t} | {status} |")
+              tr_thresh = thresholds.get("triage_recall")
+              if tr_recall is not None and tr_thresh is not None:
+                  effective = tr_thresh - tol
+                  status = "✅" if tr_recall >= effective else "❌"
+                  rows.append(f"| Triage Recall | {tr_recall:.4f} | ≥ {effective:.2f} | {status} |")
 
               tr_fn = triage.get("fn_count")
               tr_fn_max = thresholds.get("triage_fn_max")


### PR DESCRIPTION
## Summary
- Skip metrics with missing thresholds instead of defaulting to 0 (false positive green check)
- Apply `regression_tolerance` from thresholds.json to step summary display
- Step summary now shows effective threshold (baseline - tolerance)
- Deduplicate score metric blocks with a loop

## Problem
`thresholds.get(key, 0)` silently treated missing threshold keys as 0, causing the step summary to show ✅ even when the threshold config was incomplete. Raised by CodeRabbit review on PR #355.

## Solution
Only render a metric row when both the score and the threshold are present. Apply `regression_tolerance` to match the check logic in opendataloader-bench.

## Verification
- [ ] YAML syntax validated locally
- [ ] Step Summary renders correctly in Actions tab
- [ ] Missing threshold key results in skipped row, not false ✅

Companion: opendataloader-project/opendataloader-bench#9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test benchmark workflow to enforce explicit regression thresholds for key metrics instead of using defaults, and introduced tolerance-based threshold adjustments for stricter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->