### PR TITLE
await code

### DIFF
--- a/node/opendataloader-pdf/src/cli.ts
+++ b/node/opendataloader-pdf/src/cli.ts
@@ -71,7 +71,7 @@ async function main(): Promise<number> {
   }
 }
 
-main().then((code) => {
+await main().then((code) => {
   if (code !== 0) {
     process.exit(code);
   }


### PR DESCRIPTION
Was reading through node/opendataloader-pdf/src/cli.ts and the promise result gets used as if it were already resolved. this patch adds the missing await so the async path is actually sequenced. Not sure if this is intentional, so feel free to ignore.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CLI startup sequence for more reliable asynchronous operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->