### PR TITLE
fix: preserve whitespace chunk positions to restore missing spaces

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TextLineProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TextLineProcessor.java
@@ -27,8 +27,11 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ListUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.TextChunkUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
 
 public class TextLineProcessor {
 
@@ -38,13 +41,27 @@ public class TextLineProcessor {
 
     public static List<IObject> processTextLines(List<IObject> contents) {
         List<IObject> newContents = new ArrayList<>();
+        // Track which TextChunk immediately follows a whitespace chunk in stream order,
+        // using reference identity so lookups are immune to TextChunk.equals() semantics.
+        // Stream order may differ from visual (leftX) order in rare PDFs, but whitespace
+        // chunks originate from the same PDF text operator as their adjacent text chunks,
+        // so stream-order adjacency is reliable for this signal.
+        Set<TextChunk> chunksAfterWhitespace = Collections.newSetFromMap(new IdentityHashMap<>());
         TextLine previousLine = new TextLine(new TextChunk(""));
         boolean isSeparateLine = false;
+        boolean pendingWhitespace = false;
         for (IObject content : contents) {
             if (content instanceof TextChunk) {
                 TextChunk textChunk = (TextChunk) content;
                 if (textChunk.isWhiteSpaceChunk() || textChunk.isEmpty()) {
+                    if (textChunk.isWhiteSpaceChunk()) {
+                        pendingWhitespace = true;
+                    }
                     continue;
+                }
+                if (pendingWhitespace) {
+                    chunksAfterWhitespace.add(textChunk);
+                    pendingWhitespace = false;
                 }
                 TextLine currentLine = new TextLine(textChunk);
                 double oneLineProbability = ChunksMergeUtils.countOneLineProbability(new SemanticTextNode(), previousLine, currentLine);
@@ -62,6 +79,7 @@ public class TextLineProcessor {
                     isSeparateLine = true;
                 }
                 newContents.add(content);
+                pendingWhitespace = false;
             }
         }
         for (int i = 0; i < newContents.size(); i++) {
@@ -70,14 +88,15 @@ public class TextLineProcessor {
                 TextLine textLine = (TextLine) content;
                 textLine.getTextChunks().sort(TEXT_CHUNK_COMPARATOR);
                 double threshold = textLine.getFontSize() * TextChunkUtils.TEXT_LINE_SPACE_RATIO;
-                newContents.set(i, getTextLineWithSpaces(textLine, threshold));
+                newContents.set(i, getTextLineWithSpaces(textLine, threshold, chunksAfterWhitespace));
             }
         }
         linkTextLinesWithConnectedLineArtBullet(newContents);
         return newContents;
     }
 
-    private static TextLine getTextLineWithSpaces(TextLine textLine, double threshold) {
+    private static TextLine getTextLineWithSpaces(TextLine textLine, double threshold,
+                                                   Set<TextChunk> chunksAfterWhitespace) {
         List<TextChunk> textChunks = textLine.getTextChunks();
         TextChunk currentTextChunk = textChunks.get(0);
         double previousEnd = currentTextChunk.getBoundingBox().getRightX();
@@ -86,10 +105,14 @@ public class TextLineProcessor {
         for (int i = 1; i < textChunks.size(); i++) {
             currentTextChunk = textChunks.get(i);
             double currentStart = currentTextChunk.getBoundingBox().getLeftX();
-            if (currentStart - previousEnd > threshold) {
+            boolean hasGap = currentStart - previousEnd > threshold;
+            boolean hadWhitespace = chunksAfterWhitespace.contains(currentTextChunk);
+            if (hasGap || hadWhitespace) {
+                double spaceLeft = Math.min(previousEnd, currentStart);
+                double spaceRight = Math.max(previousEnd, currentStart);
                 BoundingBox spaceBBox = new BoundingBox(currentTextChunk.getBoundingBox());
-                spaceBBox.setLeftX(previousEnd);
-                spaceBBox.setRightX(currentStart);
+                spaceBBox.setLeftX(spaceLeft);
+                spaceBBox.setRightX(spaceRight);
                 TextChunk spaceChunk = new TextChunk(spaceBBox, " ", textLine.getFontSize(), textLine.getBaseLine());
                 newLine.add(spaceChunk);
             }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/TextLineProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/TextLineProcessorTest.java
@@ -84,6 +84,42 @@ public class TextLineProcessorTest {
     }
 
     /**
+     * Regression test for issue #358: when a whitespace chunk exists between two text chunks
+     * but the physical gap is smaller than the threshold, a space should still be inserted
+     * because the PDF explicitly contains a space character at that position.
+     */
+    @Test
+    public void testProcessTextLinesPreservesSpaceFromWhitespaceChunk() {
+        StaticContainers.setIsIgnoreCharactersWithoutUnicode(false);
+        StaticContainers.setIsDataLoader(true);
+        List<IObject> contents = new ArrayList<>();
+
+        // "Evolution" at x=46..85.5, font size 9.5 (threshold = 9.5*0.17 = 1.615)
+        TextChunk chunk1 = new TextChunk(new BoundingBox(0, 46.0, 300.0, 85.5, 310.0),
+            "Evolution", 9.5, 300.0);
+        // Whitespace chunk at x=85.5..87.9 — will be dropped by isWhiteSpaceChunk()
+        TextChunk spaceChunk = new TextChunk(new BoundingBox(0, 85.5, 300.0, 87.9, 310.0),
+            " ", 9.5, 300.0);
+        // "Of" at x=86.0..94.4 — gap from chunk1 = 0.5 < threshold 1.615, so no gap-based space
+        TextChunk chunk2 = new TextChunk(new BoundingBox(0, 86.0, 300.0, 94.4, 310.0),
+            "Of", 9.5, 300.0);
+
+        contents.add(chunk1);
+        contents.add(spaceChunk);
+        contents.add(chunk2);
+
+        contents = TextLineProcessor.processTextLines(contents);
+
+        Assertions.assertEquals(1, contents.size());
+        Assertions.assertTrue(contents.get(0) instanceof TextLine);
+
+        TextLine textLine = (TextLine) contents.get(0);
+        // Space must be preserved even though the physical gap is below threshold
+        Assertions.assertEquals("Evolution Of", textLine.getValue(),
+            "Space from whitespace chunk should be preserved, but got: " + textLine.getValue());
+    }
+
+    /**
      * Regression test for issue #150: spaces should be inserted between sorted chunks
      * when there is a physical gap between them.
      */


### PR DESCRIPTION
## Summary

Closes #358.

- **Objective:** Words are concatenated without spaces in markdown output for PDFs with tight kerning (e.g., Roboto font). The PDF contains explicit space characters, but they are lost during text extraction.
- **Approach:** When `TextLineProcessor` drops whitespace chunks, record which text chunk follows each one. In `getTextLineWithSpaces()`, insert a space if either the physical gap exceeds the threshold (existing logic) **or** a whitespace chunk was present at that position (new signal).
- **Evidence:** Converted the reporter's `Test.pdf` locally:

| Scenario | Before | After |
|----------|--------|-------|
| Title line | `EvolutionOfSearch LexicalSearch:` | `Evolution Of Search Lexical Search:` |
| Body text | `Traditionalsearchreliesonkeywordmatching,...` | `Traditional search relies on keyword matching,...` |
| List items | `1.Mailsfrommymanager` | `1. Mails from my manager` |
| All 443 unit tests | ✅ Pass | ✅ Pass |

## Test plan

- [x] New regression test `testProcessTextLinesPreservesSpaceFromWhitespaceChunk` — whitespace chunk between two tight chunks produces a space
- [x] All existing `TextLineProcessorTest` tests pass (no regression in gap-based spacing)
- [x] Full `opendataloader-pdf-core` test suite: 443 tests, 0 failures
- [ ] Benchmark run to check for regression on other documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whitespace preservation in PDF text extraction so explicit whitespace fragments are retained between adjacent text pieces, ensuring spaces are kept even when geometric gaps are below the usual spacing threshold.

* **Tests**
  * Added a regression test verifying preserved spaces are included in reconstructed text lines when an explicit whitespace fragment is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->