### PR TITLE
  feat: add --dry-run flag to preview extraction without writing files

### DIFF
--- a/content/docs/cli-options-reference.mdx
+++ b/content/docs/cli-options-reference.mdx
@@ -39,6 +39,7 @@ This page documents all available CLI options for opendataloader-pdf.
 | `--hybrid-timeout`          | -     | `string`  | `"0"`        | Hybrid backend request timeout in milliseconds (0 = no timeout). Default: 0                                                                                                                                          |
 | `--hybrid-fallback`         | -     | `boolean` | `false`      | Opt in to Java fallback on hybrid backend error (default: disabled)                                                                                                                                                  |
 | `--to-stdout`               | -     | `boolean` | `false`      | Write output to stdout instead of file (single format only)                                                                                                                                                          |
+| `--dry-run`                 | -     | `boolean` | `false`      | Parse and analyze the PDF without writing any output files. Prints a summary of page count, element count, reading order, table method, output formats, and output directory.                                        |
 
 ## Examples
 

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
@@ -140,6 +140,11 @@ public class CLIOptions {
     private static final String TO_STDOUT_LONG_OPTION = "to-stdout";
     private static final String TO_STDOUT_DESC = "Write output to stdout instead of file (single format only)";
 
+    // ===== Dry Run =====
+    private static final String DRY_RUN_LONG_OPTION = "dry-run";
+    private static final String DRY_RUN_DESC = "Parse and analyze the PDF without writing any output files. "
+            + "Prints a summary of what would be extracted (page count, element count, output formats)";
+
     // ===== Export Options (internal) =====
     public static final String EXPORT_OPTIONS_LONG_OPTION = "export-options";
 
@@ -188,6 +193,7 @@ public class CLIOptions {
             new OptionDefinition(HYBRID_TIMEOUT_LONG_OPTION, null, "string", "0", HYBRID_TIMEOUT_DESC, true),
             new OptionDefinition(HYBRID_FALLBACK_LONG_OPTION, null, "boolean", false, HYBRID_FALLBACK_DESC, true),
             new OptionDefinition(TO_STDOUT_LONG_OPTION, null, "boolean", false, TO_STDOUT_DESC, true),
+            new OptionDefinition(DRY_RUN_LONG_OPTION, null, "boolean", false, DRY_RUN_DESC, true),
             new OptionDefinition(EXPORT_OPTIONS_LONG_OPTION, null, "boolean", null, null, false),
 
             // Legacy options (not exported, for backward compatibility)
@@ -516,6 +522,9 @@ public class CLIOptions {
         }
         if (commandLine.hasOption(TO_STDOUT_LONG_OPTION)) {
             config.setOutputStdout(true);
+        }
+        if (commandLine.hasOption(DRY_RUN_LONG_OPTION)) {
+            config.setDryRun(true);
         }
     }
 

--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIOptionsTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIOptionsTest.java
@@ -464,4 +464,29 @@ class CLIOptionsTest {
         assertTrue(config.getHybridConfig().isFallbackToJava(),
             "hybrid fallback should be enabled when explicitly passed");
     }
+
+    @Test
+    void testDefineOptions_containsDryRunOption() {
+        assertTrue(options.hasOption("dry-run"));
+    }
+
+    @Test
+    void testCreateConfig_dryRunDefaultsFalse() throws ParseException {
+        String[] args = {testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertFalse(config.isDryRun(), "dry-run should be false by default");
+    }
+
+    @Test
+    void testCreateConfig_withDryRun() throws ParseException {
+        String[] args = {"--dry-run", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertTrue(config.isDryRun(), "dry-run should be true when flag is passed");
+    }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -865,6 +865,16 @@ public class Config {
         this.outputStdout = outputStdout;
     }
 
+    private boolean dryRun = false;
+
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+
     /**
      * Returns true if any output format requires structured content
      * (reading order, heading levels, list detection, etc.).

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -300,6 +300,12 @@ public class DocumentProcessor {
     }
 
     private static void generateOutputs(String inputPdfName, List<List<IObject>> contents, Config config) throws IOException {
+        // Dry-run mode: print extraction summary, skip all file I/O
+        if (config.isDryRun()) {
+            printDryRunSummary(inputPdfName, contents, config);
+            return;
+        }
+
         // Stdout mode: write primary format to stdout, skip file I/O
         if (config.isOutputStdout()) {
             java.io.Writer stdoutWriter = new java.io.BufferedWriter(
@@ -355,6 +361,32 @@ public class DocumentProcessor {
                 textGenerator.writeToText(contents);
             }
         }
+    }
+
+    private static void printDryRunSummary(String inputPdfName, List<List<IObject>> contents, Config config) {
+        int totalPages = StaticContainers.getDocument().getNumberOfPages();
+        int processedPages = contents.size();
+        int totalElements = contents.stream().mapToInt(List::size).sum();
+
+        List<String> formats = new java.util.ArrayList<>();
+        if (config.isGenerateJSON()) formats.add("json");
+        if (config.isGenerateMarkdown()) formats.add("markdown");
+        if (config.isGenerateHtml()) formats.add("html");
+        if (config.isGenerateText()) formats.add("text");
+        if (config.isGeneratePDF()) formats.add("pdf");
+
+        String pagesDesc = (config.getPages() != null && !config.getPages().isEmpty())
+                ? config.getPages() + " (" + processedPages + " pages)"
+                : "all (" + totalPages + " pages)";
+
+        System.out.println("[dry-run] " + inputPdfName);
+        System.out.println("  Pages:         " + pagesDesc);
+        System.out.println("  Elements:      " + totalElements);
+        System.out.println("  Reading order: " + config.getReadingOrder());
+        System.out.println("  Table method:  " + config.getTableMethod());
+        System.out.println("  Formats:       " + (formats.isEmpty() ? "(none)" : String.join(", ", formats)));
+        System.out.println("  Output dir:    " + config.getOutputFolder());
+        System.out.println("No files written.");
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -93,7 +93,7 @@ public class DocumentProcessor {
         ContentSanitizer contentSanitizer = new ContentSanitizer(config.getFilterConfig().getFilterRules(),
             config.getFilterConfig().isFilterSensitiveData());
         contentSanitizer.sanitizeContents(contents);
-        generateOutputs(inputPdfName, contents, config);
+        generateOutputs(inputPdfName, contents, config, pagesToProcess);
     }
 
     /**
@@ -299,10 +299,10 @@ public class DocumentProcessor {
         return pagesToProcess == null || pagesToProcess.contains(pageNumber);
     }
 
-    private static void generateOutputs(String inputPdfName, List<List<IObject>> contents, Config config) throws IOException {
+    private static void generateOutputs(String inputPdfName, List<List<IObject>> contents, Config config, Set<Integer> pagesToProcess) throws IOException {
         // Dry-run mode: print extraction summary, skip all file I/O
         if (config.isDryRun()) {
-            printDryRunSummary(inputPdfName, contents, config);
+            printDryRunSummary(inputPdfName, contents, config, pagesToProcess);
             return;
         }
 
@@ -363,9 +363,9 @@ public class DocumentProcessor {
         }
     }
 
-    private static void printDryRunSummary(String inputPdfName, List<List<IObject>> contents, Config config) {
+    private static void printDryRunSummary(String inputPdfName, List<List<IObject>> contents, Config config, Set<Integer> pagesToProcess) {
         int totalPages = StaticContainers.getDocument().getNumberOfPages();
-        int processedPages = contents.size();
+        int processedPages = pagesToProcess == null ? totalPages : pagesToProcess.size();
         int totalElements = contents.stream().mapToInt(List::size).sum();
 
         List<String> formats = new java.util.ArrayList<>();

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -33,4 +33,5 @@ export function registerCliOptions(program: Command): void {
   program.option('--hybrid-timeout <value>', 'Hybrid backend request timeout in milliseconds (0 = no timeout). Default: 0');
   program.option('--hybrid-fallback', 'Opt in to Java fallback on hybrid backend error (default: disabled)');
   program.option('--to-stdout', 'Write output to stdout instead of file (single format only)');
+  program.option('--dry-run', 'Parse and analyze the PDF without writing any output files. Prints a summary of what would be extracted (page count, element count, output formats)');
 }

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -57,6 +57,8 @@ export interface ConvertOptions {
   hybridFallback?: boolean;
   /** Write output to stdout instead of file (single format only) */
   toStdout?: boolean;
+  /** Parse and analyze the PDF without writing any output files. Prints a summary of what would be extracted (page count, element count, output formats) */
+  dryRun?: boolean;
 }
 
 /**
@@ -89,6 +91,7 @@ export interface CliOptions {
   hybridTimeout?: string;
   hybridFallback?: boolean;
   toStdout?: boolean;
+  dryRun?: boolean;
 }
 
 /**
@@ -174,6 +177,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.toStdout) {
     convertOptions.toStdout = true;
+  }
+  if (cliOptions.dryRun) {
+    convertOptions.dryRun = true;
   }
 
   return convertOptions;
@@ -274,6 +280,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.toStdout) {
     args.push('--to-stdout');
+  }
+  if (options.dryRun) {
+    args.push('--dry-run');
   }
 
   return args;

--- a/options.json
+++ b/options.json
@@ -207,6 +207,14 @@
       "required": false,
       "default": false,
       "description": "Write output to stdout instead of file (single format only)"
+    },
+    {
+      "name": "dry-run",
+      "shortName": null,
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "description": "Parse and analyze the PDF without writing any output files. Prints a summary of what would be extracted (page count, element count, output formats)"
     }
   ]
 }

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -243,6 +243,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "default": False,
         "description": "Write output to stdout instead of file (single format only)",
     },
+    {
+        "name": "dry-run",
+        "python_name": "dry_run",
+        "short_name": None,
+        "type": "boolean",
+        "required": False,
+        "default": False,
+        "description": "Parse and analyze the PDF without writing any output files. Prints a summary of what would be extracted (page count, element count, output formats)",
+    },
 ]
 
 


### PR DESCRIPTION
  Adds a --dry-run CLI option that runs the full PDF parsing and extraction
  pipeline but skips all file I/O. Instead it prints a summary to stdout:
  page count, element count, reading order, table method, output formats,
  and the output directory that would have been used.

  Useful for validating extraction settings and debugging without
  polluting the filesystem or needing to clean up afterward.

  - Config: dryRun field + isDryRun() / setDryRun()
  - CLIOptions: --dry-run option definition (exported), wired into createConfigFromCommandLine()
  - DocumentProcessor: early return in generateOutputs() + printDryRunSummary()
  - Synced options.json and generated Python / Node.js bindings
  - CLIOptionsTest: three unit tests covering default, flag present, option registered

<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` CLI option to preview PDF analysis without writing output files.
  * Dry-run displays a summary: page count, element count, reading order, table method, output formats, and output folder.

* **Documentation**
  * CLI reference updated with `--dry-run` description and behavior.

* **Tests**
  * Added unit tests validating `--dry-run` option presence and Config behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->