### PR TITLE
fix: prevent footer detection from absorbing distant body text

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HeaderFooterProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HeaderFooterProcessor.java
@@ -203,9 +203,9 @@ public class HeaderFooterProcessor {
         IObject previousElement = pageContents.get(previousIndex);
         double gap;
         if (isHeaderDetection) {
-            gap = previousElement.getTopY() - candidate.getBottomY();
+            gap = previousElement.getBottomY() - candidate.getTopY();
         } else {
-            gap = candidate.getTopY() - previousElement.getBottomY();
+            gap = candidate.getBottomY() - previousElement.getTopY();
         }
         return gap <= MAX_HEADER_FOOTER_GAP;
     }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HeaderFooterProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HeaderFooterProcessorTest.java
@@ -156,4 +156,46 @@ public class HeaderFooterProcessorTest {
                 "Page " + page + ": repeated note text should remain in body, not be absorbed into footer");
         }
     }
+
+    /**
+     * Positive control: two closely spaced footer lines (gap < 30pt) should be
+     * grouped into a single footer. Ensures the proximity check does not reject
+     * legitimate multi-line footers.
+     */
+    @Test
+    public void testCloseFooterLinesAreGrouped() {
+        initContainers();
+        List<List<IObject>> contents = new ArrayList<>();
+        for (int page = 0; page < 3; page++) {
+            List<IObject> pageContents = new ArrayList<>();
+            // Body text at top
+            pageContents.add(new TextLine(new TextChunk(
+                new BoundingBox(page, 37.0, 500.0, 300.0, 530.0),
+                "Body text page " + (page + 1), 10, 530.0)));
+
+            // Two footer lines close together (11pt gap between nearest edges)
+            // Line 1: y=[55, 67]  Line 2: y=[35, 44]  gap = 55-44 = 11pt
+            pageContents.add(new TextLine(new TextChunk(
+                new BoundingBox(page, 37.0, 55.0, 280.0, 67.0),
+                "Copyright 2026", 7.5, 67.0)));
+            pageContents.add(new TextLine(new TextChunk(
+                new BoundingBox(page, 37.0, 35.0, 280.0, 44.0),
+                "Company Footer", 7.5, 44.0)));
+
+            contents.add(pageContents);
+        }
+
+        HeaderFooterProcessor.processHeadersAndFooters(contents, false);
+
+        for (int page = 0; page < 3; page++) {
+            List<IObject> pageContent = contents.get(page);
+            IObject lastElement = pageContent.get(pageContent.size() - 1);
+            Assertions.assertTrue(lastElement instanceof SemanticHeaderOrFooter,
+                "Page " + page + ": last element should be footer");
+            SemanticHeaderOrFooter footer = (SemanticHeaderOrFooter) lastElement;
+            Assertions.assertEquals(SemanticType.FOOTER, footer.getSemanticType());
+            Assertions.assertEquals(2, footer.getContents().size(),
+                "Page " + page + ": footer should contain both close footer lines (gap=11pt < 30pt)");
+        }
+    }
 }


### PR DESCRIPTION
## Objective
Body text that repeats on adjacent pages — such as `※ 출수 중 출수 버튼을 터치하면 출수가 정지됩니다.` on pages 19–20 of the reporter's PDF — is incorrectly classified as footer content, causing it to disappear from Markdown output (#385, parent #354).

## Approach
Add a spatial proximity check in `HeaderFooterProcessor.getNumberOfHeaderOrFooterContentsForEachPage()`. When expanding the footer region upward (or header region downward), the next candidate element must be within 30pt of the previously accepted element. If the gap exceeds this threshold, expansion stops for that page.

This prevents the cross-page pattern matcher from pulling distant body text into the footer just because it happens to repeat across pages.

## Evidence
Converted the reporter's 52-page CERAGEM BALANCE PDF with the fixed JAR:

| Scenario | Before | After |
|----------|--------|-------|
| Page 19 footer height | 100.4pt (2 children) | **9.2pt (1 child)** ✅ |
| Page 20 footer height | 100.4pt (2 children) | **9.2pt (1 child)** ✅ |
| Page 21 footer (control) | 9.2pt (1 child) | 9.2pt (unchanged) ✅ |
| ※ note on page 19 | Missing from MD (absorbed into footer) | **Present as body paragraph** ✅ |
| ※ note on page 20 | Missing from MD (absorbed into footer) | **Present as body paragraph** ✅ |
| ※ note count in full MD | 5 occurrences | **7 occurrences** (2 restored) ✅ |
| Footer text leak in MD | 0 | 0 (no regression) ✅ |
| All other page footers (1–52) | Correctly detected | Correctly detected (no regression) ✅ |
| Unit tests | 34 pass | **35 pass** (1 new) ✅ |

Fixes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header/footer detection with stricter vertical adjacency checks to avoid merging non-adjacent lines.
  * Prevented repeated body text from being misclassified as footer content on multi-page documents.

* **Tests**
  * Added tests validating that close footer lines are grouped and repeated body notes remain as body content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->