### PR TITLE
fix(node): prevent stdout double-write when streamOutput=true in executeJar()

### DIFF
--- a/node/opendataloader-pdf/src/index.ts
+++ b/node/opendataloader-pdf/src/index.ts
@@ -42,8 +42,10 @@ function executeJar(args: string[], executionOptions: JarExecutionOptions = {}):
       const chunk = data.toString();
       if (streamOutput) {
         process.stdout.write(chunk);
+      } else {
+        // Only accumulate when not streaming to avoid double-write by the caller
+        stdout += chunk;
       }
-      stdout += chunk;
     });
 
     javaProcess.stderr.on('data', (data) => {
@@ -56,7 +58,9 @@ function executeJar(args: string[], executionOptions: JarExecutionOptions = {}):
 
     javaProcess.on('close', (code) => {
       if (code === 0) {
-        resolve(stdout);
+        // When streamOutput=true, content was already written to process.stdout in real-time.
+        // Return empty string to prevent callers from double-writing the same output.
+        resolve(streamOutput ? '' : stdout);
       } else {
         const errorOutput = stderr || stdout;
         const error = new Error(

--- a/node/opendataloader-pdf/src/index.ts
+++ b/node/opendataloader-pdf/src/index.ts
@@ -37,11 +37,17 @@ function executeJar(args: string[], executionOptions: JarExecutionOptions = {}):
 
     let stdout = '';
     let stderr = '';
+    let streamedStdoutTail = '';
+    const MAX_STDOUT_TAIL = 64 * 1024;
 
     javaProcess.stdout.on('data', (data) => {
       const chunk = data.toString();
       if (streamOutput) {
         process.stdout.write(chunk);
+        streamedStdoutTail += chunk;
+        if (streamedStdoutTail.length > MAX_STDOUT_TAIL) {
+          streamedStdoutTail = streamedStdoutTail.slice(-MAX_STDOUT_TAIL);
+        }
       } else {
         // Only accumulate when not streaming to avoid double-write by the caller
         stdout += chunk;
@@ -62,7 +68,7 @@ function executeJar(args: string[], executionOptions: JarExecutionOptions = {}):
         // Return empty string to prevent callers from double-writing the same output.
         resolve(streamOutput ? '' : stdout);
       } else {
-        const errorOutput = stderr || stdout;
+        const errorOutput = stderr || (streamOutput ? streamedStdoutTail : stdout);
         const error = new Error(
           `The opendataloader-pdf CLI exited with code ${code}.\n\n${errorOutput}`,
         );


### PR DESCRIPTION
## Summary

Fixes #398

## Problem

In `node/opendataloader-pdf/src/index.ts`, the `executeJar()` function had a bug where output was written to `process.stdout` **twice** when the `quiet` option was not set.

### How the double-write happened

1. `executeJar()` is called with `streamOutput: !options.quiet`
2. When `streamOutput=true`, each data chunk is immediately written to `process.stdout` **AND** accumulated in the `stdout` string
3. The function resolves with the accumulated `stdout` string
4. `cli.ts` receives the resolved value and writes it to `process.stdout` **again**

Result: every line of output appears **twice** for all CLI users who don't pass `--quiet`.

## Fix

When `streamOutput=true`, do **not** accumulate chunks in the `stdout` variable. Instead, return an empty string from the promise (since the output was already streamed in real-time). This prevents the CLI layer from re-writing already-displayed content.

```typescript
// Before (buggy)
javaProcess.stdout.on('data', (data) => {
  const chunk = data.toString();
  if (streamOutput) {
    process.stdout.write(chunk);
  }
  stdout += chunk;  // ← accumulated even when already streamed
});

javaProcess.on('close', (code) => {
  if (code === 0) {
    resolve(stdout);  // ← returned and written again by cli.ts
  }
  ...
});

// After (fixed)
javaProcess.stdout.on('data', (data) => {
  const chunk = data.toString();
  if (streamOutput) {
    process.stdout.write(chunk);
  } else {
    stdout += chunk;  // ← only accumulate when NOT streaming
  }
});

javaProcess.on('close', (code) => {
  if (code === 0) {
    resolve(streamOutput ? '' : stdout);  // ← empty when already streamed
  }
  ...
});
```

## Impact

All CLI users who do not pass `--quiet` previously saw every line of conversion output duplicated. This fix ensures output is written exactly once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved streaming output handling to prevent duplicate console output and reduce resource use.
  * Error messages now include recent program output when available, providing clearer context on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->