### PR TITLE
fix: update CID warning hybrid guidance

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
@@ -78,7 +78,7 @@ public class ContentFilterProcessor {
             LOGGER.log(Level.WARNING,
                 "Page {0}: {1,number,#.#%} of characters are replacement characters (U+FFFD). "
                 + "This PDF likely contains CID-keyed fonts without ToUnicode mappings. "
-                + "Text extraction may be incomplete. Consider using --hybrid-mode for OCR fallback.",
+                + "Text extraction may be incomplete. Consider enabling hybrid OCR fallback with --hybrid docling-fast.",
                 new Object[]{pageNumber + 1, replacementCharRatio});
         }
         TextProcessor.replaceUndefinedCharacters(pageContents, config.getReplaceInvalidChars());

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/CidFontDetectionTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/CidFontDetectionTest.java
@@ -120,9 +120,11 @@ public class CidFontDetectionTest {
             );
 
             boolean hasReplacementWarning = warnings.stream()
-                .anyMatch(w -> w.contains("replacement characters"));
+                .anyMatch(w -> w.contains("replacement characters")
+                    && w.contains("--hybrid docling-fast")
+                    && !w.contains("--hybrid-mode for OCR fallback"));
             Assertions.assertTrue(hasReplacementWarning,
-                "Expected WARNING log about replacement characters");
+                "Expected WARNING log about replacement characters with actionable hybrid guidance");
         } finally {
             logger.removeHandler(handler);
         }


### PR DESCRIPTION
## Summary

Update the CID-font replacement-character warning to recommend the current hybrid OCR command instead of the obsolete `--hybrid-mode` flag.

## Reproduction

`ContentFilterProcessor` warns when a page is mostly replacement characters (U+FFFD), but the warning text still pointed users to `--hybrid-mode for OCR fallback`.

## Patch Summary

- change the warning text to recommend `--hybrid docling-fast`
- tighten `CidFontDetectionTest` so it asserts the new guidance and rejects the stale wording

## Risks

Low. This is a message-only correction plus a focused test update.

## Validation

- `cd java && mvn -pl opendataloader-pdf-core -Dtest=CidFontDetectionTest test`

Resolves #404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated warning message to recommend the correct command-line flag for enabling hybrid OCR fallback when replacement character issues are detected.

* **Tests**
  * Updated test to validate the improved warning message guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->