### PR TITLE
fix(struct-tree): render table cell text when use_struct_tree=True

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
@@ -314,7 +314,20 @@ public class TaggedDocumentProcessor {
     }
 
     private static void processTableCell(TableBorderCell cell, INode elem) {
-        processChildContents(elem, cell.getContents());
+        List<IObject> rawContents = new ArrayList<>();
+        processChildContents(elem, rawContents);
+        List<IObject> processed = TextLineProcessor.processTextLines(rawContents);
+        TextBlock textBlock = new TextBlock(new MultiBoundingBox());
+        for (IObject content : processed) {
+            if (content instanceof TextLine) {
+                textBlock.add((TextLine) content);
+            } else {
+                cell.getContents().add(content);
+            }
+        }
+        if (!textBlock.isEmpty()) {
+            cell.getContents().add(ParagraphProcessor.createParagraphFromTextBlock(textBlock));
+        }
         BoundingBox cellBoundingBox = new MultiBoundingBox();
         for (IObject content : cell.getContents()) {
             cellBoundingBox.union(content.getBoundingBox());


### PR DESCRIPTION
## Summary

- Fixes #359: table cells were empty in struct-tree mode (`use_struct_tree=True`)
- Root cause: `processTableCell()` collected raw `TextChunk` objects into `cell.getContents()`, but `MarkdownGenerator.isSupportedContent()` does not handle `TextChunk` — only `SemanticTextNode` subclasses — so all cell text was silently dropped
- Fix: mirror the `createParagraph()` pattern already used elsewhere — pipe raw content through `TextLineProcessor` → `TextBlock` → `ParagraphProcessor.createParagraphFromTextBlock()`, producing a `SemanticParagraph` that `MarkdownGenerator` recognises

## Evidence

Ran `opendataloader-pdf --use-struct-tree` on `Tables_test.pdf` (fixture for #359):

| Scenario | Before | After |
|---|---|---|
| Simple table | `\|Name\| \|` (empty cells) | `\|Name\|Jane\|` ✅ |
| Span table | all cells empty | `\|Alex\|\$12,000\|A\|…\|` ✅ |
| Row-span table | all cells empty | `\|AI Research\|Lead\|Dr. Smith\|` ✅ |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PDF table cell content processing to properly format and organize text into structured paragraphs, improving data extraction accuracy and text readability within PDF tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->