### PR TITLE
Fix: handle invalid input paths in Java API to prevent crash

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
@@ -19,12 +19,19 @@ import org.opendataloader.pdf.hybrid.HybridClientFactory;
 import org.opendataloader.pdf.processors.DocumentProcessor;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The main entry point for the opendataloader-pdf library.
  * Use the static method {@link #processFile(String, Config)} to process a PDF.
  */
 public final class OpenDataLoaderPDF {
+
+    private static final Logger LOGGER = Logger.getLogger(OpenDataLoaderPDF.class.getCanonicalName());
 
     private OpenDataLoaderPDF() {
     }
@@ -37,7 +44,43 @@ public final class OpenDataLoaderPDF {
      * @throws IOException If an error occurs during file reading or processing.
      */
     public static void processFile(String inputPdfName, Config config) throws IOException {
+        if (!isValidInputFile(inputPdfName)) return;
+
         DocumentProcessor.processFile(inputPdfName, config);
+    }
+
+    /**
+     * Validates whether the given path refers to a valid PDF file.
+     *
+     * @param inputPdfName the path to the input file
+     * @return {@code true} if the path is non-null, points to an existing
+     *         regular file, and has a .pdf extension; {@code false} otherwise
+     */
+    private static boolean isValidInputFile(String inputPdfName) {
+
+        if (inputPdfName == null || inputPdfName.isBlank()) {
+            LOGGER.log(Level.WARNING, "Input file path is null or empty");
+            return false;
+        }
+
+        Path path = Paths.get(inputPdfName);
+
+        if (!Files.exists(path)) {
+            LOGGER.log(Level.WARNING, () -> "File does not exist: " + inputPdfName);
+            return false;
+        }
+
+        if (!Files.isRegularFile(path)) {
+            LOGGER.log(Level.WARNING, () -> "Not a valid file: " + inputPdfName);
+            return false;
+        }
+
+        if (!inputPdfName.toLowerCase().endsWith(".pdf")) {
+            LOGGER.log(Level.WARNING, () -> "Not a PDF file: " + inputPdfName);
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
@@ -43,26 +43,26 @@ public final class OpenDataLoaderPDF {
      *
      * @param inputPdfName The path to the input PDF file.
      * @param config       The configuration object specifying output formats and other options.
-     * @throws IOException If an error occurs during file reading or processing.
+     *
      */
-    public static void processFile(String inputPdfName, Config config) throws IOException {
-        if (!isValidInputFile(inputPdfName)) return;
-
-        DocumentProcessor.processFile(inputPdfName, config);
+    public static void processFile(String inputPdfName, Config config) {
+        try {
+            validateInputFile(inputPdfName);
+            DocumentProcessor.processFile(inputPdfName, config);
+        } catch (IllegalArgumentException | IOException ex) {
+            LOGGER.log(Level.WARNING, ex.getMessage());
+        }
     }
 
     /**
      * Validates whether the given path refers to a valid PDF file.
      *
      * @param inputPdfName the path to the input file
-     * @return {@code true} if the path is non-null, points to an existing
-     * regular file, and has a .pdf extension; {@code false} otherwise
      */
-    private static boolean isValidInputFile(String inputPdfName) {
+    private static void validateInputFile(String inputPdfName) {
 
         if (inputPdfName == null || inputPdfName.isBlank()) {
-            LOGGER.log(Level.WARNING, "Input file path is null or empty");
-            return false;
+            throw new IllegalArgumentException("Input PDF name is null or Empty");
         }
 
         final Path path;
@@ -70,26 +70,21 @@ public final class OpenDataLoaderPDF {
         try {
             path = Paths.get(inputPdfName);
         } catch (InvalidPathException ex) {
-            LOGGER.log(Level.WARNING, () -> "Invalid file path: " + inputPdfName);
-            return false;
+            throw new IllegalArgumentException("Invalid Path: " + inputPdfName);
         }
 
         if (!Files.exists(path)) {
-            LOGGER.log(Level.WARNING, () -> "File does not exist: " + inputPdfName);
-            return false;
+            throw new IllegalArgumentException("File not fount at " + inputPdfName + " location");
         }
 
         if (!Files.isRegularFile(path)) {
-            LOGGER.log(Level.WARNING, () -> "Not a valid file: " + inputPdfName);
-            return false;
+            throw new IllegalArgumentException("Not a valid file " + inputPdfName);
         }
 
         if (!path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".pdf")) {
-            LOGGER.log(Level.WARNING, () -> "Not a PDF file: " + inputPdfName);
-            return false;
+            throw new IllegalArgumentException("Not a PDF file");
         }
 
-        return true;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
@@ -20,8 +20,10 @@ import org.opendataloader.pdf.processors.DocumentProcessor;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -54,7 +56,7 @@ public final class OpenDataLoaderPDF {
      *
      * @param inputPdfName the path to the input file
      * @return {@code true} if the path is non-null, points to an existing
-     *         regular file, and has a .pdf extension; {@code false} otherwise
+     * regular file, and has a .pdf extension; {@code false} otherwise
      */
     private static boolean isValidInputFile(String inputPdfName) {
 
@@ -63,7 +65,14 @@ public final class OpenDataLoaderPDF {
             return false;
         }
 
-        Path path = Paths.get(inputPdfName);
+        final Path path;
+
+        try {
+            path = Paths.get(inputPdfName);
+        } catch (InvalidPathException ex) {
+            LOGGER.log(Level.WARNING, () -> "Invalid file path: " + inputPdfName);
+            return false;
+        }
 
         if (!Files.exists(path)) {
             LOGGER.log(Level.WARNING, () -> "File does not exist: " + inputPdfName);
@@ -75,7 +84,7 @@ public final class OpenDataLoaderPDF {
             return false;
         }
 
-        if (!inputPdfName.toLowerCase().endsWith(".pdf")) {
+        if (!path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".pdf")) {
             LOGGER.log(Level.WARNING, () -> "Not a PDF file: " + inputPdfName);
             return false;
         }


### PR DESCRIPTION
###  Problem

When using the Java API (`OpenDataLoaderPDF.processFile`) in a loop (as shown in the documentation https://opendataloader.org/docs/quick-start-java ), providing an invalid file path causes an exception and stops the entire processing.

###  Reproduction Example

The issue can be reproduced using the documented example:

```java
import org.opendataloader.pdf.api.Config;
import org.opendataloader.pdf.api.OpenDataLoaderPDF;

public class Sample {
    public static void main(String[] args) throws Exception {
        Config config = new Config();
        config.setOutputFolder("path/to/output");
        config.setGeneratePDF(true);
        config.setGenerateMarkdown(true);
        config.setGenerateHtml(true);

        try {
            // Process multiple files in one JVM invocation
            for (String pdf : new String[]{"valid.pdf", "invalid.pdf"}) {
                OpenDataLoaderPDF.processFile(pdf, config);
            }
        } finally {
            OpenDataLoaderPDF.shutdown();
        }
    }
}

```

### ❌ Current Behavior

If one of the input paths is invalid or does not exist, the program throws an exception and stops execution, preventing other valid files from being processed.

### ⚠️ Inconsistency

- CLI handles invalid paths gracefully  
- Java API does not  
- Documentation suggests batch processing should work reliably  

### ✅ Fix

- Added input file validation in `OpenDataLoaderPDF.processFile`
- If a path is invalid:
  - Log a warning
  - Skip processing that file
- Continue processing remaining valid inputs

### 📈 Impact

- Prevents crashes during batch processing  
- Improves robustness of the Java API  
- Aligns behavior with CLI and documented usage  

### 🧪 Testing

Tested manually with:
- Valid paths only  
- Mix of valid and invalid paths  
- All invalid paths  

Unit tests can be added if required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - PDF inputs are validated before processing: null/blank, invalid paths, missing or non-regular files, and non-.pdf names are detected; invalid inputs are skipped and validation failures are logged.

* **Changes**
  - Processing now returns a result object indicating success or failure instead of throwing exceptions; failures are logged and reported in the returned result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->