### PR TITLE
fix(hybrid): add --device flag and fix misleading GPU log on Apple Silicon (#371)

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -574,7 +574,7 @@ def main():
             gpu_name = torch.cuda.get_device_name(0)
             cuda_version = torch.version.cuda
             logger.info(f"Accelerator: CUDA — {gpu_name} (CUDA {cuda_version})")
-        elif torch.backends.mps.is_available():
+        elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
             logger.info("Accelerator: MPS (Apple Silicon)")
         elif hasattr(torch, "xpu") and torch.xpu.is_available():
             logger.info("Accelerator: XPU (Intel GPU)")


### PR DESCRIPTION
## Summary

- Added `--device` CLI flag (`auto`/`cpu`/`cuda`/`mps`/`xpu`, default: `auto`) to `opendataloader-pdf-hybrid`
- Passes `AcceleratorOptions(device=...)` through `create_converter()` into `PdfPipelineOptions` — the plumbing already existed in Docling, this just connects the CLI to it
- Fixed startup log to detect CUDA, MPS (Apple Silicon), and XPU instead of CUDA-only

Closes #371

## Evidence

Started the server on port 5005 with `--device auto` on Apple M4 Pro and sent `umich_03_ssd-single-shot-multibox-detector.pdf` (10-page academic paper) via curl:

| Scenario | Before | After |
|----------|--------|-------|
| Startup log (MPS mac) | `No GPU detected, using CPU.` | `Accelerator: MPS (Apple Silicon)` |
| `--device mps` flag | unrecognized argument | accepted, passed to Docling |
| PDF conversion (10p) | — | `status: success`, 18.75s |
| Test suite | — | 42/42 passed |

## Workaround (before this fix)

```bash
export DOCLING_DEVICE=mps
opendataloader-pdf-hybrid --port 5002
```

## Test plan

- [x] `--device auto` on Apple Silicon shows `Accelerator: MPS (Apple Silicon)` in startup log
- [x] `--device cpu` forces CPU (verified via `DOCLING_DEVICE` env var override in Docling)
- [x] PDF conversion completes successfully with default `--device auto`
- [x] 42/42 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--device` command-line option to specify compute device (auto, cpu, cuda, mps, xpu) for optimized hardware selection.
  * Improved startup and converter logging to report accelerator status (CUDA/MPS/XPU/CPU), show when a manual device override is used, and display the selected device during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->