### PR TITLE
Bug Fix

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -325,7 +325,7 @@ public class DocumentProcessor {
                 imagesDirectory = config.getImageDir();
             } else {
                 String fileName = Paths.get(inputPdfName).getFileName().toString();
-                String baseName = fileName.substring(0, fileName.length() - 4);
+                String baseName = fileName.substring(0, fileName.length() - 4).replace(" ", "_");
                 imagesDirectory = config.getOutputFolder() + File.separator + baseName + MarkdownSyntax.IMAGES_DIRECTORY_SUFFIX;
             }
             StaticLayoutContainers.setImagesDirectory(imagesDirectory);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -326,6 +326,9 @@ public class DocumentProcessor {
             } else {
                 String fileName = Paths.get(inputPdfName).getFileName().toString();
                 String baseName = fileName.substring(0, fileName.length() - 4).replace(" ", "_");
++               int dotIndex = fileName.lastIndexOf('.');
++               String rawBaseName = dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;
++               String baseName = rawBaseName.replace(" ", "_");
                 imagesDirectory = config.getOutputFolder() + File.separator + baseName + MarkdownSyntax.IMAGES_DIRECTORY_SUFFIX;
             }
             StaticLayoutContainers.setImagesDirectory(imagesDirectory);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -325,7 +325,6 @@ public class DocumentProcessor {
                 imagesDirectory = config.getImageDir();
             } else {
                 String fileName = Paths.get(inputPdfName).getFileName().toString();
-                String baseName = fileName.substring(0, fileName.length() - 4).replace(" ", "_");
 +               int dotIndex = fileName.lastIndexOf('.');
 +               String rawBaseName = dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;
 +               String baseName = rawBaseName.replace(" ", "_");

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,7 +58,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <verapdf.version>[1.31.0,1.32.0-RC]</verapdf.version>
+        <verapdf.version>[1.31.0,1.32.0-RC)</verapdf.version>
         <junit.jupiter.version>5.14.3</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>
         <commons.cli.version>1.11.0</commons.cli.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,7 +58,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <verapdf.version>[1.31.0,1.32.0-RC)</verapdf.version>
+        <verapdf.version>[1.31.0,1.32.0-RC]</verapdf.version>
         <junit.jupiter.version>5.14.3</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>
         <commons.cli.version>1.11.0</commons.cli.version>


### PR DESCRIPTION
I have addressed the issue where images extracted from PDFs with filenames containing spaces fail to render in Markdown format.

Following your suggestion, I updated DocumentProcessor.java to replace spaces with underscores in the image directory name before it is assigned to StaticLayoutContainers.

This ensures both the output directory and referenced paths use consistent naming (for example, my_paper_images instead of my paper_images), which resolves the broken links without requiring separate URL encoding logic for Markdown or HTML generators.

I also verified that the project compiles successfully after the change.

Please let me know if any additional changes or testing are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image output directory names now preserve filename stems (handles names without extensions) and replace spaces with underscores to avoid malformed image folders when no custom image directory is set.

* **Chores**
  * Adjusted a dependency version range for improved resolution and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->