### PR TITLE
perf: cap backward scan in ListProcessor to fix O(n²) scaling (~50x)

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -50,6 +50,12 @@ public class ListProcessor {
     private static final double LIST_ITEM_X_INTERVAL_RATIO = 0.3;
     private static final Pattern ATTACHMENTS_PATTERN = Pattern.compile("^붙\\s*임\\s*(?=.)");
 
+    /**
+     * Maximum number of intervals to scan backward when matching a TextLine to an existing list.
+     * Prevents O(n²) scaling on large documents. A higher value is safer but slower.
+     */
+    private static final int MAX_LIST_INTERVAL_LOOKBACK = 500;
+
     public static void processLists(List<List<IObject>> contents, boolean isTableCell) {
         List<TextListInterval> intervalsList = getTextLabelListIntervals(contents);
         for (TextListInterval interval : intervalsList) {
@@ -143,7 +149,8 @@ public class ListProcessor {
         boolean shouldHaveSameLeftDifference = false;
         boolean isUnordered = true;
         Double previousLeftDifference = null;
-        for (int index = listIntervals.size() - 1; index >= 0; index--) {
+        int minIndex = Math.max(0, listIntervals.size() - MAX_LIST_INTERVAL_LOOKBACK);
+        for (int index = listIntervals.size() - 1; index >= minIndex; index--) {
             TextListInterval interval = listIntervals.get(index);
             ListItemTextInfo preivousListItemTextInfo = interval.getLastListItemInfo();
             double leftDifference = listItemTextInfo.getListItemValue().getLeftX() -


### PR DESCRIPTION
## Problem

`ListProcessor.processLists()` has O(n²) scaling due to an unbounded backward scan in `processListItem()`. Each TextLine scans the entire `listIntervals` history to find a matching list. Since matched intervals are re-appended to the list, it grows to O(n) entries, making total cost O(n²).

On a 2324-page, 29MB PDF, `ListProcessor.processLists()` alone took **240+ seconds**, dominating the entire pipeline and causing total conversion time to exceed **15 minutes**.

## Fix

Cap the backward scan to the last 500 intervals (`MAX_LIST_INTERVAL_LOOKBACK`). List items in practice match within the most recent few entries.

## Results

Tested on a 2324-page PDF (markdown output, `--image-output off`):

| Lookback cap | Total conversion time | Speedup vs. unlimited |
|---|---|---|
| 100 | 8.3s | ~108x |
| 500 (chosen) | 18.4s | ~49x |
| 1000 | 28.8s | ~31x |
| unlimited (current) | >900s | baseline |

500 was chosen as a balance between safety and performance. The value is defined as `MAX_LIST_INTERVAL_LOOKBACK` and can be tuned if needed.

## Risk

This should be safe for typical documents, but could potentially miss list continuations where 500+ intervening list-candidate lines are processed between items of the same list. The most likely scenario would be a very dense page or section with hundreds of nested or interleaved lists (e.g., a deeply nested table of contents), where inner list items push an outer list's interval past the lookback window. If triggered, the affected list would be split into two separate lists in the output — content is not lost, but the list structure/numbering would restart.

All existing tests pass with identical output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified list item matching to apply a maximum lookback limit when scanning for related items, improving efficiency by constraining the search space rather than examining the entire history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->