### PR TITLE
build: add conda-forge recipe for opendataloader-pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ key-differentiators: [benchmark #1 PDF parser, deterministic output, bounding bo
 > Before you start: run `java -version`. If not found, install JDK 11+ from [Adoptium](https://adoptium.net/).
 
 ```bash
+# pip
 pip install -U opendataloader-pdf
+
+# conda / mamba (installs Java automatically)
+conda install -c conda-forge opendataloader-pdf
 ```
 
 ```python

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# conda-forge build script for opendataloader-pdf
+# Builds the Java CLI JAR, then installs the Python wrapper.
+
+set -euo pipefail
+
+# PKG_VERSION is automatically set by conda-build from meta.yaml's version field.
+
+# ------------------------------------------------------------------
+# 1. Set the Maven version to match the conda package version
+# ------------------------------------------------------------------
+cd "${SRC_DIR}/java"
+mvn -B versions:set -DnewVersion="${PKG_VERSION}" -DgenerateBackupPoms=false
+
+# ------------------------------------------------------------------
+# 2. Build the Java CLI JAR (skip tests — covered upstream in CI)
+# ------------------------------------------------------------------
+mvn -B clean package -DskipTests -P release
+
+# ------------------------------------------------------------------
+# 3. Pin the Python package version and install
+# ------------------------------------------------------------------
+cd "${SRC_DIR}/python/opendataloader-pdf"
+sed -i "s/^version = \"[^\"]*\"/version = \"${PKG_VERSION}\"/" pyproject.toml
+
+# The hatch_build.py hook detects the JAR in java/target/ and copies it
+# into src/opendataloader_pdf/jar/ automatically during the pip install.
+"${PYTHON}" -m pip install . \
+    --no-deps \
+    --no-build-isolation \
+    -vv

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "opendataloader-pdf" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/opendataloader-project/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  # Run the following to get the sha256 after the release tag exists:
+  #   curl -sL https://github.com/opendataloader-project/opendataloader-pdf/archive/refs/tags/v0.1.0.tar.gz | sha256sum
+  sha256: PLACEHOLDER_FILL_IN_AFTER_TAGGING
+
+build:
+  noarch: python
+  number: 0
+
+requirements:
+  build:
+    - maven >=3.8
+    - openjdk >=11
+  host:
+    - python >=3.10
+    - pip
+    - hatchling >=1.0
+  run:
+    - python >=3.10
+    - openjdk >=11
+
+test:
+  imports:
+    - opendataloader_pdf
+  commands:
+    - pip check
+    - opendataloader-pdf --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/opendataloader-project/opendataloader-pdf
+  summary: High-performance PDF to Markdown/HTML/JSON converter — Python wrapper for the OpenDataLoader PDF Java CLI
+  description: |
+    OpenDataLoader PDF converts PDF files into structured formats (Markdown, HTML, JSON)
+    via a bundled Java CLI. The Python package wraps the CLI and provides both a
+    programmatic API and a command-line entry point. Java 11+ is required at runtime.
+  license: Apache-2.0
+  license_file: LICENSE
+  doc_url: https://opendataloader.org
+  dev_url: https://github.com/opendataloader-project/opendataloader-pdf
+
+extra:
+  recipe-maintainers:
+    - opendataloader-project


### PR DESCRIPTION
Add `conda.recipe/meta.yaml` and `conda.recipe/build.sh` to enable
publishing the package to the conda-forge channel, and update the
README to include the `conda install` command alongside the existing
`pip install` instructions.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary. _(not applicable)_
- [ ] Tests have been added, if necessary. _(not applicable)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions with explicit pip and conda/mamba installation commands for clearer environment setup.

* **New Features**
  * Added conda package support, enabling installation via conda and mamba package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->