### PR TITLE
fix(hybrid): remove default 100MB file size limit

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -66,6 +66,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 5002
 MAX_FILE_SIZE = 0  # No file size limit by default (0 = unlimited)
+UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1MB chunks for streaming upload
+
+
+def _non_negative_int(value: str) -> int:
+    """Argparse type validator that rejects negative integers."""
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("--max-file-size must be >= 0")
+    return parsed
+
 
 # Global converter instance (initialized on startup with CLI options)
 converter = None
@@ -370,22 +380,27 @@ def create_app(
             except ValueError:
                 pass
 
-        # Read and validate file size
-        content = await files.read()
-        if max_file_size > 0 and len(content) > max_file_size:
-            return JSONResponse(
-                {
-                    "status": "failure",
-                    "errors": [f"File size exceeds maximum allowed ({max_file_size // (1024*1024)}MB)"],
-                },
-                status_code=413,
-            )
-
-        # Save uploaded file to temp location
+        # Stream upload to temp file and enforce size incrementally
         tmp_path = None
+        total_size = 0
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-            tmp.write(content)
             tmp_path = tmp.name
+            while True:
+                chunk = await files.read(UPLOAD_CHUNK_SIZE)
+                if not chunk:
+                    break
+                total_size += len(chunk)
+                if max_file_size > 0 and total_size > max_file_size:
+                    tmp.close()
+                    os.unlink(tmp_path)
+                    return JSONResponse(
+                        {
+                            "status": "failure",
+                            "errors": [f"File size exceeds maximum allowed ({max_file_size // (1024*1024)}MB)"],
+                        },
+                        status_code=413,
+                    )
+                tmp.write(chunk)
 
         try:
             def _do_convert():
@@ -512,7 +527,7 @@ def main():
     )
     parser.add_argument(
         "--max-file-size",
-        type=int,
+        type=_non_negative_int,
         default=MAX_FILE_SIZE,
         help="Maximum upload file size in MB. 0 means no limit (default: 0).",
     )


### PR DESCRIPTION
## Objective

When processing PDFs larger than 100MB in hybrid mode, users get `413: File size exceeds maximum allowed (100MB)` with no way to change the limit.

Fixes [opendataloader-project/opendataloader-pdf#364](https://github.com/opendataloader-project/opendataloader-pdf/issues/364)

## Approach

Remove the default file size limit — there is no reason for a local server to block users from processing their own files. Users who need a limit can opt in with `--max-file-size 200` (in MB).

Additionally, based on code review feedback:
- Upload is now streamed in 1MB chunks to disk — large files no longer load entirely into memory before the size check
- Negative `--max-file-size` values are rejected via argparse validation

## Evidence

Started the hybrid server and sent dummy files via curl:

| Scenario | Expected | Actual |
|----------|----------|--------|
| 101MB, no limit (new default) | No 413 | ✅ Passed size check (500 from dummy file, not 413) |
| 101MB, `--max-file-size 50` | 413 | ✅ `413: File size exceeds maximum allowed (50MB)` |
| 10MB, `--max-file-size 50` | No 413 | ✅ Passed size check |
| `--max-file-size -1` | Reject | ✅ `ArgumentTypeError: --max-file-size must be >= 0` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)