### PR TITLE
docs: update collaboration with PDFa

### DIFF
--- a/content/docs/tagged-pdf-collaboration.mdx
+++ b/content/docs/tagged-pdf-collaboration.mdx
@@ -8,7 +8,7 @@ description: Partnering with Dual Lab and veraPDF for Tagged PDF and PDF/UA stan
 <img src="/figures/duallab-logo.webp" alt="Dual Lab" width="160" />
 </div>
 
-[Partner members](https://pdfa.org/member/?wpv-wpcf-member-status=4) of PDF Association
+[Partner members of the PDF Association](https://pdfa.org/member/?wpv-wpcf-member-status=4)
 <div className="flex flex-col md:flex-row justify-center items-center gap-8 mb-8 bg-white p-6 rounded-lg">
 <img src="/figures/pdf-association-logo.webp" alt="PDF Association" width="160" />
 </div>

--- a/content/docs/tagged-pdf-collaboration.mdx
+++ b/content/docs/tagged-pdf-collaboration.mdx
@@ -1,13 +1,18 @@
 ---
 title: Tagged PDF Collaboration
-description: Partnering with PDF Association, Dual Lab, and veraPDF for Tagged PDF and PDF/UA standards
+description: Partnering with Dual Lab and veraPDF for Tagged PDF and PDF/UA standards based on PDF Association specifications and best practice guides
 ---
 
 <div className="flex flex-col md:flex-row justify-center items-center gap-8 mb-8 bg-white p-6 rounded-lg">
-<img src="/figures/pdf-association-logo.webp" alt="PDF Association" width="160" />
 <img src="/figures/hnc-logo.webp" alt="Hancom" width="160" />
 <img src="/figures/duallab-logo.webp" alt="Dual Lab" width="160" />
 </div>
+
+[Partner members](https://pdfa.org/member/?wpv-wpcf-member-status=4) of PDF Association
+<div className="flex flex-col md:flex-row justify-center items-center gap-8 mb-8 bg-white p-6 rounded-lg">
+<img src="/figures/pdf-association-logo.webp" alt="PDF Association" width="160" />
+</div>
+
 
 ## 1. The Growing Importance of Tagged PDF
 
@@ -26,7 +31,7 @@ Lost Context: Flawed tags can cause an AI to misinterpret a document's logical f
 
 ### 2.1. A Collaborative Solution
 
-This challenge presents a unique opportunity for innovation. Hancom and Dual Lab are collaborating with the PDF Association to drive a solution.
+This challenge presents a unique opportunity for innovation. Hancom and Dual Lab are collaborating based on PDF Association specifications and best practice guides to drive a solution.
 
 | Organization    | Role                                                                                                                                            |
 | :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
clarified the role of PDF Association

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified wording to state the collaboration follows PDF Association specifications and best-practice guides.
  * Reorganized partner section: removed the logo from the primary row, added a “Partner members of the PDF Association” link, and placed the PDF Association logo in a dedicated area for clearer hierarchy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->