### PR TITLE
feat: auto-tagging — generate tagged PDFs with structure tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Generate reference docs
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         run: |
+          mkdir -p content/docs/reference
           node scripts/generate-options.mjs
           node scripts/generate-schema.mjs
 

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -16,10 +16,8 @@
 package org.opendataloader.pdf.cli;
 
 import org.apache.commons.cli.*;
-import org.opendataloader.pdf.api.AutoTagger;
 import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.api.OpenDataLoaderPDF;
-import org.opendataloader.pdf.api.TaggingResult;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
 
 import java.io.File;
@@ -71,36 +69,6 @@ public class CLIMain {
         }
 
         String[] arguments = commandLine.getArgs();
-
-        // Handle --format tagged-pdf as a standalone format before normal processing
-        String format = commandLine.getOptionValue(CLIOptions.FORMAT_LONG_OPTION);
-        if (format != null && format.trim().equalsIgnoreCase("tagged-pdf")) {
-            Config tagConfig;
-            try {
-                tagConfig = CLIOptions.createConfigFromCommandLine(commandLine);
-            } catch (IllegalArgumentException exception) {
-                System.out.println(exception.getMessage());
-                formatter.printHelp(HELP, options);
-                return 2;
-            }
-            for (String argument : arguments) {
-                try (TaggingResult result = AutoTagger.tag(argument, tagConfig)) {
-                    String baseName = new File(argument).getName();
-                    int dotIndex = baseName.lastIndexOf('.');
-                    baseName = dotIndex > 0 ? baseName.substring(0, dotIndex) : baseName;
-                    String outputDir = tagConfig.getOutputFolder() != null && !tagConfig.getOutputFolder().isEmpty()
-                            ? tagConfig.getOutputFolder()
-                            : new File(argument).getParent();
-                    new File(outputDir).mkdirs();
-                    result.saveTo(outputDir + File.separator + baseName + "_tagged.pdf");
-                } catch (Exception exception) {
-                    LOGGER.log(Level.SEVERE, "Exception during tagged-pdf processing of " + argument + ": " +
-                            exception.getMessage(), exception);
-                }
-            }
-            AutoTagger.shutdown();
-            return 0;
-        }
 
         Config config;
         boolean quiet;

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -16,8 +16,10 @@
 package org.opendataloader.pdf.cli;
 
 import org.apache.commons.cli.*;
+import org.opendataloader.pdf.api.AutoTagger;
 import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.api.OpenDataLoaderPDF;
+import org.opendataloader.pdf.api.TaggingResult;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
 
 import java.io.File;
@@ -69,6 +71,40 @@ public class CLIMain {
         }
 
         String[] arguments = commandLine.getArgs();
+
+        // Handle --format tagged-pdf as a standalone format before normal processing
+        String format = commandLine.getOptionValue(CLIOptions.FORMAT_LONG_OPTION);
+        if (format != null && format.contains("tagged-pdf")) {
+            if (format.contains(",")) {
+                System.err.println("Error: --format tagged-pdf cannot be combined with other formats.");
+                System.exit(1);
+            }
+            Config tagConfig;
+            try {
+                tagConfig = CLIOptions.createConfigFromCommandLine(commandLine);
+            } catch (IllegalArgumentException exception) {
+                System.out.println(exception.getMessage());
+                formatter.printHelp(HELP, options);
+                return 2;
+            }
+            for (String argument : arguments) {
+                try (TaggingResult result = AutoTagger.tag(argument, tagConfig)) {
+                    String baseName = new File(argument).getName();
+                    baseName = baseName.substring(0, baseName.length() - 4);
+                    String outputDir = tagConfig.getOutputFolder() != null && !tagConfig.getOutputFolder().isEmpty()
+                            ? tagConfig.getOutputFolder()
+                            : new File(argument).getParent();
+                    new File(outputDir).mkdirs();
+                    result.saveTo(outputDir + File.separator + baseName + "_tagged.pdf");
+                } catch (Exception exception) {
+                    LOGGER.log(Level.SEVERE, "Exception during tagged-pdf processing of " + argument + ": " +
+                            exception.getMessage(), exception);
+                }
+            }
+            AutoTagger.shutdown();
+            return 0;
+        }
+
         Config config;
         boolean quiet;
         try {

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -74,11 +74,7 @@ public class CLIMain {
 
         // Handle --format tagged-pdf as a standalone format before normal processing
         String format = commandLine.getOptionValue(CLIOptions.FORMAT_LONG_OPTION);
-        if (format != null && format.contains("tagged-pdf")) {
-            if (format.contains(",")) {
-                System.err.println("Error: --format tagged-pdf cannot be combined with other formats.");
-                System.exit(1);
-            }
+        if (format != null && format.trim().equalsIgnoreCase("tagged-pdf")) {
             Config tagConfig;
             try {
                 tagConfig = CLIOptions.createConfigFromCommandLine(commandLine);
@@ -90,7 +86,8 @@ public class CLIMain {
             for (String argument : arguments) {
                 try (TaggingResult result = AutoTagger.tag(argument, tagConfig)) {
                     String baseName = new File(argument).getName();
-                    baseName = baseName.substring(0, baseName.length() - 4);
+                    int dotIndex = baseName.lastIndexOf('.');
+                    baseName = dotIndex > 0 ? baseName.substring(0, dotIndex) : baseName;
                     String outputDir = tagConfig.getOutputFolder() != null && !tagConfig.getOutputFolder().isEmpty()
                             ? tagConfig.getOutputFolder()
                             : new File(argument).getParent();

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
@@ -433,7 +433,7 @@ public class CLIOptions {
                     config.setAddImageToMarkdown(true);
                     break;
                 case "tagged-pdf":
-                    // Handled as a standalone format in CLIMain before config creation
+                    config.setGenerateTaggedPDF(true);
                     break;
                 default:
                     throw new IllegalArgumentException(String.format(

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
@@ -43,9 +43,9 @@ public class CLIOptions {
 
     // ===== Format =====
     public static final String FORMAT_OPTION = "f";
-    private static final String FORMAT_LONG_OPTION = "format";
+    public static final String FORMAT_LONG_OPTION = "format";
     private static final String FORMAT_DESC = "Output formats (comma-separated). "
-            + "Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images. Default: json";
+            + "Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images, tagged-pdf. Default: json";
 
     // ===== Quiet =====
     public static final String QUIET_OPTION = "q";
@@ -398,13 +398,13 @@ public class CLIOptions {
         String[] optionValues = commandLine.getOptionValues(FORMAT_OPTION);
         if (optionValues == null || optionValues.length == 0) {
             throw new IllegalArgumentException(
-                    "Option --format requires at least one value. Supported values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images");
+                    "Option --format requires at least one value. Supported values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images, tagged-pdf");
         }
 
         Set<String> values = parseOptionValues(optionValues);
         if (values.isEmpty()) {
             throw new IllegalArgumentException(
-                    "Option --format requires at least one value. Supported values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images");
+                    "Option --format requires at least one value. Supported values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images, tagged-pdf");
         }
 
         config.setGenerateJSON(false);
@@ -432,9 +432,12 @@ public class CLIOptions {
                 case "markdown-with-images":
                     config.setAddImageToMarkdown(true);
                     break;
+                case "tagged-pdf":
+                    // Handled as a standalone format in CLIMain before config creation
+                    break;
                 default:
                     throw new IllegalArgumentException(String.format(
-                            "Unsupported format '%s'. Supported values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images",
+                            "Unsupported format '%s'. Supported values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images, tagged-pdf",
                             value));
             }
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/AutoTagger.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/AutoTagger.java
@@ -60,11 +60,22 @@ public final class AutoTagger {
      * @throws IOException if unable to read or process the PDF
      */
     public static TaggingResult tag(String inputPdf, Config config) throws IOException {
-        // extractContents() handles structured processing internally;
-        // no need to mutate the caller's config — output flags are not used.
         ExtractionResult extraction = DocumentProcessor.extractContents(inputPdf, config);
+        return tag(inputPdf, extraction);
+    }
 
-        // Tagging (no save)
+    /**
+     * Tag a PDF document from a previously computed {@link ExtractionResult}.
+     * Use this when you need both tagged PDF and other output formats from the
+     * same extraction — call {@link DocumentProcessor#extractContents} once,
+     * then pass the result here and to other output generators.
+     *
+     * @param inputPdf   path to the input PDF file (used for metadata)
+     * @param extraction pre-computed extraction result
+     * @return result containing the tagged PDDocument and timing metadata
+     * @throws IOException if unable to tag the document
+     */
+    public static TaggingResult tag(String inputPdf, ExtractionResult extraction) throws IOException {
         long t0 = System.nanoTime();
         PDDocument document = StaticResources.getDocument();
         AutoTaggingProcessor.tagDocument(new File(inputPdf), document, extraction.getContents());

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/AutoTagger.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/AutoTagger.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.api;
+
+import org.opendataloader.pdf.processors.AutoTaggingProcessor;
+import org.opendataloader.pdf.processors.DocumentProcessor;
+import org.opendataloader.pdf.processors.ExtractionResult;
+import org.verapdf.pd.PDDocument;
+import org.verapdf.tools.StaticResources;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Public API for standalone PDF auto-tagging.
+ *
+ * <p>Returns an in-memory tagged {@link PDDocument} without writing intermediate files.
+ * Use {@link OpenDataLoaderPDF#processFile} for the full extraction + output pipeline.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * Config config = new Config();
+ * config.setHybrid("docling-fast");
+ *
+ * try (TaggingResult result = AutoTagger.tag("input.pdf", config)) {
+ *     PDDocument tagged = result.getDocument();
+ *     // use tagged document...
+ *     result.saveTo("output_tagged.pdf");
+ * }
+ * AutoTagger.shutdown();
+ * }</pre>
+ */
+public final class AutoTagger {
+
+    private AutoTagger() {
+    }
+
+    /**
+     * Extract content from a PDF and produce a tagged PDF document in-memory.
+     * Output format flags in config are ignored — this method only produces
+     * a tagged PDDocument.
+     *
+     * @param inputPdf path to the input PDF file
+     * @param config   configuration (extraction + hybrid fields are used;
+     *                 output format flags are ignored)
+     * @return result containing the tagged PDDocument and timing metadata
+     * @throws IOException if unable to read or process the PDF
+     */
+    public static TaggingResult tag(String inputPdf, Config config) throws IOException {
+        // Force tag-only mode
+        config.setGenerateJSON(false);
+        config.setGenerateMarkdown(false);
+        config.setGenerateHtml(false);
+        config.setGenerateText(false);
+        config.setGeneratePDF(false);
+
+        // Extraction
+        ExtractionResult extraction = DocumentProcessor.extractContents(inputPdf, config);
+
+        // Tagging (no save)
+        long t0 = System.nanoTime();
+        PDDocument document = StaticResources.getDocument();
+        AutoTaggingProcessor.tagDocument(new File(inputPdf), document, extraction.getContents());
+        long taggingNs = System.nanoTime() - t0;
+
+        return new TaggingResult(document, extraction.getExtractionNs(), taggingNs,
+            extraction.getHybridTimings());
+    }
+
+    /**
+     * Release hybrid client resources. Call when processing is complete.
+     */
+    public static void shutdown() {
+        OpenDataLoaderPDF.shutdown();
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/AutoTagger.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/AutoTagger.java
@@ -60,14 +60,8 @@ public final class AutoTagger {
      * @throws IOException if unable to read or process the PDF
      */
     public static TaggingResult tag(String inputPdf, Config config) throws IOException {
-        // Force tag-only mode
-        config.setGenerateJSON(false);
-        config.setGenerateMarkdown(false);
-        config.setGenerateHtml(false);
-        config.setGenerateText(false);
-        config.setGeneratePDF(false);
-
-        // Extraction
+        // extractContents() handles structured processing internally;
+        // no need to mutate the caller's config — output flags are not used.
         ExtractionResult extraction = DocumentProcessor.extractContents(inputPdf, config);
 
         // Tagging (no save)

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -63,6 +63,7 @@ public class Config {
     private boolean keepLineBreaks = false;
     private boolean isGenerateJSON = true;
     private boolean isGenerateText = false;
+    private boolean isGenerateTaggedPDF = false;
     private boolean useStructTree = false;
     private boolean useHTMLInMarkdown = false;
     private boolean addImageToMarkdown = false;
@@ -265,6 +266,14 @@ public class Config {
      */
     public void setGenerateText(boolean generateText) {
         isGenerateText = generateText;
+    }
+
+    public boolean isGenerateTaggedPDF() {
+        return isGenerateTaggedPDF;
+    }
+
+    public void setGenerateTaggedPDF(boolean generateTaggedPDF) {
+        isGenerateTaggedPDF = generateTaggedPDF;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/TaggingResult.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/TaggingResult.java
@@ -21,6 +21,9 @@ public class TaggingResult implements AutoCloseable {
     private final JsonNode hybridTimings;
 
     public TaggingResult(PDDocument document, long extractionNs, long taggingNs, JsonNode hybridTimings) {
+        if (document == null) {
+            throw new IllegalArgumentException("document must not be null");
+        }
         this.document = document;
         this.extractionNs = extractionNs;
         this.taggingNs = taggingNs;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/TaggingResult.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/TaggingResult.java
@@ -1,0 +1,65 @@
+package org.opendataloader.pdf.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.verapdf.pd.PDDocument;
+
+import java.io.IOException;
+
+/**
+ * Result of {@link AutoTagger#tag}. Contains the tagged PDF document in-memory
+ * and processing timing metadata.
+ *
+ * <p>Implements {@link AutoCloseable} for use with try-with-resources.
+ * The caller is responsible for closing this result, which releases the
+ * underlying PDDocument resources.
+ */
+public class TaggingResult implements AutoCloseable {
+
+    private final PDDocument document;
+    private final long extractionNs;
+    private final long taggingNs;
+    private final JsonNode hybridTimings;
+
+    public TaggingResult(PDDocument document, long extractionNs, long taggingNs, JsonNode hybridTimings) {
+        this.document = document;
+        this.extractionNs = extractionNs;
+        this.taggingNs = taggingNs;
+        this.hybridTimings = hybridTimings;
+    }
+
+    /** The tagged PDF document. Do not close this directly — close the TaggingResult instead. */
+    public PDDocument getDocument() {
+        return document;
+    }
+
+    /** Time spent on extraction (parsing + layout + content extraction) in nanoseconds. */
+    public long getExtractionNs() {
+        return extractionNs;
+    }
+
+    /** Time spent on auto-tagging (structure tree creation) in nanoseconds. */
+    public long getTaggingNs() {
+        return taggingNs;
+    }
+
+    /** Per-step hybrid server timings, or null if hybrid mode was not used. */
+    public JsonNode getHybridTimings() {
+        return hybridTimings;
+    }
+
+    /**
+     * Save the tagged PDF to a file.
+     *
+     * @param outputPath the output file path
+     */
+    public void saveTo(String outputPath) throws IOException {
+        document.saveAs(outputPath);
+    }
+
+    @Override
+    public void close() {
+        if (document != null) {
+            document.close();
+        }
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -1,7 +1,6 @@
 package org.opendataloader.pdf.autotagging;
 
 import org.opendataloader.pdf.processors.AutoTaggingProcessor;
-import org.opendataloader.pdf.processors.PDFStreamWriter;
 import org.verapdf.as.ASAtom;
 import org.verapdf.as.io.ASInputStream;
 import org.verapdf.cos.*;
@@ -26,6 +25,8 @@ import java.io.InputStream;
 import java.util.*;
 
 public class ChunksWriter {
+
+    private static final java.util.logging.Logger CHUNKS_LOGGER = java.util.logging.Logger.getLogger(ChunksWriter.class.getName());
 
     private final ResourceHandler resourceHandler;
     private final GraphicsState graphicsState;
@@ -163,8 +164,6 @@ public class ChunksWriter {
         }
     }
 
-    private static final java.util.logging.Logger CHUNKS_LOGGER = java.util.logging.Logger.getLogger(ChunksWriter.class.getName());
-
     private static String getStructureType(Integer mcid, OperatorStreamKey operatorStreamKey) {
         if (mcid == null || operatorStreamKey == null) return null;
         List<COSObject> parents = AutoTaggingProcessor.getStructParents().get(operatorStreamKey);
@@ -226,11 +225,13 @@ public class ChunksWriter {
             if (!array.isEmpty()) {
                 StreamInfo peekInfo = streamInfoQueue.peek();
                 COSObject target = peekInfo != null ? map.get(peekInfo) : null;
-                if (target != null && target.get() instanceof COSArray) {
+                if (target != null && target.getType() == COSObjType.COS_ARRAY) {
                     COSArray currentArray = (COSArray) target.get();
                     for (COSObject element : array) {
                         currentArray.add(element);
                     }
+                } else {
+                    CHUNKS_LOGGER.warning("Issue during text operator processing");
                 }
             }
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -88,6 +88,10 @@ public class ChunksWriter {
                         && xObjectStructParent != null) {
                     COSName xObjectName = getLastCOSName(arguments);
                     PDXObject pdxObject = resourceHandler.getXObject(xObjectName);
+                    if (pdxObject == null) {
+                        processContentOperator(result, rawOperator, arguments, operatorIndex, operatorIndexesToStreamInfosMap, operatorName, operatorStreamKey);
+                        break;
+                    }
                     pdxObject.setKey(ASAtom.STRUCT_PARENTS,
                         COSInteger.construct(xObjectStructParent));
                     StaticResources.getDocument().getDocument().addChangedObject(pdxObject.getObject());

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -223,9 +223,13 @@ public class ChunksWriter {
                 }
             }
             if (!array.isEmpty()) {
-                COSArray currentArray = ((COSArray)map.get(streamInfoQueue.peek()).get());
-                for (COSObject element : array) {
-                    currentArray.add(element);
+                StreamInfo peekInfo = streamInfoQueue.peek();
+                COSObject target = peekInfo != null ? map.get(peekInfo) : null;
+                if (target != null && target.get() instanceof COSArray) {
+                    COSArray currentArray = (COSArray) target.get();
+                    for (COSObject element : array) {
+                        currentArray.add(element);
+                    }
                 }
             }
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -1,0 +1,279 @@
+package org.opendataloader.pdf.autotagging;
+
+import org.opendataloader.pdf.processors.AutoTaggingProcessor;
+import org.opendataloader.pdf.processors.PDFStreamWriter;
+import org.verapdf.as.ASAtom;
+import org.verapdf.as.io.ASInputStream;
+import org.verapdf.cos.*;
+import org.verapdf.gf.model.factory.chunks.ChunkParser;
+import org.verapdf.gf.model.factory.chunks.GraphicsState;
+import org.verapdf.gf.model.impl.sa.util.ResourceHandler;
+import org.verapdf.operator.Operator;
+import org.verapdf.parser.Operators;
+import org.verapdf.parser.PDFStreamParser;
+import org.verapdf.pd.PDContentStream;
+import org.verapdf.pd.PDExtGState;
+import org.verapdf.pd.images.PDXForm;
+import org.verapdf.pd.images.PDXObject;
+import org.verapdf.tools.StaticResources;
+import org.verapdf.tools.TaggedPDFConstants;
+import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
+import org.verapdf.wcag.algorithms.semanticalgorithms.utils.StreamInfo;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+public class ChunksWriter {
+
+    private final ResourceHandler resourceHandler;
+    private final GraphicsState graphicsState;
+
+    public ChunksWriter(GraphicsState inheritedGraphicState, ResourceHandler resourceHandler) {
+        this.graphicsState = inheritedGraphicState.clone();
+        this.resourceHandler = resourceHandler;
+    }
+
+    public static List<Object> getTokens(PDContentStream pdContentStream) {
+        if (pdContentStream != null) {
+            try {
+                COSObject contentStream = pdContentStream.getContents();
+                if (contentStream.getType() == COSObjType.COS_STREAM || contentStream.getType() == COSObjType.COS_ARRAY) {
+                    try (ASInputStream opStream = contentStream.getDirectBase().getData(COSStream.FilterFlags.DECODE)) {
+                        try (PDFStreamParser streamParser = new PDFStreamParser(opStream)) {
+                            streamParser.parseTokens();
+                            return streamParser.getTokens();
+                        }
+                    }
+                }
+            } catch (IOException e) {
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    public List<Object> processTokens(List<Object> processTokens, OperatorStreamKey operatorStreamKey) throws IOException {
+        Map<Integer, Set<StreamInfo>> operatorIndexesToStreamInfosMap = AutoTaggingProcessor.getOperatorIndexesToStreamInfosMap().get(operatorStreamKey);
+        List<Object> result = new ArrayList<>();
+        List<COSBase> arguments = new ArrayList<>();
+        for (int index = 0; index < processTokens.size(); index++) {
+            Object token = processTokens.get(index);
+            if (token instanceof COSBase) {
+                arguments.add((COSBase) token);
+            } else if (token instanceof Operator) {
+                processOperator(result, (Operator)token, arguments, index, operatorIndexesToStreamInfosMap, operatorStreamKey);
+                arguments.clear();
+            }
+        }
+        return result;
+    }
+
+    private void processOperator(List<Object> result, Operator rawOperator, List<COSBase> arguments, int operatorIndex,
+                                 Map<Integer, Set<StreamInfo>> operatorIndexesToStreamInfosMap,
+                                 OperatorStreamKey operatorStreamKey) throws IOException {
+        String operatorName = rawOperator.getOperator();
+        switch (operatorName) {
+            case Operators.BMC:
+            case Operators.EMC:
+            case Operators.BDC:
+                break;
+            case Operators.DO:
+                OperatorStreamKey xObjectOperatorStreamKey = new OperatorStreamKey(operatorStreamKey.getPageNumber(), arguments.get(0).getString());
+                if (AutoTaggingProcessor.getOperatorIndexesToStreamInfosMap().containsKey(xObjectOperatorStreamKey)) {
+                    COSName xObjectName = getLastCOSName(arguments);
+                    PDXObject pdxObject = resourceHandler.getXObject(xObjectName);
+                    pdxObject.setKey(ASAtom.STRUCT_PARENTS,
+                        COSInteger.construct(AutoTaggingProcessor.getStructParentsIntegers().get(xObjectOperatorStreamKey)));
+                    StaticResources.getDocument().getDocument().addChangedObject(pdxObject.getObject());
+                    PDXForm pdxForm = (PDXForm)pdxObject;
+                    GraphicsState xFormGraphicsState = graphicsState.clone();
+                    AutoTaggingProcessor.setUpContents(pdxForm.getObject(), new ChunksWriter(xFormGraphicsState,
+                        resourceHandler.getExtendedResources(pdxForm.getResources())).processTokens(
+                            ChunksWriter.getTokens(pdxForm), xObjectOperatorStreamKey));
+                } else {
+                    processContentOperator(result, rawOperator, arguments, operatorIndex, operatorIndexesToStreamInfosMap, operatorName);
+                }
+                break;
+            case Operators.TJ_SHOW:
+            case Operators.TJ_SHOW_POS:
+            case Operators.QUOTE:
+            case Operators.DOUBLE_QUOTE:
+            case Operators.BI:
+            case Operators.F_FILL:
+            case Operators.F_FILL_OBSOLETE:
+            case Operators.F_STAR_FILL:
+            case Operators.B_CLOSEPATH_FILL_STROKE:
+            case Operators.B_STAR_CLOSEPATH_EOFILL_STROKE:
+            case Operators.S_CLOSE_STROKE:
+            case Operators.S_STROKE:
+                processContentOperator(result, rawOperator, arguments, operatorIndex, operatorIndexesToStreamInfosMap, operatorName);
+                break;
+            case org.verapdf.model.tools.constants.Operators.GS:
+                PDExtGState extGState = this.resourceHandler.getExtGState(getLastCOSName(arguments));
+                this.graphicsState.copyPropertiesFromExtGState(extGState);
+                result.addAll(arguments);
+                result.add(rawOperator);
+                break;
+            case org.verapdf.model.tools.constants.Operators.TF:
+                this.graphicsState.getTextState().setTextFont(resourceHandler.getFont(getFirstCOSName(arguments)));
+                result.addAll(arguments);
+                result.add(rawOperator);
+                break;
+            default:
+//                    if (!Operators.D_SET_DASH.equals(operatorName)) {
+                result.addAll(arguments);
+                result.add(rawOperator);
+//                    }
+                break;
+        }
+    }
+
+    private void processContentOperator(List<Object> result, Operator rawOperator, List<COSBase> arguments, int operatorIndex,
+                                        Map<Integer, Set<StreamInfo>> operatorIndexesToStreamInfosMap, String operatorName) {
+        Set<StreamInfo> streamInfos = operatorIndexesToStreamInfosMap.get(operatorIndex);
+        if (streamInfos == null || streamInfos.isEmpty()) {
+            writeMarkedContent(result, arguments, rawOperator, operatorName, null);
+        } else {
+            if (streamInfos.size() == 1) {
+                writeMarkedContent(result, arguments, rawOperator, operatorName, streamInfos.iterator().next().getMcid());
+            } else {
+                List<StreamInfo> streamInfosList = updateStreamInfos(streamInfos);
+                Map<StreamInfo, COSObject> newArguments = getArguments(arguments.get(arguments.size() - 1), streamInfosList);
+                for (Map.Entry<StreamInfo, COSObject> entry : newArguments.entrySet()) {
+                    arguments.set(arguments.size() - 1, entry.getValue().get());
+                    writeMarkedContent(result, arguments, rawOperator, operatorName, entry.getKey().getMcid());
+                }
+            }
+        }
+    }
+
+    private static void writeMarkedContent(List<Object> result, List<COSBase> arguments, Operator token,
+                                           String operatorName, Integer mcid) {
+        if (mcid == null) {
+            result.add(COSName.construct(TaggedPDFConstants.ARTIFACT).getDirectBase());
+            result.add(Operator.getOperator(Operators.BMC));
+        } else {
+            if (Operators.BI.equals(operatorName) || Operators.DO.equals(operatorName)) {
+                result.add(COSName.construct(TaggedPDFConstants.FIGURE).getDirectBase());
+            } else {
+                result.add(COSName.construct(TaggedPDFConstants.SPAN).getDirectBase());
+            }
+            COSObject dictionary = COSDictionary.construct();
+            dictionary.setKey(ASAtom.MCID, COSInteger.construct(mcid));
+            result.add(dictionary.getDirectBase());
+            result.add(Operator.getOperator(Operators.BDC));
+        }
+        result.addAll(arguments);
+        result.add(token);
+        result.add(Operator.getOperator(Operators.EMC));
+    }
+
+    private Map<StreamInfo, COSObject> getArguments(COSBase object, List<StreamInfo> streamInfos) {
+        Map<StreamInfo, COSObject> map = new TreeMap<>();
+        if (object.getType() == COSObjType.COS_STRING) {
+            Queue<StreamInfo> streamInfoQueue = new LinkedList<>(streamInfos);
+            processString((COSString)object, map, streamInfoQueue, null, 0);
+        } else if (object.getType() == COSObjType.COS_ARRAY) {
+            int stringIndex = 0;
+            List<COSObject> array = new ArrayList<>();
+            Queue<StreamInfo> streamInfoQueue = new LinkedList<>(streamInfos);
+            for (COSObject element : (COSArray)object.getDirectBase()) {
+                if (element.getType() == COSObjType.COS_STRING) {
+                    stringIndex = processString((COSString)element.get(), map, streamInfoQueue, array, stringIndex);
+                } else if (element.getType().isNumber()) {
+                    array.add(element);
+                }
+            }
+            if (!array.isEmpty()) {
+                COSArray currentArray = ((COSArray)map.get(streamInfoQueue.peek()).get());
+                for (COSObject element : array) {
+                    currentArray.add(element);
+                }
+            }
+        }
+        return map;
+    }
+
+    public int processString(COSString string, Map<StreamInfo, COSObject> map, Queue<StreamInfo> streamInfoQueue,
+                             List<COSObject> array, int stringIndex) {
+        int currentStringIndex = stringIndex;
+        int currentBytesIndex = 0;
+        int dif = 0;
+        byte[] bytes = string.get();
+        try (InputStream inputStream = new ByteArrayInputStream(bytes)) {
+            int available = inputStream.available();
+            while (inputStream.available() > 0) {
+                int code = graphicsState.getTextState().getTextFont().readCode(inputStream);
+                String value = graphicsState.getTextState().getTextFont().toUnicode(code);
+                if (value == null) {
+                    value = StaticContainers.getIsIgnoreCharactersWithoutUnicode() ? "" : ChunkParser.REPLACEMENT_CHARACTER_STRING;
+                }
+                int newAvailable = inputStream.available();
+                dif += available - newAvailable;
+                available = newAvailable;
+                int length = streamInfoQueue.peek().getEndIndex() - currentStringIndex;
+                currentStringIndex += value.length();
+                if (length <= value.length()) {
+                    COSObject cosString = COSString.construct(Arrays.copyOfRange(bytes, currentBytesIndex, currentBytesIndex + dif));
+                    if (array != null) {
+                        array.add(cosString);
+                        map.put(streamInfoQueue.peek(), new COSObject(new COSArray(array)));
+                    } else {
+                        map.put(streamInfoQueue.peek(), cosString);
+                    }
+                    currentBytesIndex += dif;
+                    dif = 0;
+                    if (array != null) {
+                        array.clear();
+                    }
+                    if (streamInfoQueue.size() > 1) {
+                        streamInfoQueue.poll();
+                    }
+                }
+            }
+        } catch (IOException e) {
+        }
+        if (array != null && dif > 0) {
+            array.add(COSString.construct(Arrays.copyOfRange(bytes, currentBytesIndex, currentBytesIndex + dif)));
+        }
+        return currentStringIndex;
+    }
+
+    private static List<StreamInfo> updateStreamInfos(Set<StreamInfo> streamInfos) {
+        Iterator<StreamInfo> streamInfoIterator = streamInfos.iterator();
+        List<StreamInfo> newStreamInfos = new ArrayList<>();
+        StreamInfo streamInfo = null;
+        int currentIndex = 0;
+        while (streamInfoIterator.hasNext()) {
+            streamInfo = streamInfoIterator.next();
+            if (currentIndex < streamInfo.getStartIndex()) {
+                newStreamInfos.add(new StreamInfo(streamInfo.getOperatorIndex(), streamInfo.getXObjectName(), currentIndex,
+                    streamInfo.getStartIndex(), streamInfo.getLength(), null));
+            }
+            currentIndex = streamInfo.getEndIndex();
+            newStreamInfos.add(streamInfo);
+        }
+        if (currentIndex < streamInfo.getLength()) {
+            newStreamInfos.add(new StreamInfo(streamInfo.getOperatorIndex(), streamInfo.getXObjectName(), streamInfo.getEndIndex(),
+                streamInfo.getLength(), streamInfo.getLength(), null));
+        }
+        return newStreamInfos;
+    }
+
+    private static COSName getFirstCOSName(List<COSBase> arguments) {
+        COSBase lastElement = arguments.isEmpty() ? null : arguments.get(0);
+        if (lastElement instanceof COSName) {
+            return (COSName) lastElement;
+        }
+        return null;
+    }
+
+    private static COSName getLastCOSName(List<COSBase> arguments) {
+        COSBase lastElement = arguments.isEmpty() ? null : arguments.get(arguments.size() - 1);
+        if (lastElement instanceof COSName) {
+            return (COSName) lastElement;
+        }
+        return null;
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -100,6 +100,9 @@ public class ChunksWriter {
                     AutoTaggingProcessor.setUpContents(pdxForm.getObject(), new ChunksWriter(xFormGraphicsState,
                         resourceHandler.getExtendedResources(pdxForm.getResources())).processTokens(
                             ChunksWriter.getTokens(pdxForm), xObjectOperatorStreamKey));
+                    // Preserve the Do operator in the parent stream so the XObject is still invoked
+                    result.addAll(arguments);
+                    result.add(rawOperator);
                 } else {
                     processContentOperator(result, rawOperator, arguments, operatorIndex, operatorIndexesToStreamInfosMap, operatorName, operatorStreamKey);
                 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -55,6 +55,9 @@ public class ChunksWriter {
 
     public List<Object> processTokens(List<Object> processTokens, OperatorStreamKey operatorStreamKey) throws IOException {
         Map<Integer, Set<StreamInfo>> operatorIndexesToStreamInfosMap = AutoTaggingProcessor.getOperatorIndexesToStreamInfosMap().get(operatorStreamKey);
+        if (operatorIndexesToStreamInfosMap == null) {
+            operatorIndexesToStreamInfosMap = Collections.emptyMap();
+        }
         List<Object> result = new ArrayList<>();
         List<COSBase> arguments = new ArrayList<>();
         for (int index = 0; index < processTokens.size(); index++) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -97,7 +97,7 @@ public class ChunksWriter {
                         resourceHandler.getExtendedResources(pdxForm.getResources())).processTokens(
                             ChunksWriter.getTokens(pdxForm), xObjectOperatorStreamKey));
                 } else {
-                    processContentOperator(result, rawOperator, arguments, operatorIndex, operatorIndexesToStreamInfosMap, operatorName);
+                    processContentOperator(result, rawOperator, arguments, operatorIndex, operatorIndexesToStreamInfosMap, operatorName, operatorStreamKey);
                 }
                 break;
             case Operators.TJ_SHOW:
@@ -112,7 +112,7 @@ public class ChunksWriter {
             case Operators.B_STAR_CLOSEPATH_EOFILL_STROKE:
             case Operators.S_CLOSE_STROKE:
             case Operators.S_STROKE:
-                processContentOperator(result, rawOperator, arguments, operatorIndex, operatorIndexesToStreamInfosMap, operatorName);
+                processContentOperator(result, rawOperator, arguments, operatorIndex, operatorIndexesToStreamInfosMap, operatorName, operatorStreamKey);
                 break;
             case org.verapdf.model.tools.constants.Operators.GS:
                 PDExtGState extGState = this.resourceHandler.getExtGState(getLastCOSName(arguments));
@@ -135,35 +135,51 @@ public class ChunksWriter {
     }
 
     private void processContentOperator(List<Object> result, Operator rawOperator, List<COSBase> arguments, int operatorIndex,
-                                        Map<Integer, Set<StreamInfo>> operatorIndexesToStreamInfosMap, String operatorName) {
+                                        Map<Integer, Set<StreamInfo>> operatorIndexesToStreamInfosMap, String operatorName,
+                                        OperatorStreamKey operatorStreamKey) {
         Set<StreamInfo> streamInfos = operatorIndexesToStreamInfosMap.get(operatorIndex);
         if (streamInfos == null || streamInfos.isEmpty()) {
-            writeMarkedContent(result, arguments, rawOperator, operatorName, null);
+            writeMarkedContent(result, arguments, rawOperator, operatorName, null, null);
         } else {
             if (streamInfos.size() == 1) {
-                writeMarkedContent(result, arguments, rawOperator, operatorName, streamInfos.iterator().next().getMcid());
+                Integer mcid = streamInfos.iterator().next().getMcid();
+                writeMarkedContent(result, arguments, rawOperator, operatorName, mcid, operatorStreamKey);
             } else {
                 List<StreamInfo> streamInfosList = updateStreamInfos(streamInfos);
                 Map<StreamInfo, COSObject> newArguments = getArguments(arguments.get(arguments.size() - 1), streamInfosList);
                 for (Map.Entry<StreamInfo, COSObject> entry : newArguments.entrySet()) {
                     arguments.set(arguments.size() - 1, entry.getValue().get());
-                    writeMarkedContent(result, arguments, rawOperator, operatorName, entry.getKey().getMcid());
+                    writeMarkedContent(result, arguments, rawOperator, operatorName, entry.getKey().getMcid(), operatorStreamKey);
                 }
             }
         }
     }
 
+    private static String getStructureType(Integer mcid, OperatorStreamKey operatorStreamKey) {
+        if (mcid == null || operatorStreamKey == null) return null;
+        List<COSObject> parents = AutoTaggingProcessor.getStructParents().get(operatorStreamKey);
+        if (parents == null || mcid >= parents.size()) return null;
+        COSObject structElem = parents.get(mcid);
+        if (structElem == null) return null;
+        COSObject typeObj = structElem.getKey(ASAtom.S);
+        if (typeObj == null || typeObj.empty()) return null;
+        return typeObj.getString();
+    }
+
     private static void writeMarkedContent(List<Object> result, List<COSBase> arguments, Operator token,
-                                           String operatorName, Integer mcid) {
+                                           String operatorName, Integer mcid, OperatorStreamKey operatorStreamKey) {
         if (mcid == null) {
             result.add(COSName.construct(TaggedPDFConstants.ARTIFACT).getDirectBase());
             result.add(Operator.getOperator(Operators.BMC));
         } else {
+            String tagName;
             if (Operators.BI.equals(operatorName) || Operators.DO.equals(operatorName)) {
-                result.add(COSName.construct(TaggedPDFConstants.FIGURE).getDirectBase());
+                tagName = TaggedPDFConstants.FIGURE;
             } else {
-                result.add(COSName.construct(TaggedPDFConstants.SPAN).getDirectBase());
+                String structType = getStructureType(mcid, operatorStreamKey);
+                tagName = (structType != null) ? structType : TaggedPDFConstants.SPAN;
             }
+            result.add(COSName.construct(tagName).getDirectBase());
             COSObject dictionary = COSDictionary.construct();
             dictionary.setKey(ASAtom.MCID, COSInteger.construct(mcid));
             result.add(dictionary.getDirectBase());

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -48,6 +48,7 @@ public class ChunksWriter {
                     }
                 }
             } catch (IOException e) {
+                CHUNKS_LOGGER.warning("Failed to read content stream tokens: " + e.getMessage());
             }
         }
         return Collections.emptyList();
@@ -274,6 +275,7 @@ public class ChunksWriter {
                 }
             }
         } catch (IOException e) {
+            CHUNKS_LOGGER.warning("Failed to process font string: " + e.getMessage());
         }
         if (array != null && dif > 0) {
             array.add(COSString.construct(Arrays.copyOfRange(bytes, currentBytesIndex, currentBytesIndex + dif), string.isHexadecimal()));

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -155,10 +155,19 @@ public class ChunksWriter {
         }
     }
 
+    private static final java.util.logging.Logger CHUNKS_LOGGER = java.util.logging.Logger.getLogger(ChunksWriter.class.getName());
+
     private static String getStructureType(Integer mcid, OperatorStreamKey operatorStreamKey) {
         if (mcid == null || operatorStreamKey == null) return null;
         List<COSObject> parents = AutoTaggingProcessor.getStructParents().get(operatorStreamKey);
-        if (parents == null || mcid >= parents.size()) return null;
+        if (parents == null) {
+            CHUNKS_LOGGER.warning("structParents: no entry for key page=" + operatorStreamKey.getPageNumber() + " xobj=" + operatorStreamKey.getXObjectName() + " (available keys: " + AutoTaggingProcessor.getStructParents().keySet().stream().map(k -> "p"+k.getPageNumber()+"x"+k.getXObjectName()).collect(java.util.stream.Collectors.joining(",")) + ")");
+            return null;
+        }
+        if (mcid >= parents.size()) {
+            CHUNKS_LOGGER.warning("structParents: mcid=" + mcid + " out of range (size=" + parents.size() + ") for key page=" + operatorStreamKey.getPageNumber() + " xobj=" + operatorStreamKey.getXObjectName());
+            return null;
+        }
         COSObject structElem = parents.get(mcid);
         if (structElem == null) return null;
         COSObject typeObj = structElem.getKey(ASAtom.S);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -215,7 +215,7 @@ public class ChunksWriter {
                 int length = streamInfoQueue.peek().getEndIndex() - currentStringIndex;
                 currentStringIndex += value.length();
                 if (length <= value.length()) {
-                    COSObject cosString = COSString.construct(Arrays.copyOfRange(bytes, currentBytesIndex, currentBytesIndex + dif));
+                    COSObject cosString = COSString.construct(Arrays.copyOfRange(bytes, currentBytesIndex, currentBytesIndex + dif), string.isHexadecimal());
                     if (array != null) {
                         array.add(cosString);
                         map.put(streamInfoQueue.peek(), new COSObject(new COSArray(array)));
@@ -235,7 +235,7 @@ public class ChunksWriter {
         } catch (IOException e) {
         }
         if (array != null && dif > 0) {
-            array.add(COSString.construct(Arrays.copyOfRange(bytes, currentBytesIndex, currentBytesIndex + dif)));
+            array.add(COSString.construct(Arrays.copyOfRange(bytes, currentBytesIndex, currentBytesIndex + dif), string.isHexadecimal()));
         }
         return currentStringIndex;
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/ChunksWriter.java
@@ -83,11 +83,13 @@ public class ChunksWriter {
                 break;
             case Operators.DO:
                 OperatorStreamKey xObjectOperatorStreamKey = new OperatorStreamKey(operatorStreamKey.getPageNumber(), arguments.get(0).getString());
-                if (AutoTaggingProcessor.getOperatorIndexesToStreamInfosMap().containsKey(xObjectOperatorStreamKey)) {
+                Integer xObjectStructParent = AutoTaggingProcessor.getStructParentsIntegers().get(xObjectOperatorStreamKey);
+                if (AutoTaggingProcessor.getOperatorIndexesToStreamInfosMap().containsKey(xObjectOperatorStreamKey)
+                        && xObjectStructParent != null) {
                     COSName xObjectName = getLastCOSName(arguments);
                     PDXObject pdxObject = resourceHandler.getXObject(xObjectName);
                     pdxObject.setKey(ASAtom.STRUCT_PARENTS,
-                        COSInteger.construct(AutoTaggingProcessor.getStructParentsIntegers().get(xObjectOperatorStreamKey)));
+                        COSInteger.construct(xObjectStructParent));
                     StaticResources.getDocument().getDocument().addChangedObject(pdxObject.getObject());
                     PDXForm pdxForm = (PDXForm)pdxObject;
                     GraphicsState xFormGraphicsState = graphicsState.clone();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/OperatorStreamKey.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/autotagging/OperatorStreamKey.java
@@ -1,0 +1,39 @@
+package org.opendataloader.pdf.autotagging;
+
+import java.util.Objects;
+
+public class OperatorStreamKey {
+    private final int pageNumber;
+    private final String xObjectName;
+
+    public OperatorStreamKey(int pageNumber, String xObjectName) {
+        this.pageNumber = pageNumber;
+        this.xObjectName = xObjectName;
+    }
+
+    public int getPageNumber() {
+        return pageNumber;
+    }
+
+    public String getXObjectName() {
+        return xObjectName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OperatorStreamKey that = (OperatorStreamKey) o;
+        return pageNumber == that.pageNumber &&
+            Objects.equals(xObjectName, that.xObjectName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pageNumber, xObjectName);
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/entities/EnrichedImageChunk.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/entities/EnrichedImageChunk.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.entities;
+
+import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
+
+/**
+ * An ImageChunk enriched with an AI-generated description (alt text).
+ *
+ * <p>Created when the hybrid backend returns a SemanticPicture whose bounding
+ * box overlaps a Java-extracted ImageChunk. The description is matched by
+ * bounding-box IoU in HybridDocumentProcessor and propagated to:
+ * <ul>
+ *   <li>AutoTaggingProcessor — inserts /Alt into the Figure struct element</li>
+ *   <li>ImageSerializer — writes "alt" field to JSON output</li>
+ *   <li>MarkdownGenerator / HtmlGenerator — uses description as alt text</li>
+ * </ul>
+ */
+public class EnrichedImageChunk extends ImageChunk {
+
+    private final String description;
+
+    public EnrichedImageChunk(ImageChunk source, String description) {
+        super(source.getBoundingBox());
+        // Copy index so serializers can reference the image file
+        setIndex(source.getIndex());
+        // Copy stream infos so MCID / struct-tree linkage is preserved
+        getStreamInfos().addAll(source.getStreamInfos());
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description != null ? description : "";
+    }
+
+    public boolean hasDescription() {
+        return description != null && !description.isEmpty();
+    }
+
+    /**
+     * Sanitized description safe for use as PDF /Alt, Markdown alt text,
+     * HTML alt attribute, and JSON value.
+     */
+    public String sanitizeDescription() {
+        if (!hasDescription()) return "";
+        return description
+                .replace("\r\n", " ")
+                .replace("\n", " ")
+                .replace("\r", " ")
+                .replace("\"", "")
+                .replace("[", "")
+                .replace("]", "")
+                .replace("<", "")
+                .replace(">", "")
+                .replace("&", "")
+                .replace("\u0000", "")
+                .replaceAll("\\s{2,}", " ")
+                .trim();
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
@@ -18,6 +18,7 @@ package org.opendataloader.pdf.html;
 import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.opendataloader.pdf.entities.SemanticFormula;
+import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.markdown.MarkdownSyntax;
 import org.opendataloader.pdf.utils.Base64ImageUtils;
@@ -228,7 +229,10 @@ public class HtmlGenerator implements Closeable {
                 }
                 if (imageSource != null) {
                     String escapedSource = escapeHtmlAttribute(imageSource);
-                    String imageString = String.format("<img src=\"%s\" alt=\"figure%d\">", escapedSource, image.getIndex());
+                    String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
+                            ? ((EnrichedImageChunk) image).sanitizeDescription()
+                            : "figure" + image.getIndex();
+                    String imageString = String.format("<img src=\"%s\" alt=\"%s\">", escapedSource, altText);
                     htmlWriter.write(imageString);
                     htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
                 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingFastServerClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingFastServerClient.java
@@ -230,7 +230,10 @@ public class DoclingFastServerClient implements HybridClient {
         // Extract failed pages (1-indexed) from partial_success responses
         List<Integer> failedPages = extractFailedPages(root);
 
-        return new HybridResponse(null, null, jsonContent, pageContents, failedPages);
+        // Extract per-step pipeline timings (layout, ocr, table_structure, etc.)
+        JsonNode timingsNode = root.get("timings");
+
+        return new HybridResponse(null, null, jsonContent, pageContents, failedPages, timingsNode);
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClient.java
@@ -187,6 +187,7 @@ public interface HybridClient {
         private final JsonNode json;
         private final Map<Integer, JsonNode> pageContents;
         private final List<Integer> failedPages;
+        private final JsonNode timings;
 
         /**
          * Creates a new HybridResponse.
@@ -196,9 +197,11 @@ public interface HybridClient {
          * @param json         The full structured JSON output (DoclingDocument format).
          * @param pageContents Per-page JSON content, keyed by 1-indexed page number.
          * @param failedPages  List of 1-indexed page numbers that failed during backend processing.
+         * @param timings      Per-step pipeline timings from the hybrid server (may be null).
          */
         public HybridResponse(String markdown, String html, JsonNode json,
-                              Map<Integer, JsonNode> pageContents, List<Integer> failedPages) {
+                              Map<Integer, JsonNode> pageContents, List<Integer> failedPages,
+                              JsonNode timings) {
             this.markdown = markdown != null ? markdown : "";
             this.html = html != null ? html : "";
             this.json = json;
@@ -206,6 +209,15 @@ public interface HybridClient {
             this.failedPages = failedPages != null
                 ? Collections.unmodifiableList(new ArrayList<>(failedPages))
                 : Collections.emptyList();
+            this.timings = timings;
+        }
+
+        /**
+         * Creates a new HybridResponse (without timings, backward compatible).
+         */
+        public HybridResponse(String markdown, String html, JsonNode json,
+                              Map<Integer, JsonNode> pageContents, List<Integer> failedPages) {
+            this(markdown, html, json, pageContents, failedPages, null);
         }
 
         /**
@@ -257,6 +269,18 @@ public interface HybridClient {
         }
 
         /**
+         * Returns per-step pipeline timings from the hybrid server.
+         *
+         * <p>Keys are step names (e.g. "layout", "ocr", "table_structure",
+         * "picture_description"). Each value contains "total_s", "avg_s", and "count".
+         *
+         * @return Timings JSON node, or null if profiling was not enabled on the server.
+         */
+        public JsonNode getTimings() {
+            return timings;
+        }
+
+        /**
          * Returns the list of 1-indexed page numbers that failed during backend processing.
          *
          * <p>When the backend returns partial_success, some pages may have failed due to
@@ -287,12 +311,13 @@ public interface HybridClient {
                 Objects.equals(html, that.html) &&
                 Objects.equals(json, that.json) &&
                 Objects.equals(pageContents, that.pageContents) &&
-                Objects.equals(failedPages, that.failedPages);
+                Objects.equals(failedPages, that.failedPages) &&
+                Objects.equals(timings, that.timings);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(markdown, html, json, pageContents, failedPages);
+            return Objects.hash(markdown, html, json, pageContents, failedPages, timings);
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/ImageSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/ImageSerializer.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.json.JsonName;
 import org.opendataloader.pdf.markdown.MarkdownSyntax;
 import org.opendataloader.pdf.utils.Base64ImageUtils;
@@ -42,6 +43,12 @@ public class ImageSerializer extends StdSerializer<ImageChunk> {
         String relativePath = String.format(MarkdownSyntax.IMAGE_FILE_NAME_FORMAT, StaticLayoutContainers.getImagesDirectoryName(), "/", imageChunk.getIndex(), imageFormat);
         jsonGenerator.writeStartObject();
         SerializerUtil.writeEssentialInfo(jsonGenerator, imageChunk, JsonName.IMAGE_CHUNK_TYPE);
+        if (imageChunk instanceof EnrichedImageChunk) {
+            String alt = ((EnrichedImageChunk) imageChunk).sanitizeDescription();
+            if (!alt.isEmpty()) {
+                jsonGenerator.writeStringField("alt", alt);
+            }
+        }
         if (ImagesUtils.isImageFileExists(absolutePath)) {
             if (StaticLayoutContainers.isEmbedImages()) {
                 File imageFile = new File(absolutePath);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -18,6 +18,7 @@ package org.opendataloader.pdf.markdown;
 import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.opendataloader.pdf.entities.SemanticFormula;
+import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.utils.Base64ImageUtils;
 import org.opendataloader.pdf.utils.GeneratorUtils;
@@ -166,7 +167,10 @@ public class MarkdownGenerator implements Closeable {
                     imageSource = relativePath;
                 }
                 if (imageSource != null) {
-                    String imageString = String.format(MarkdownSyntax.IMAGE_FORMAT, "image " + image.getIndex(), imageSource);
+                    String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
+                            ? ((EnrichedImageChunk) image).sanitizeDescription()
+                            : "image " + image.getIndex();
+                    String imageString = String.format(MarkdownSyntax.IMAGE_FORMAT, altText, imageSource);
                     markdownWriter.write(getCorrectMarkdownString(imageString));
                 }
             }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -141,7 +141,7 @@ public class AutoTaggingProcessor {
     private static void createFigureStructElem(ImageChunk image, COSObject parent, COSDocument cosDocument) {
         COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE);
         double[] bbox = {image.getLeftX(), image.getBottomY(), image.getRightX(), image.getTopY()};
-        figureObject.setKey(ASAtom.BBOX, COSArray.construct(4, bbox));
+        addAttributeToStructElem(figureObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         //TODO: process image, add height and width attributes
     }
 
@@ -151,10 +151,10 @@ public class AutoTaggingProcessor {
             listObject.setKey(ASAtom.ID, COSString.construct(String.valueOf(list.getRecognizedStructureId()).getBytes()));
         }
         if (list.getPreviousList() != null) {
-            listObject.setKey(ASAtom.CONTINUED_LIST, COSBoolean.construct(true));
-            listObject.setKey(ASAtom.CONTINUED_FROM, COSString.construct(String.valueOf(list.getPreviousList().getRecognizedStructureId()).getBytes()));
+            addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.CONTINUED_LIST, COSBoolean.construct(true));
+            addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.CONTINUED_FROM, COSString.construct(String.valueOf(list.getPreviousList().getRecognizedStructureId()).getBytes()));
         }
-        listObject.setKey(ASAtom.LIST_NUMBERING, COSName.construct(ListProcessor.getListNumbering(list.getNumberingStyle())));
+        addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.LIST_NUMBERING, COSName.construct(ListProcessor.getListNumbering(list.getNumberingStyle())));
 
         for (ListItem listItem : list.getListItems()) {
             COSObject listItemObject = addStructElement(listObject, cosDocument, TaggedPDFConstants.LI);
@@ -189,14 +189,58 @@ public class AutoTaggingProcessor {
                 TableBorderCell cell = row.getCell(colNumber);
                 if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
                     COSObject cellObject = addStructElement(rowObject, cosDocument, TaggedPDFConstants.TD);
-                    cellObject.setKey(ASAtom.COL_SPAN, COSInteger.construct(cell.getColSpan()));
-                    cellObject.setKey(ASAtom.ROW_SPAN, COSInteger.construct(cell.getRowSpan()));
+                    if (cell.getColSpan() != 1) {
+                        addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.COL_SPAN, COSInteger.construct(cell.getColSpan()));
+                    }
+                    if (cell.getRowSpan() != 1) {
+                        addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.ROW_SPAN, COSInteger.construct(cell.getRowSpan()));
+                    }
                     for (IObject cellContent : cell.getContents()) {
                         createStructElem(cellContent, cellObject, cosDocument);
                     }
                 }
             }
         }
+    }
+
+    private static void addAttributeToStructElem(COSObject structElement, ASAtom ownerASAtom, ASAtom attributeName, COSObject attributeValue) {
+        COSObject aObject = structElement.getKey(ASAtom.A);
+        COSObject owner = COSName.construct(ownerASAtom);
+        if (aObject.empty()) {
+            aObject = COSDictionary.construct();
+            aObject.setKey(ASAtom.O, owner);
+            aObject.setKey(attributeName, attributeValue);
+        } else if (aObject.getType() == COSObjType.COS_DICT) {
+            COSObject ownerObject = aObject.getKey(ASAtom.O);
+            if (owner.equals(ownerObject)) {
+                aObject.setKey(attributeName, attributeValue);
+            } else {
+                COSObject previousADictionary = aObject;
+                aObject = COSArray.construct();
+                aObject.add(previousADictionary);
+                addAttributeDictionaryToArray(owner, attributeName, attributeValue, aObject);
+            }
+        } else if (aObject.getType() == COSObjType.COS_ARRAY) {
+            boolean isAttributeSet = false;
+            for (COSObject dictionary : (COSArray) aObject.getDirectBase()) {
+                if (owner.equals(dictionary.getKey(ASAtom.O))) {
+                    dictionary.setKey(attributeName, attributeValue);
+                    isAttributeSet = true;
+                    break;
+                }
+            }
+            if (!isAttributeSet) {
+                addAttributeDictionaryToArray(owner, attributeName, attributeValue, aObject);
+            }
+        }
+        structElement.setKey(ASAtom.A, aObject);
+    }
+
+    private static void addAttributeDictionaryToArray(COSObject owner, ASAtom attributeName, COSObject attributeValue, COSObject aObject) {
+        COSObject newADictionary = COSDictionary.construct();
+        newADictionary.setKey(ASAtom.O, owner);
+        newADictionary.setKey(attributeName, attributeValue);
+        aObject.add(newADictionary);
     }
 
 //    protected static List<Object> getTokens(PDContentStream pdContentStream) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -158,7 +158,8 @@ public class AutoTaggingProcessor {
 
         for (ListItem listItem : list.getListItems()) {
             COSObject listItemObject = addStructElement(listObject, cosDocument, TaggedPDFConstants.LI);
-            if (listItem.getLabelLength() > 0) {
+            int labelLength = listItem.getLabelLength();
+            if (labelLength > 0) {
                 COSObject lblObject = addStructElement(listItemObject, cosDocument, TaggedPDFConstants.LBL);
                 SemanticTextNode lblTextNode = new SemanticTextNode();
                 lblTextNode.add(new TextLine(listItem.getFirstLine(), 0, listItem.getLabelLength()));
@@ -169,7 +170,9 @@ public class AutoTaggingProcessor {
             for (TextLine line : listItem.getLines()) {
                 lBodyTextNode.add(line);
             }
-            lBodyTextNode.setFirstLine(new TextLine(listItem.getFirstLine(), listItem.getLabelLength(), listItem.getFirstLine().getValue().length()));
+            if (labelLength > 0) {
+                lBodyTextNode.setFirstLine(new TextLine(listItem.getFirstLine(), listItem.getLabelLength(), listItem.getFirstLine().getValue().length()));
+            }
             //processTextNode(lBodyTextNode, lBodyObject);
             for (IObject content : listItem.getContents()) {
                 createStructElem(content, lBodyObject, cosDocument);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -1,0 +1,205 @@
+package org.opendataloader.pdf.processors;
+
+import org.verapdf.as.ASAtom;
+import org.verapdf.cos.*;
+
+import org.verapdf.pd.*;
+import org.verapdf.tools.TaggedPDFConstants;
+import org.verapdf.wcag.algorithms.entities.*;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AutoTaggingProcessor {
+
+//    private static List<Integer> mcids = new ArrayList<>();
+    private static List<COSObject> structParents = new ArrayList<>();
+
+    public static void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
+        COSDocument cosDocument = document.getDocument();
+        PDCatalog catalog = document.getCatalog();
+        COSObject structTreeRoot = createStructTreeRoot(catalog, cosDocument, document);
+        createStructureTreeElements(contents, structTreeRoot, cosDocument);
+//        updatePages(document, cosDocument);
+//        createParentTree(cosDocument, structTreeRoot);
+        String outputFileName = outputFolder + File.separator +
+            inputPDF.getName().substring(0, inputPDF.getName().length() - 4) + "_tagged.pdf";
+        try (OutputStream output = new FileOutputStream(outputFileName)) {
+            document.saveTo(output);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+//    private static void updatePages(PDDocument document, COSDocument cosDocument) throws IOException {
+//        List<org.verapdf.pd.PDPage> rawPages = document.getPages();
+//        for (PDPage page : rawPages) {
+//            page.getObject().setKey(ASAtom.STRUCT_PARENTS, COSInteger.construct(page.getPageNumber()));
+//            cosDocument.addChangedObject(page.getObject());
+//            COSObject contentsObject = page.getKey(ASAtom.CONTENTS);
+////            byte[] res = new PDFStreamWriter().write(processTokens(getTokens(page.getContent())));
+//            try (InputStream inStream = new ByteArrayInputStream(res)) {
+//                contentsObject.setData(new ASMemoryInStream(inStream));
+//            }
+//            contentsObject.setKey(ASAtom.FILTER, new COSObject());
+////            ((COSStream)contentsObject.getDirectBase()).setFilters(new COSFilters(COSName.construct(ASAtom.FLATE_DECODE)));
+//            cosDocument.addChangedObject(contentsObject);
+//        }
+//    }
+
+    private static COSObject createStructTreeRoot(PDCatalog catalog, COSDocument cosDocument, PDDocument document) {
+        COSObject structTreeRoot = COSIndirect.construct(COSDictionary.construct(), cosDocument);
+        catalog.setKey(ASAtom.STRUCT_TREE_ROOT, structTreeRoot);
+        structTreeRoot.setKey(ASAtom.TYPE, COSName.construct(ASAtom.STRUCT_TREE_ROOT));
+        cosDocument.addObject(structTreeRoot);
+        structTreeRoot.setKey(ASAtom.PARENT_TREE_NEXT_KEY, COSInteger.construct(document.getNumberOfPages()));
+        cosDocument.addChangedObject(catalog.getObject());
+        return structTreeRoot;
+    }
+
+//    private static void createParentTree(COSDocument cosDocument, COSObject structTreeRoot) {
+//        COSObject parentTree = COSIndirect.construct(COSDictionary.construct(), cosDocument);
+//        cosDocument.addObject(parentTree);
+//        structTreeRoot.setKey(ASAtom.PARENT_TREE, parentTree);
+//        COSObject nums = COSArray.construct();
+//        parentTree.setKey(ASAtom.NUMS, nums);
+//        nums.add(COSInteger.construct(0));//todo fix
+//        COSObject array = COSArray.construct();
+//        for (COSObject structParent : structParents) {
+//            array.add(structParent);
+//        }
+//        nums.add(array);
+//    }
+
+    private static COSObject addStructElement(COSObject parent, COSDocument cosDocument, String type) {
+        COSObject structElement = COSIndirect.construct(COSDictionary.construct(), cosDocument);
+        COSObject k = parent.getKey(ASAtom.K);
+        if (k.getType() == COSObjType.COS_ARRAY) {
+            k.add(structElement);
+        } else {
+            k = COSArray.construct();
+            parent.setKey(ASAtom.K, k);
+            k.add(structElement);
+        }
+        structElement.setKey(ASAtom.S, COSName.construct(type));
+        structElement.setKey(ASAtom.TYPE, COSName.construct(ASAtom.STRUCT_ELEM));
+        structElement.setKey(ASAtom.P, parent);
+        structElement.setKey(ASAtom.PG, cosDocument.getPDDocument().getPages().get(0).getObject());//todo calculate page number
+        cosDocument.addObject(structElement);
+        return structElement;
+    }
+
+
+    public static void createStructureTreeElements(List<List<IObject>> contents, COSObject structTreeRoot, COSDocument cosDocument) {
+        COSObject seDocument = addStructElement(structTreeRoot, cosDocument, TaggedPDFConstants.DOCUMENT);
+        for (List<IObject> pageContents : contents) {
+            for (IObject content : pageContents) {
+                createStructElem(content, seDocument, cosDocument);
+            }
+        }
+    }
+
+    private static void createStructElem(IObject object, COSObject parentStructElem, COSDocument cosDocument) {
+        if (object instanceof SemanticHeading) {
+            createHeadingStructElem((SemanticHeading) object, parentStructElem, cosDocument);
+        } else if (object instanceof SemanticParagraph) {
+            createParagraphStructElem((SemanticParagraph) object, parentStructElem, cosDocument);
+        } else if (object instanceof SemanticCaption) {
+            createCaptionStructElem((SemanticCaption) object, parentStructElem, cosDocument);
+//        } else if (object instanceof PDFList) {
+//            createListStructElem((PDFList) object, parent, cosDocument);
+//        } else if (object instanceof TableBorder) {
+//            createTableStructElem((TableBorder) object, parentStructElem, cosDocument);
+//        } else if (object instanceof ImageChunk) {
+//            createFigureStructElem((ImageChunk) object, parentStructElem, cosDocument);
+        }
+    }
+
+    private static void createHeadingStructElem(SemanticHeading heading, COSObject parent, COSDocument cosDocument) {
+        COSObject headingObject = addStructElement(parent, cosDocument, TaggedPDFConstants.H + heading.getHeadingLevel());
+//        processTextNode(heading, headingObject);
+    }
+
+    private static void createParagraphStructElem(SemanticParagraph paragraph, COSObject parent, COSDocument cosDocument) {
+        COSObject paragraphObject = addStructElement(parent, cosDocument, TaggedPDFConstants.P);
+//        processTextNode(paragraph, paragraphObject);
+    }
+
+    private static void createCaptionStructElem(SemanticCaption caption, COSObject parent, COSDocument cosDocument) {
+        COSObject captionObject = addStructElement(parent, cosDocument, TaggedPDFConstants.CAPTION);
+//        processTextNode(caption, captionObject);
+    }
+
+//    protected static List<Object> getTokens(PDContentStream pdContentStream) {
+//        if (pdContentStream != null) {
+//            try {
+//                COSObject contentStream = pdContentStream.getContents();
+//                if (contentStream.getType() == COSObjType.COS_STREAM || contentStream.getType() == COSObjType.COS_ARRAY) {
+//                    try (ASInputStream opStream = contentStream.getDirectBase().getData(COSStream.FilterFlags.DECODE)) {
+//                        try (PDFStreamParser streamParser = new PDFStreamParser(opStream)) {
+//                            streamParser.parseTokens();
+//                            return streamParser.getTokens();
+//                        }
+//                    }
+//                }
+//            } catch (IOException e) {
+//            }
+//        }
+//        return Collections.emptyList();
+//    }
+
+//    private static void processTextNode(SemanticTextNode textNode, COSObject cosObject) {
+//        List<Integer> mcids = new ArrayList<>();
+//        for (TextColumn textColumn : textNode.getColumns()) {
+//            for (TextLine textLine : textColumn.getLines()) {
+//                for (TextChunk textChunk : textLine.getTextChunks()) {
+//                    mcids.addAll(textChunk.getErrorCodes());
+//                }
+//            }
+//        }
+//        AutoTaggingProcessor.mcids.addAll(mcids);
+//        for (int index : mcids) {
+//            structParents.add(cosObject);
+//        }
+//        if (!mcids.isEmpty()) {
+//            COSObject array = COSArray.construct();
+//            cosObject.setKey(ASAtom.K, array);
+//            for (Integer mcid : mcids) {
+//                array.add(COSInteger.construct(AutoTaggingProcessor.mcids.indexOf(mcid)));
+//            }
+//        }
+//    }
+
+//    protected static List<Object> processTokens(List<Object> processTokens) {
+//        List<Object> result = new ArrayList<>();
+//        List<Object> arguments = new ArrayList<>();
+//        for (int index = 0; index < processTokens.size(); index++) {
+//            Object token = processTokens.get(index);
+//            if (token instanceof COSBase) {
+//                arguments.add(token);
+//            } else if (token instanceof Operator) {
+//                if (Operators.BDC.equals(((Operator) token).getOperator()) ||
+//                    Operators.EMC.equals(((Operator) token).getOperator()) ||
+//                    Operators.BMC.equals(((Operator) token).getOperator())) {
+//                    arguments.clear();
+//                    continue;
+//                }
+//                if (mcids.contains(index)) {
+//                    result.add(COSName.construct("Span").getDirectBase());
+//                    COSObject dictionary = COSDictionary.construct();
+//                    dictionary.setKey(ASAtom.MCID, COSInteger.construct(mcids.indexOf(index)));
+//                    result.add(dictionary.getDirectBase());
+//                    result.add(Operator.getOperator(Operators.BDC));
+//                }
+//                result.addAll(arguments);
+//                arguments.clear();
+//                result.add(token);
+//                if (mcids.contains(index)) {
+//                    result.add(Operator.getOperator(Operators.EMC));
+//                }
+//            }
+//        }
+//        return result;
+//    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -6,6 +6,7 @@ import org.verapdf.cos.*;
 import org.verapdf.pd.*;
 import org.verapdf.tools.TaggedPDFConstants;
 import org.verapdf.wcag.algorithms.entities.*;
+import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
 import org.verapdf.wcag.algorithms.entities.lists.ListItem;
 import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
@@ -116,8 +117,8 @@ public class AutoTaggingProcessor {
             createListStructElem((PDFList) object, parentStructElem, cosDocument);
         } else if (object instanceof TableBorder) {
             createTableStructElem((TableBorder) object, parentStructElem, cosDocument);
-//        } else if (object instanceof ImageChunk) {
-//            createFigureStructElem((ImageChunk) object, parentStructElem, cosDocument);
+        } else if (object instanceof ImageChunk) {
+            createFigureStructElem((ImageChunk) object, parentStructElem, cosDocument);
         }
     }
 
@@ -134,6 +135,13 @@ public class AutoTaggingProcessor {
     private static void createCaptionStructElem(SemanticCaption caption, COSObject parent, COSDocument cosDocument) {
         COSObject captionObject = addStructElement(parent, cosDocument, TaggedPDFConstants.CAPTION);
 //        processTextNode(caption, captionObject);
+    }
+
+    private static void createFigureStructElem(ImageChunk image, COSObject parent, COSDocument cosDocument) {
+        COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE);
+        double[] bbox = {image.getLeftX(), image.getBottomY(), image.getRightX(), image.getTopY()};
+        figureObject.setKey(ASAtom.BBOX, COSArray.construct(4, bbox));
+        //TODO: process image, add height and width attributes
     }
 
     private static void createListStructElem(PDFList list, COSObject parent, COSDocument cosDocument) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -7,6 +7,7 @@ import org.verapdf.pd.*;
 import org.verapdf.tools.TaggedPDFConstants;
 import org.verapdf.wcag.algorithms.entities.*;
 import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
+import org.verapdf.wcag.algorithms.entities.content.TextLine;
 import org.verapdf.wcag.algorithms.entities.lists.ListItem;
 import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
@@ -157,7 +158,22 @@ public class AutoTaggingProcessor {
 
         for (ListItem listItem : list.getListItems()) {
             COSObject listItemObject = addStructElement(listObject, cosDocument, TaggedPDFConstants.LI);
-            // TODO: Add Lbl, LBody and kids
+            if (listItem.getLabelLength() > 0) {
+                COSObject lblObject = addStructElement(listItemObject, cosDocument, TaggedPDFConstants.LBL);
+                SemanticTextNode lblTextNode = new SemanticTextNode();
+                lblTextNode.add(new TextLine(listItem.getFirstLine(), 0, listItem.getLabelLength()));
+                //processTextNode(lblTextNode, lblObject);
+            }
+            COSObject lBodyObject = addStructElement(listItemObject, cosDocument, TaggedPDFConstants.LBODY);
+            SemanticTextNode lBodyTextNode = new SemanticTextNode();
+            for (TextLine line : listItem.getLines()) {
+                lBodyTextNode.add(line);
+            }
+            lBodyTextNode.setFirstLine(new TextLine(listItem.getFirstLine(), listItem.getLabelLength(), listItem.getFirstLine().getValue().length()));
+            //processTextNode(lBodyTextNode, lBodyObject);
+            for (IObject content : listItem.getContents()) {
+                createStructElem(content, lBodyObject, cosDocument);
+            }
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -6,6 +6,10 @@ import org.verapdf.cos.*;
 import org.verapdf.pd.*;
 import org.verapdf.tools.TaggedPDFConstants;
 import org.verapdf.wcag.algorithms.entities.*;
+import org.verapdf.wcag.algorithms.entities.lists.PDFList;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -109,8 +113,8 @@ public class AutoTaggingProcessor {
             createCaptionStructElem((SemanticCaption) object, parentStructElem, cosDocument);
 //        } else if (object instanceof PDFList) {
 //            createListStructElem((PDFList) object, parent, cosDocument);
-//        } else if (object instanceof TableBorder) {
-//            createTableStructElem((TableBorder) object, parentStructElem, cosDocument);
+        } else if (object instanceof TableBorder) {
+            createTableStructElem((TableBorder) object, parentStructElem, cosDocument);
 //        } else if (object instanceof ImageChunk) {
 //            createFigureStructElem((ImageChunk) object, parentStructElem, cosDocument);
         }
@@ -129,6 +133,25 @@ public class AutoTaggingProcessor {
     private static void createCaptionStructElem(SemanticCaption caption, COSObject parent, COSDocument cosDocument) {
         COSObject captionObject = addStructElement(parent, cosDocument, TaggedPDFConstants.CAPTION);
 //        processTextNode(caption, captionObject);
+    }
+
+    private static void createTableStructElem(TableBorder table, COSObject parent, COSDocument cosDocument) {
+        COSObject tableObject = addStructElement(parent, cosDocument, TaggedPDFConstants.TABLE);
+        for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
+            TableBorderRow row = table.getRow(rowNumber);
+            COSObject rowObject = addStructElement(tableObject, cosDocument, TaggedPDFConstants.TR);
+            for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
+                TableBorderCell cell = row.getCell(colNumber);
+                if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
+                    COSObject cellObject = addStructElement(rowObject, cosDocument, TaggedPDFConstants.TD);
+                    cellObject.setKey(ASAtom.COL_SPAN, COSInteger.construct(cell.getColSpan()));
+                    cellObject.setKey(ASAtom.ROW_SPAN, COSInteger.construct(cell.getRowSpan()));
+                    for (IObject cellContent : cell.getContents()) {
+                        createStructElem(cellContent, cellObject, cosDocument);
+                    }
+                }
+            }
+        }
     }
 
 //    protected static List<Object> getTokens(PDContentStream pdContentStream) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -6,6 +6,7 @@ import org.verapdf.cos.*;
 import org.verapdf.pd.*;
 import org.verapdf.tools.TaggedPDFConstants;
 import org.verapdf.wcag.algorithms.entities.*;
+import org.verapdf.wcag.algorithms.entities.lists.ListItem;
 import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
@@ -111,8 +112,8 @@ public class AutoTaggingProcessor {
             createParagraphStructElem((SemanticParagraph) object, parentStructElem, cosDocument);
         } else if (object instanceof SemanticCaption) {
             createCaptionStructElem((SemanticCaption) object, parentStructElem, cosDocument);
-//        } else if (object instanceof PDFList) {
-//            createListStructElem((PDFList) object, parent, cosDocument);
+        } else if (object instanceof PDFList) {
+            createListStructElem((PDFList) object, parentStructElem, cosDocument);
         } else if (object instanceof TableBorder) {
             createTableStructElem((TableBorder) object, parentStructElem, cosDocument);
 //        } else if (object instanceof ImageChunk) {
@@ -133,6 +134,23 @@ public class AutoTaggingProcessor {
     private static void createCaptionStructElem(SemanticCaption caption, COSObject parent, COSDocument cosDocument) {
         COSObject captionObject = addStructElement(parent, cosDocument, TaggedPDFConstants.CAPTION);
 //        processTextNode(caption, captionObject);
+    }
+
+    private static void createListStructElem(PDFList list, COSObject parent, COSDocument cosDocument) {
+        COSObject listObject = addStructElement(parent, cosDocument, TaggedPDFConstants.L);
+        if (list.getNextList() != null) {
+            listObject.setKey(ASAtom.ID, COSString.construct(String.valueOf(list.getRecognizedStructureId()).getBytes()));
+        }
+        if (list.getPreviousList() != null) {
+            listObject.setKey(ASAtom.CONTINUED_LIST, COSBoolean.construct(true));
+            listObject.setKey(ASAtom.CONTINUED_FROM, COSString.construct(String.valueOf(list.getPreviousList().getRecognizedStructureId()).getBytes()));
+        }
+        listObject.setKey(ASAtom.LIST_NUMBERING, COSName.construct(ListProcessor.getListNumbering(list.getNumberingStyle())));
+
+        for (ListItem listItem : list.getListItems()) {
+            COSObject listItemObject = addStructElement(listObject, cosDocument, TaggedPDFConstants.LI);
+            // TODO: Add Lbl, LBody and kids
+        }
     }
 
     private static void createTableStructElem(TableBorder table, COSObject parent, COSDocument cosDocument) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -60,11 +60,7 @@ public class AutoTaggingProcessor {
         createParentTree(cosDocument, structTreeRoot);
         String outputFileName = outputFolder + File.separator +
             inputPDF.getName().substring(0, inputPDF.getName().length() - 4) + "_tagged.pdf";
-        try (OutputStream output = new FileOutputStream(outputFileName)) {
-            document.saveTo(output);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        document.saveAs(outputFileName);
     }
 
     private static void updatePages(PDDocument document, COSDocument cosDocument) throws IOException {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -58,6 +58,7 @@ public class AutoTaggingProcessor {
         updatePages(document, cosDocument);
         createLinkAnnotationStructElements(document, cosDocument, seDocument);
         createParentTree(cosDocument, structTreeRoot);
+        cosDocument.getTrailer().removeKey(ASAtom.ENCRYPT);
         String outputFileName = outputFolder + File.separator +
             inputPDF.getName().substring(0, inputPDF.getName().length() - 4) + "_tagged.pdf";
         document.saveAs(outputFileName);
@@ -87,7 +88,6 @@ public class AutoTaggingProcessor {
                     cosDocument.addChangedObject(contentsObject);
                 } else {
                     page.getObject().setKey(ASAtom.CONTENTS, createContentsIndirect(cosDocument, processedTokens));
-                    cosDocument.addChangedObject(page.getObject());
                 }
             } else {
                 COSObject streamsArray = COSArray.construct();
@@ -98,7 +98,6 @@ public class AutoTaggingProcessor {
                     streamsArray.add(streamIndirect);
                 }
                 page.getObject().setKey(ASAtom.CONTENTS, streamsArray);
-                cosDocument.addChangedObject(page.getObject());
             }
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -4,7 +4,6 @@ import org.opendataloader.pdf.autotagging.ChunksWriter;
 import org.opendataloader.pdf.autotagging.OperatorStreamKey;
 import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticFormula;
-import org.opendataloader.pdf.entities.SemanticPicture;
 import org.verapdf.as.ASAtom;
 import org.verapdf.as.io.ASMemoryInStream;
 import org.verapdf.cos.*;
@@ -44,6 +43,8 @@ public class AutoTaggingProcessor {
     private static final Map<Long, SemanticCaption> structElementIdToCaptionMap = new HashMap<>();
     private static boolean isPDF2_0 = false;
     private static final int MAX_TOKENS_PER_STREAM = 100_000;
+    // imageChunkCounter is per-call; tracked via the figureObject index across a document
+    private static int imageChunkFigureCounter = 0;
 
     /**
      * Tag a PDF document in-memory without saving to disk.
@@ -319,40 +320,27 @@ public class AutoTaggingProcessor {
         // structParentsIntegers is populated by updatePages() which runs before this method.
         int annotStructParentKey = structParentsIntegers.isEmpty() ? 0
                 : structParentsIntegers.values().stream().mapToInt(Integer::intValue).max().getAsInt() + 1;
-        for (int pageNum = 0; pageNum < pages.size(); pageNum++) {
-            PDPage page = pages.get(pageNum);
+        for (int pageNumber = 0; pageNumber < pages.size(); pageNumber++) {
+            PDPage page = pages.get(pageNumber);
             List<PDAnnotation> annotations = page.getAnnotations();
             if (annotations == null) continue;
             boolean pageChanged = false;
             for (PDAnnotation annotation : annotations) {
-                if (!ASAtom.getASAtom("Link").equals(annotation.getSubtype())) continue;
                 COSObject annotObj = annotation.getObject();
                 if (annotObj == null || annotObj.empty()) continue;
-                // For indirect annotations, resolve the canonical COSObject via its key
-                // so that setKey writes go to the same instance that the writer will flush.
-                org.verapdf.cos.COSKey cosKey = annotObj.getObjectKey();
-                if (cosKey != null) {
-                    COSObject canonical = cosDocument.getObject(cosKey);
-                    if (canonical != null && !canonical.empty()) {
-                        annotObj = canonical;
-                    }
-                }
+                if (!ASAtom.LINK.equals(annotation.getSubtype())) continue;
                 // Get URI from action if available
                 String uriString = null;
                 try {
                     PDAction action = annotation.getA();
-                    if (action != null && action.getObject() != null && !action.getObject().empty()
-                            && ASAtom.getASAtom("URI").equals(action.getSubtype())) {
-                        COSObject uriObj = action.getObject().getKey(ASAtom.URI);
-                        if (uriObj != null && !uriObj.empty()) {
-                            uriString = uriObj.getString();
-                        }
+                    if (action != null && action.getObject() != null && ASAtom.URI.equals(action.getSubtype())) {
+                        uriString = action.getStringKey(ASAtom.URI);
                     }
                 } catch (Exception e) {
                     // ignore — URI not critical
                 }
                 // Create Link struct element
-                COSObject linkElem = addStructElement(seDocument, cosDocument, TaggedPDFConstants.LINK, pageNum);
+                COSObject linkElem = addStructElement(seDocument, cosDocument, TaggedPDFConstants.LINK, pageNumber);
                 // Set Alt text to URI or "Link"
                 String altText = uriString != null ? uriString : "Link";
                 linkElem.setKey(ASAtom.ALT, COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
@@ -360,7 +348,8 @@ public class AutoTaggingProcessor {
                 int structParentInt = annotStructParentKey++;
                 annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
                 // Set Contents on annotation if absent.
-                if (annotation.getContents() == null || annotation.getContents().isEmpty()) {
+                String contents = annotation.getContents();
+                if (contents == null || contents.isEmpty()) {
                     annotObj.setKey(ASAtom.CONTENTS,
                         COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
                 }
@@ -369,7 +358,7 @@ public class AutoTaggingProcessor {
                 pageChanged = true;
                 // Create OBJR pointing to the annotation
                 COSObject objr = COSDictionary.construct();
-                objr.setKey(ASAtom.TYPE, COSName.construct(ASAtom.getASAtom("OBJR")));
+                objr.setKey(ASAtom.TYPE, COSName.construct(ASAtom.OBJR));
                 objr.setKey(ASAtom.OBJ, annotObj);
                 objr.setKey(ASAtom.PG, page.getObject());
                 COSObject kArray = COSArray.construct();
@@ -401,7 +390,7 @@ public class AutoTaggingProcessor {
         } else if (object instanceof TableBorder) {
             TableBorder table = (TableBorder) object;
             if (table.isTextBlock()) {
-                createAsideStructElemForTextBlock(table, parentStructElem, cosDocument);
+                createStructElemForTextBlock(table, parentStructElem, cosDocument);
             } else if (!table.isOneCellTable()) {
                 createTableStructElem(table, parentStructElem, cosDocument);
             }
@@ -437,8 +426,6 @@ public class AutoTaggingProcessor {
         createFigureStructElemReturning(image, parent, cosDocument);
     }
 
-    // imageChunkCounter is per-call; tracked via the figureObject index across a document
-    private static int imageChunkFigureCounter = 0;
 
     private static COSObject createFigureStructElemReturning(ImageChunk image, COSObject parent, COSDocument cosDocument) {
         COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE, image.getPageNumber());
@@ -457,7 +444,7 @@ public class AutoTaggingProcessor {
     }
 
     private static void createFormulaStructElem(SemanticFormula formula, COSObject parent, COSDocument cosDocument) {
-        COSObject formulaObject = addStructElement(parent, cosDocument, "Formula", formula.getPageNumber());
+        COSObject formulaObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FORMULA, formula.getPageNumber());
         double[] bbox = {formula.getLeftX(), formula.getBottomY(), formula.getRightX(), formula.getTopY()};
         addAttributeToStructElem(formulaObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         String altText = formula.getLatex().isEmpty() ? "formula" : formula.getLatex();
@@ -517,11 +504,11 @@ public class AutoTaggingProcessor {
             for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
                 TableBorderCell cell = row.getCell(colNumber);
                 if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
-                    String cellTag = isHeaderRow ? "TH" : TaggedPDFConstants.TD;
+                    String cellTag = isHeaderRow ? TaggedPDFConstants.TH : TaggedPDFConstants.TD;
                     COSObject cellObject = addStructElement(rowObject, cosDocument, cellTag, cell.getPageNumber());
                     if (isHeaderRow) {
                         addAttributeToStructElem(cellObject, ASAtom.TABLE,
-                            ASAtom.getASAtom("Scope"), COSName.construct(ASAtom.getASAtom("Column")));
+                            ASAtom.SCOPE, COSName.construct(ASAtom.getASAtom("Column")));
                     }
                     if (cell.getColSpan() != 1) {
                         addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.COL_SPAN, COSInteger.construct(cell.getColSpan()));
@@ -537,8 +524,8 @@ public class AutoTaggingProcessor {
         return tableObject;
     }
 
-    private static void createAsideStructElemForTextBlock(TableBorder table, COSObject parent, COSDocument cosDocument) {
-        COSObject partObject = addStructElement(parent, cosDocument, TaggedPDFConstants.ASIDE, table.getPageNumber());
+    private static void createStructElemForTextBlock(TableBorder table, COSObject parent, COSDocument cosDocument) {
+        COSObject partObject = addStructElement(parent, cosDocument, isPDF2_0 ? TaggedPDFConstants.ASIDE : TaggedPDFConstants.ART, table.getPageNumber());
         TableBorderCell cell = table.getCell(0,0);
         addKids(cell.getContents(), partObject, cosDocument);
         addCaptionIfPresent(table, partObject, cosDocument);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -1,35 +1,45 @@
 package org.opendataloader.pdf.processors;
 
 import org.verapdf.as.ASAtom;
+import org.verapdf.as.io.ASInputStream;
+import org.verapdf.as.io.ASMemoryInStream;
 import org.verapdf.cos.*;
 
+import org.verapdf.operator.Operator;
+import org.verapdf.parser.Operators;
+import org.verapdf.parser.PDFStreamParser;
 import org.verapdf.pd.*;
 import org.verapdf.tools.TaggedPDFConstants;
 import org.verapdf.wcag.algorithms.entities.*;
 import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
+import org.verapdf.wcag.algorithms.entities.content.TextChunk;
+import org.verapdf.wcag.algorithms.entities.content.TextColumn;
 import org.verapdf.wcag.algorithms.entities.lists.ListItem;
 import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
+import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 public class AutoTaggingProcessor {
 
-//    private static List<Integer> mcids = new ArrayList<>();
-    private static List<COSObject> structParents = new ArrayList<>();
+    private static Map<Integer, List<Integer>> operatorIndexes = new HashMap<>();
+    private static Map<Integer, List<COSObject>> structParents = new HashMap<>();
+    private static final Set<String> operatorsForContents = new HashSet<>();
 
     public static void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
+        operatorIndexes.clear();
+        structParents.clear();
         COSDocument cosDocument = document.getDocument();
         PDCatalog catalog = document.getCatalog();
         COSObject structTreeRoot = createStructTreeRoot(catalog, cosDocument, document);
         createStructureTreeElements(contents, structTreeRoot, cosDocument);
-//        updatePages(document, cosDocument);
-//        createParentTree(cosDocument, structTreeRoot);
+        updatePages(document, cosDocument);
+        createParentTree(cosDocument, structTreeRoot);
         String outputFileName = outputFolder + File.separator +
             inputPDF.getName().substring(0, inputPDF.getName().length() - 4) + "_tagged.pdf";
         try (OutputStream output = new FileOutputStream(outputFileName)) {
@@ -39,21 +49,22 @@ public class AutoTaggingProcessor {
         }
     }
 
-//    private static void updatePages(PDDocument document, COSDocument cosDocument) throws IOException {
-//        List<org.verapdf.pd.PDPage> rawPages = document.getPages();
-//        for (PDPage page : rawPages) {
-//            page.getObject().setKey(ASAtom.STRUCT_PARENTS, COSInteger.construct(page.getPageNumber()));
-//            cosDocument.addChangedObject(page.getObject());
-//            COSObject contentsObject = page.getKey(ASAtom.CONTENTS);
-////            byte[] res = new PDFStreamWriter().write(processTokens(getTokens(page.getContent())));
-//            try (InputStream inStream = new ByteArrayInputStream(res)) {
-//                contentsObject.setData(new ASMemoryInStream(inStream));
-//            }
-//            contentsObject.setKey(ASAtom.FILTER, new COSObject());
-////            ((COSStream)contentsObject.getDirectBase()).setFilters(new COSFilters(COSName.construct(ASAtom.FLATE_DECODE)));
-//            cosDocument.addChangedObject(contentsObject);
-//        }
-//    }
+    private static void updatePages(PDDocument document, COSDocument cosDocument) throws IOException {
+        List<org.verapdf.pd.PDPage> rawPages = document.getPages();
+        for (int pageNumber = 0; pageNumber < rawPages.size(); pageNumber++) {
+            PDPage page = rawPages.get(pageNumber);
+            page.getObject().setKey(ASAtom.STRUCT_PARENTS, COSInteger.construct(page.getPageNumber()));
+            cosDocument.addChangedObject(page.getObject());
+            COSObject contentsObject = page.getKey(ASAtom.CONTENTS);
+            byte[] res = new PDFStreamWriter().write(processTokens(getTokens(page.getContent()), pageNumber));
+            try (InputStream inStream = new ByteArrayInputStream(res)) {
+                contentsObject.setData(new ASMemoryInStream(inStream));
+            }
+            contentsObject.setKey(ASAtom.FILTER, new COSObject());
+            ((COSStream)contentsObject.getDirectBase()).setFilters(new COSFilters(COSName.construct(ASAtom.FLATE_DECODE)));
+            cosDocument.addChangedObject(contentsObject);
+        }
+    }
 
     private static COSObject createStructTreeRoot(PDCatalog catalog, COSDocument cosDocument, PDDocument document) {
         COSObject structTreeRoot = COSIndirect.construct(COSDictionary.construct(), cosDocument);
@@ -65,21 +76,26 @@ public class AutoTaggingProcessor {
         return structTreeRoot;
     }
 
-//    private static void createParentTree(COSDocument cosDocument, COSObject structTreeRoot) {
-//        COSObject parentTree = COSIndirect.construct(COSDictionary.construct(), cosDocument);
-//        cosDocument.addObject(parentTree);
-//        structTreeRoot.setKey(ASAtom.PARENT_TREE, parentTree);
-//        COSObject nums = COSArray.construct();
-//        parentTree.setKey(ASAtom.NUMS, nums);
-//        nums.add(COSInteger.construct(0));//todo fix
-//        COSObject array = COSArray.construct();
-//        for (COSObject structParent : structParents) {
-//            array.add(structParent);
-//        }
-//        nums.add(array);
-//    }
+    private static void createParentTree(COSDocument cosDocument, COSObject structTreeRoot) {
+        COSObject parentTree = COSIndirect.construct(COSDictionary.construct(), cosDocument);
+        cosDocument.addObject(parentTree);
+        structTreeRoot.setKey(ASAtom.PARENT_TREE, parentTree);
+        COSObject nums = COSArray.construct();
+        parentTree.setKey(ASAtom.NUMS, nums);
+        for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
+            nums.add(COSInteger.construct(pageNumber));
+            COSObject array = COSArray.construct();
+            List<COSObject> pageStructParents = structParents.get(pageNumber);
+            if (pageStructParents != null) {
+                for (COSObject structParent : pageStructParents) {
+                    array.add(structParent);
+                }
+            }
+            nums.add(array);
+        }
+    }
 
-    private static COSObject addStructElement(COSObject parent, COSDocument cosDocument, String type) {
+    private static COSObject addStructElement(COSObject parent, COSDocument cosDocument, String type, Integer pageNumber) {
         COSObject structElement = COSIndirect.construct(COSDictionary.construct(), cosDocument);
         COSObject k = parent.getKey(ASAtom.K);
         if (k.getType() == COSObjType.COS_ARRAY) {
@@ -92,14 +108,16 @@ public class AutoTaggingProcessor {
         structElement.setKey(ASAtom.S, COSName.construct(type));
         structElement.setKey(ASAtom.TYPE, COSName.construct(ASAtom.STRUCT_ELEM));
         structElement.setKey(ASAtom.P, parent);
-        structElement.setKey(ASAtom.PG, cosDocument.getPDDocument().getPages().get(0).getObject());//todo calculate page number
+        if (pageNumber != null) {
+            structElement.setKey(ASAtom.PG, cosDocument.getPDDocument().getPages().get(pageNumber).getObject());
+        }
         cosDocument.addObject(structElement);
         return structElement;
     }
 
 
     public static void createStructureTreeElements(List<List<IObject>> contents, COSObject structTreeRoot, COSDocument cosDocument) {
-        COSObject seDocument = addStructElement(structTreeRoot, cosDocument, TaggedPDFConstants.DOCUMENT);
+        COSObject seDocument = addStructElement(structTreeRoot, cosDocument, TaggedPDFConstants.DOCUMENT, null);
         for (List<IObject> pageContents : contents) {
             for (IObject content : pageContents) {
                 createStructElem(content, seDocument, cosDocument);
@@ -124,56 +142,61 @@ public class AutoTaggingProcessor {
     }
 
     private static void createHeadingStructElem(SemanticHeading heading, COSObject parent, COSDocument cosDocument) {
-        COSObject headingObject = addStructElement(parent, cosDocument, TaggedPDFConstants.H + heading.getHeadingLevel());
-//        processTextNode(heading, headingObject);
+        COSObject headingObject = addStructElement(parent, cosDocument, TaggedPDFConstants.H + heading.getHeadingLevel(),
+            heading.getPageNumber());
+        processTextNode(heading, headingObject);
     }
 
     private static void createParagraphStructElem(SemanticParagraph paragraph, COSObject parent, COSDocument cosDocument) {
-        COSObject paragraphObject = addStructElement(parent, cosDocument, TaggedPDFConstants.P);
-//        processTextNode(paragraph, paragraphObject);
+        COSObject paragraphObject = addStructElement(parent, cosDocument, TaggedPDFConstants.P, paragraph.getPageNumber());
+        processTextNode(paragraph, paragraphObject);
     }
 
     private static void createCaptionStructElem(SemanticCaption caption, COSObject parent, COSDocument cosDocument) {
-        COSObject captionObject = addStructElement(parent, cosDocument, TaggedPDFConstants.CAPTION);
-//        processTextNode(caption, captionObject);
+        COSObject captionObject = addStructElement(parent, cosDocument, TaggedPDFConstants.CAPTION, caption.getPageNumber());
+        processTextNode(caption, captionObject);
     }
 
     private static void createFigureStructElem(ImageChunk image, COSObject parent, COSDocument cosDocument) {
-        COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE);
+        COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE, image.getPageNumber());
         double[] bbox = {image.getLeftX(), image.getBottomY(), image.getRightX(), image.getTopY()};
         addAttributeToStructElem(figureObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
-        //TODO: process image, add height and width attributes
+        processImageNode(image, figureObject);
+        //TODO: add height and width attributes
     }
 
     private static void createListStructElem(PDFList list, COSObject parent, COSDocument cosDocument) {
-        COSObject listObject = addStructElement(parent, cosDocument, TaggedPDFConstants.L);
+        COSObject listObject = addStructElement(parent, cosDocument, TaggedPDFConstants.L, list.getPageNumber());
         if (list.getNextList() != null) {
             listObject.setKey(ASAtom.ID, COSString.construct(String.valueOf(list.getRecognizedStructureId()).getBytes()));
         }
         if (list.getPreviousList() != null) {
             addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.CONTINUED_LIST, COSBoolean.construct(true));
-            addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.CONTINUED_FROM, COSString.construct(String.valueOf(list.getPreviousList().getRecognizedStructureId()).getBytes()));
+            addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.CONTINUED_FROM,
+                COSString.construct(String.valueOf(list.getPreviousList().getRecognizedStructureId()).getBytes()));
         }
-        addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.LIST_NUMBERING, COSName.construct(ListProcessor.getListNumbering(list.getNumberingStyle())));
+        addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.LIST_NUMBERING,
+            COSName.construct(ListProcessor.getListNumbering(list.getNumberingStyle())));
 
         for (ListItem listItem : list.getListItems()) {
-            COSObject listItemObject = addStructElement(listObject, cosDocument, TaggedPDFConstants.LI);
+            COSObject listItemObject = addStructElement(listObject, cosDocument, TaggedPDFConstants.LI, listItem.getPageNumber());
             int labelLength = listItem.getLabelLength();
             if (labelLength > 0) {
-                COSObject lblObject = addStructElement(listItemObject, cosDocument, TaggedPDFConstants.LBL);
+                COSObject lblObject = addStructElement(listItemObject, cosDocument, TaggedPDFConstants.LBL, listItem.getPageNumber());
                 SemanticTextNode lblTextNode = new SemanticTextNode();
                 lblTextNode.add(new TextLine(listItem.getFirstLine(), 0, listItem.getLabelLength()));
-                //processTextNode(lblTextNode, lblObject);
+                processTextNode(lblTextNode, lblObject);
             }
-            COSObject lBodyObject = addStructElement(listItemObject, cosDocument, TaggedPDFConstants.LBODY);
+            COSObject lBodyObject = addStructElement(listItemObject, cosDocument, TaggedPDFConstants.LBODY, listItem.getPageNumber());
             SemanticTextNode lBodyTextNode = new SemanticTextNode();
             for (TextLine line : listItem.getLines()) {
                 lBodyTextNode.add(line);
             }
             if (labelLength > 0) {
-                lBodyTextNode.setFirstLine(new TextLine(listItem.getFirstLine(), listItem.getLabelLength(), listItem.getFirstLine().getValue().length()));
+                lBodyTextNode.setFirstLine(new TextLine(listItem.getFirstLine(), listItem.getLabelLength(),
+                    listItem.getFirstLine().getValue().length()));
             }
-            //processTextNode(lBodyTextNode, lBodyObject);
+            processTextNode(lBodyTextNode, lBodyObject);
             for (IObject content : listItem.getContents()) {
                 createStructElem(content, lBodyObject, cosDocument);
             }
@@ -181,14 +204,14 @@ public class AutoTaggingProcessor {
     }
 
     private static void createTableStructElem(TableBorder table, COSObject parent, COSDocument cosDocument) {
-        COSObject tableObject = addStructElement(parent, cosDocument, TaggedPDFConstants.TABLE);
+        COSObject tableObject = addStructElement(parent, cosDocument, TaggedPDFConstants.TABLE, table.getPageNumber());
         for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
             TableBorderRow row = table.getRow(rowNumber);
-            COSObject rowObject = addStructElement(tableObject, cosDocument, TaggedPDFConstants.TR);
+            COSObject rowObject = addStructElement(tableObject, cosDocument, TaggedPDFConstants.TR, row.getPageNumber());
             for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
                 TableBorderCell cell = row.getCell(colNumber);
                 if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
-                    COSObject cellObject = addStructElement(rowObject, cosDocument, TaggedPDFConstants.TD);
+                    COSObject cellObject = addStructElement(rowObject, cosDocument, TaggedPDFConstants.TD, cell.getPageNumber());
                     if (cell.getColSpan() != 1) {
                         addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.COL_SPAN, COSInteger.construct(cell.getColSpan()));
                     }
@@ -203,7 +226,8 @@ public class AutoTaggingProcessor {
         }
     }
 
-    private static void addAttributeToStructElem(COSObject structElement, ASAtom ownerASAtom, ASAtom attributeName, COSObject attributeValue) {
+    private static void addAttributeToStructElem(COSObject structElement, ASAtom ownerASAtom, ASAtom attributeName,
+                                                 COSObject attributeValue) {
         COSObject aObject = structElement.getKey(ASAtom.A);
         COSObject owner = COSName.construct(ownerASAtom);
         if (aObject.empty()) {
@@ -236,82 +260,118 @@ public class AutoTaggingProcessor {
         structElement.setKey(ASAtom.A, aObject);
     }
 
-    private static void addAttributeDictionaryToArray(COSObject owner, ASAtom attributeName, COSObject attributeValue, COSObject aObject) {
+    private static void addAttributeDictionaryToArray(COSObject owner, ASAtom attributeName, COSObject attributeValue,
+                                                      COSObject aObject) {
         COSObject newADictionary = COSDictionary.construct();
         newADictionary.setKey(ASAtom.O, owner);
         newADictionary.setKey(attributeName, attributeValue);
         aObject.add(newADictionary);
     }
 
-//    protected static List<Object> getTokens(PDContentStream pdContentStream) {
-//        if (pdContentStream != null) {
-//            try {
-//                COSObject contentStream = pdContentStream.getContents();
-//                if (contentStream.getType() == COSObjType.COS_STREAM || contentStream.getType() == COSObjType.COS_ARRAY) {
-//                    try (ASInputStream opStream = contentStream.getDirectBase().getData(COSStream.FilterFlags.DECODE)) {
-//                        try (PDFStreamParser streamParser = new PDFStreamParser(opStream)) {
-//                            streamParser.parseTokens();
-//                            return streamParser.getTokens();
-//                        }
-//                    }
-//                }
-//            } catch (IOException e) {
-//            }
-//        }
-//        return Collections.emptyList();
-//    }
+    protected static List<Object> getTokens(PDContentStream pdContentStream) {
+        if (pdContentStream != null) {
+            try {
+                COSObject contentStream = pdContentStream.getContents();
+                if (contentStream.getType() == COSObjType.COS_STREAM || contentStream.getType() == COSObjType.COS_ARRAY) {
+                    try (ASInputStream opStream = contentStream.getDirectBase().getData(COSStream.FilterFlags.DECODE)) {
+                        try (PDFStreamParser streamParser = new PDFStreamParser(opStream)) {
+                            streamParser.parseTokens();
+                            return streamParser.getTokens();
+                        }
+                    }
+                }
+            } catch (IOException e) {
+            }
+        }
+        return Collections.emptyList();
+    }
 
-//    private static void processTextNode(SemanticTextNode textNode, COSObject cosObject) {
-//        List<Integer> mcids = new ArrayList<>();
-//        for (TextColumn textColumn : textNode.getColumns()) {
-//            for (TextLine textLine : textColumn.getLines()) {
-//                for (TextChunk textChunk : textLine.getTextChunks()) {
-//                    mcids.addAll(textChunk.getErrorCodes());
-//                }
-//            }
-//        }
-//        AutoTaggingProcessor.mcids.addAll(mcids);
-//        for (int index : mcids) {
-//            structParents.add(cosObject);
-//        }
-//        if (!mcids.isEmpty()) {
-//            COSObject array = COSArray.construct();
-//            cosObject.setKey(ASAtom.K, array);
-//            for (Integer mcid : mcids) {
-//                array.add(COSInteger.construct(AutoTaggingProcessor.mcids.indexOf(mcid)));
-//            }
-//        }
-//    }
+    private static void processTextNode(SemanticTextNode textNode, COSObject cosObject) {
+        Set<Integer> operatorIndexes = new LinkedHashSet<>();
+        for (TextColumn textColumn : textNode.getColumns()) {
+            for (TextLine textLine : textColumn.getLines()) {
+                for (TextChunk textChunk : textLine.getTextChunks()) {
+                    operatorIndexes.addAll(textChunk.getOperatorIndexes());
+                }
+            }
+        }
+        addMcidChildren(operatorIndexes, textNode.getPageNumber(), cosObject);
+    }
 
-//    protected static List<Object> processTokens(List<Object> processTokens) {
-//        List<Object> result = new ArrayList<>();
-//        List<Object> arguments = new ArrayList<>();
-//        for (int index = 0; index < processTokens.size(); index++) {
-//            Object token = processTokens.get(index);
-//            if (token instanceof COSBase) {
-//                arguments.add(token);
-//            } else if (token instanceof Operator) {
-//                if (Operators.BDC.equals(((Operator) token).getOperator()) ||
-//                    Operators.EMC.equals(((Operator) token).getOperator()) ||
-//                    Operators.BMC.equals(((Operator) token).getOperator())) {
-//                    arguments.clear();
-//                    continue;
-//                }
-//                if (mcids.contains(index)) {
-//                    result.add(COSName.construct("Span").getDirectBase());
-//                    COSObject dictionary = COSDictionary.construct();
-//                    dictionary.setKey(ASAtom.MCID, COSInteger.construct(mcids.indexOf(index)));
-//                    result.add(dictionary.getDirectBase());
-//                    result.add(Operator.getOperator(Operators.BDC));
-//                }
-//                result.addAll(arguments);
-//                arguments.clear();
-//                result.add(token);
-//                if (mcids.contains(index)) {
-//                    result.add(Operator.getOperator(Operators.EMC));
-//                }
-//            }
-//        }
-//        return result;
-//    }
+    private static void processImageNode(ImageChunk imageChunk, COSObject cosObject) {
+        addMcidChildren(new LinkedHashSet<>(imageChunk.getOperatorIndexes()), imageChunk.getPageNumber(), cosObject);
+    }
+
+    private static void addMcidChildren(Set<Integer> operatorIndexes, Integer pageNumber, COSObject cosObject) {
+        List<Integer> pageOperatorIndexes = AutoTaggingProcessor.operatorIndexes.computeIfAbsent(pageNumber, x -> new ArrayList<>());
+        pageOperatorIndexes.addAll(operatorIndexes);
+        for (int index : operatorIndexes) {
+            structParents.computeIfAbsent(pageNumber, x -> new ArrayList<>()).add(cosObject);
+        }
+        if (!operatorIndexes.isEmpty()) {
+            COSObject array = COSArray.construct();
+            cosObject.setKey(ASAtom.K, array);
+            for (Integer operatorIndex : operatorIndexes) {
+                array.add(COSInteger.construct(pageOperatorIndexes.indexOf(operatorIndex)));
+            }
+        }
+    }
+
+    protected static List<Object> processTokens(List<Object> processTokens, int pageNumber) {
+        List<Integer> pageOperatorIndexes = operatorIndexes.computeIfAbsent(pageNumber, x -> new ArrayList<>());
+        List<Object> result = new ArrayList<>();
+        List<Object> arguments = new ArrayList<>();
+        for (int index = 0; index < processTokens.size(); index++) {
+            Object token = processTokens.get(index);
+            if (token instanceof COSBase) {
+                arguments.add(token);
+            } else if (token instanceof Operator) {
+                String operatorName = ((Operator) token).getOperator();
+                if (Operators.BDC.equals(operatorName) || Operators.EMC.equals(operatorName) ||
+                    Operators.BMC.equals(operatorName)) {
+                    arguments.clear();
+                    continue;
+                }
+                if (operatorsForContents.contains(operatorName)) {
+                    if (pageOperatorIndexes.contains(index)) {
+                        if (Operators.BI.equals(operatorName) || Operators.DO.equals(operatorName)) {
+                            result.add(COSName.construct(TaggedPDFConstants.FIGURE).getDirectBase());
+                        } else {
+                            result.add(COSName.construct(TaggedPDFConstants.SPAN).getDirectBase());
+                        }
+                        COSObject dictionary = COSDictionary.construct();
+                        dictionary.setKey(ASAtom.MCID, COSInteger.construct(pageOperatorIndexes.indexOf(index)));
+                        result.add(dictionary.getDirectBase());
+                        result.add(Operator.getOperator(Operators.BDC));
+                    } else {
+                        result.add(COSName.construct(TaggedPDFConstants.ARTIFACT).getDirectBase());
+                        result.add(Operator.getOperator(Operators.BMC));
+                    }
+                }
+                result.addAll(arguments);
+                arguments.clear();
+                result.add(token);
+                if (operatorsForContents.contains(operatorName)) {
+                    result.add(Operator.getOperator(Operators.EMC));
+                }
+            }
+        }
+        return result;
+    }
+
+    static {
+        operatorsForContents.add(Operators.TJ_SHOW);
+        operatorsForContents.add(Operators.TJ_SHOW_POS);
+        operatorsForContents.add(Operators.QUOTE);
+        operatorsForContents.add(Operators.DOUBLE_QUOTE);
+        operatorsForContents.add(Operators.BI);
+        operatorsForContents.add(Operators.DO);//image or form?
+        operatorsForContents.add(Operators.F_FILL);
+        operatorsForContents.add(Operators.F_FILL_OBSOLETE);
+        operatorsForContents.add(Operators.F_STAR_FILL);
+        operatorsForContents.add(Operators.B_CLOSEPATH_FILL_STROKE);
+        operatorsForContents.add(Operators.B_STAR_CLOSEPATH_EOFILL_STROKE);
+        operatorsForContents.add(Operators.S_CLOSE_STROKE);
+        operatorsForContents.add(Operators.S_STROKE);
+    }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -172,7 +172,7 @@ public class AutoTaggingProcessor {
             TableBorder table = (TableBorder) object;
             if (table.isTextBlock()) {
                 createPartStructElemForTextBlock(table, parentStructElem, cosDocument);
-            } else {
+            } else if (!table.isOneCellTable()) {
                 createTableStructElem(table, parentStructElem, cosDocument);
             }
         } else if (object instanceof ImageChunk) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -135,7 +135,12 @@ public class AutoTaggingProcessor {
         } else if (object instanceof PDFList) {
             createListStructElem((PDFList) object, parentStructElem, cosDocument);
         } else if (object instanceof TableBorder) {
-            createTableStructElem((TableBorder) object, parentStructElem, cosDocument);
+            TableBorder table = (TableBorder) object;
+            if (table.isTextBlock()) {
+                createPartStructElemForTextBlock(table, parentStructElem, cosDocument);
+            } else {
+                createTableStructElem(table, parentStructElem, cosDocument);
+            }
         } else if (object instanceof ImageChunk) {
             createFigureStructElem((ImageChunk) object, parentStructElem, cosDocument);
         }
@@ -223,6 +228,14 @@ public class AutoTaggingProcessor {
                     }
                 }
             }
+        }
+    }
+
+    private static void createPartStructElemForTextBlock(TableBorder table, COSObject parent, COSDocument cosDocument) {
+        COSObject partObject = addStructElement(parent, cosDocument, TaggedPDFConstants.PART, table.getPageNumber());
+        TableBorderCell cell = table.getCell(0,0);
+        for (IObject cellContent : cell.getContents()) {
+            createStructElem(cellContent, partObject, cosDocument);
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -31,6 +31,7 @@ public class AutoTaggingProcessor {
     private static Map<Integer, List<COSObject>> structParents = new HashMap<>();
     private static final Set<String> operatorsForContents = new HashSet<>();
     private static boolean isPDF2_0 = false;
+    private static final int MAX_TOKENS_PER_STREAM = 100_000;
 
     public static void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
         operatorIndexes.clear();
@@ -60,20 +61,37 @@ public class AutoTaggingProcessor {
             page.getObject().setKey(ASAtom.STRUCT_PARENTS, COSInteger.construct(page.getPageNumber()));
             cosDocument.addChangedObject(page.getObject());
             COSObject contentsObject = page.getKey(ASAtom.CONTENTS);
-            byte[] res = new PDFStreamWriter().write(processTokens(getTokens(page.getContent()), pageNumber));
-            if (contentsObject != null && contentsObject.isIndirect() != null && contentsObject.isIndirect()) {
-                setUpContents(contentsObject, res);
-                cosDocument.addChangedObject(contentsObject);
+            List<Object> processedTokens = processTokens(getTokens(page.getContent()), pageNumber);
+
+            if (processedTokens.size() <= MAX_TOKENS_PER_STREAM) {
+                if (contentsObject != null && contentsObject.isIndirect() != null && contentsObject.isIndirect()) {
+                    setUpContents(contentsObject, processedTokens);
+                    cosDocument.addChangedObject(contentsObject);
+                } else {
+                    createContentsIndirect(cosDocument, processedTokens);
+                }
             } else {
-                COSObject newContentsObject = COSIndirect.construct(COSStream.construct(), cosDocument);
-                setUpContents(newContentsObject, res);
-                page.getObject().setKey(ASAtom.CONTENTS, newContentsObject);
-                cosDocument.addObject(newContentsObject);
+                COSObject streamsArray = COSArray.construct();
+                for (int start = 0; start < processedTokens.size(); start += MAX_TOKENS_PER_STREAM) {
+                    int end = Math.min(start + MAX_TOKENS_PER_STREAM, processedTokens.size());
+                    List<Object> chunk = processedTokens.subList(start, end);
+                    COSObject streamIndirect = createContentsIndirect(cosDocument, chunk);
+                    streamsArray.add(streamIndirect);
+                }
+                page.getObject().setKey(ASAtom.CONTENTS, streamsArray);
             }
         }
     }
 
-    private static void setUpContents(COSObject contentsObj, byte[] res) throws IOException {
+    private static COSObject createContentsIndirect(COSDocument cosDocument, List<Object> tokens) throws IOException {
+        COSObject streamObj = COSIndirect.construct(COSStream.construct(), cosDocument);
+        setUpContents(streamObj, tokens);
+        cosDocument.addObject(streamObj);
+        return streamObj;
+    }
+
+    private static void setUpContents(COSObject contentsObj, List<Object> tokens) throws IOException {
+        byte[] res = new PDFStreamWriter().write(tokens);
         try (InputStream inStream = new ByteArrayInputStream(res)) {
             contentsObj.setData(new ASMemoryInStream(inStream));
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -30,10 +30,14 @@ public class AutoTaggingProcessor {
     private static Map<Integer, List<Integer>> operatorIndexes = new HashMap<>();
     private static Map<Integer, List<COSObject>> structParents = new HashMap<>();
     private static final Set<String> operatorsForContents = new HashSet<>();
+    private static boolean isPDF2_0 = false;
 
     public static void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
         operatorIndexes.clear();
         structParents.clear();
+        if (document.getVersion() == 2.0F) {
+            isPDF2_0 = true;
+        }
         COSDocument cosDocument = document.getDocument();
         PDCatalog catalog = document.getCatalog();
         COSObject structTreeRoot = createStructTreeRoot(catalog, cosDocument, document);
@@ -159,7 +163,8 @@ public class AutoTaggingProcessor {
     }
 
     private static void createHeadingStructElem(SemanticHeading heading, COSObject parent, COSDocument cosDocument) {
-        COSObject headingObject = addStructElement(parent, cosDocument, TaggedPDFConstants.H + heading.getHeadingLevel(),
+        COSObject headingObject = addStructElement(parent, cosDocument,
+            isPDF2_0 ? TaggedPDFConstants.H + heading.getHeadingLevel() : TaggedPDFConstants.H,
             heading.getPageNumber());
         processTextNode(heading, headingObject);
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -57,13 +57,25 @@ public class AutoTaggingProcessor {
             cosDocument.addChangedObject(page.getObject());
             COSObject contentsObject = page.getKey(ASAtom.CONTENTS);
             byte[] res = new PDFStreamWriter().write(processTokens(getTokens(page.getContent()), pageNumber));
-            try (InputStream inStream = new ByteArrayInputStream(res)) {
-                contentsObject.setData(new ASMemoryInStream(inStream));
+            if (contentsObject != null && contentsObject.isIndirect() != null && contentsObject.isIndirect()) {
+                setUpContents(contentsObject, res);
+                cosDocument.addChangedObject(contentsObject);
+            } else {
+                COSObject newContentsObject = COSIndirect.construct(COSStream.construct(), cosDocument);
+                setUpContents(newContentsObject, res);
+                page.getObject().setKey(ASAtom.CONTENTS, newContentsObject);
+                cosDocument.addObject(newContentsObject);
             }
-            contentsObject.setKey(ASAtom.FILTER, new COSObject());
-            ((COSStream)contentsObject.getDirectBase()).setFilters(new COSFilters(COSName.construct(ASAtom.FLATE_DECODE)));
-            cosDocument.addChangedObject(contentsObject);
         }
+    }
+
+    private static void setUpContents(COSObject contentsObj, byte[] res) throws IOException {
+        try (InputStream inStream = new ByteArrayInputStream(res)) {
+            contentsObj.setData(new ASMemoryInStream(inStream));
+        }
+        contentsObj.setKey(ASAtom.FILTER, new COSObject());
+        COSStream newStream = (COSStream) contentsObj.getDirectBase();
+        newStream.setFilters(new COSFilters(COSName.construct(ASAtom.FLATE_DECODE)));
     }
 
     private static COSObject createStructTreeRoot(PDCatalog catalog, COSDocument cosDocument, PDDocument document) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -1,14 +1,16 @@
 package org.opendataloader.pdf.processors;
 
+import org.opendataloader.pdf.autotagging.ChunksWriter;
+import org.opendataloader.pdf.autotagging.OperatorStreamKey;
 import org.verapdf.as.ASAtom;
-import org.verapdf.as.io.ASInputStream;
 import org.verapdf.as.io.ASMemoryInStream;
 import org.verapdf.cos.*;
 
-import org.verapdf.operator.Operator;
-import org.verapdf.parser.Operators;
-import org.verapdf.parser.PDFStreamParser;
+import org.verapdf.gf.model.factory.chunks.GraphicsState;
+import org.verapdf.gf.model.impl.sa.util.ResourceHandler;
 import org.verapdf.pd.*;
+import org.verapdf.pd.images.PDXObject;
+import org.verapdf.tools.StaticResources;
 import org.verapdf.tools.TaggedPDFConstants;
 import org.verapdf.wcag.algorithms.entities.*;
 import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
@@ -20,22 +22,23 @@ import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
-import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
+import org.verapdf.wcag.algorithms.semanticalgorithms.utils.StreamInfo;
 
 import java.io.*;
 import java.util.*;
 
 public class AutoTaggingProcessor {
 
-    private static Map<Integer, List<Integer>> operatorIndexes = new HashMap<>();
-    private static Map<Integer, List<COSObject>> structParents = new HashMap<>();
-    private static final Set<String> operatorsForContents = new HashSet<>();
+    private static final Map<OperatorStreamKey, Map<Integer, Set<StreamInfo>>> operatorIndexesToStreamInfosMap = new HashMap<>();
+    private static final Map<OperatorStreamKey, List<COSObject>> structParents = new HashMap<>();
+    private static final Map<OperatorStreamKey, Integer> structParentsIntegers = new HashMap<>();
     private static boolean isPDF2_0 = false;
     private static final int MAX_TOKENS_PER_STREAM = 100_000;
 
     public static void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
-        operatorIndexes.clear();
+        operatorIndexesToStreamInfosMap.clear();
         structParents.clear();
+        structParentsIntegers.clear();
         if (document.getVersion() == 2.0F) {
             isPDF2_0 = true;
         }
@@ -55,14 +58,24 @@ public class AutoTaggingProcessor {
     }
 
     private static void updatePages(PDDocument document, COSDocument cosDocument) throws IOException {
+        int currentStructParent = 0;
+        for (OperatorStreamKey operatorStreamKey : structParents.keySet()) {
+            structParentsIntegers.put(operatorStreamKey, currentStructParent++);
+        }
         List<org.verapdf.pd.PDPage> rawPages = document.getPages();
         for (int pageNumber = 0; pageNumber < rawPages.size(); pageNumber++) {
             PDPage page = rawPages.get(pageNumber);
-            page.getObject().setKey(ASAtom.STRUCT_PARENTS, COSInteger.construct(page.getPageNumber()));
+            OperatorStreamKey operatorStreamKey = new OperatorStreamKey(pageNumber, null);
+            Integer structParent = structParentsIntegers.get(operatorStreamKey);
+            if (structParent == null) {
+                continue;
+            }
+            page.getObject().setKey(ASAtom.STRUCT_PARENTS, COSInteger.construct(structParent));
             cosDocument.addChangedObject(page.getObject());
             COSObject contentsObject = page.getKey(ASAtom.CONTENTS);
-            List<Object> processedTokens = processTokens(getTokens(page.getContent()), pageNumber);
-
+            ResourceHandler resourceHandler = ResourceHandler.getInstance(page.getResources());
+            List<Object> processedTokens = new ChunksWriter(new GraphicsState(resourceHandler),
+                resourceHandler).processTokens(ChunksWriter.getTokens(page.getContent()), operatorStreamKey);
             if (processedTokens.size() <= MAX_TOKENS_PER_STREAM) {
                 if (contentsObject != null && contentsObject.isIndirect() != null && contentsObject.isIndirect()) {
                     setUpContents(contentsObject, processedTokens);
@@ -90,7 +103,7 @@ public class AutoTaggingProcessor {
         return streamObj;
     }
 
-    private static void setUpContents(COSObject contentsObj, List<Object> tokens) throws IOException {
+    public static void setUpContents(COSObject contentsObj, List<Object> tokens) throws IOException {
         byte[] res = new PDFStreamWriter().write(tokens);
         try (InputStream inStream = new ByteArrayInputStream(res)) {
             contentsObj.setData(new ASMemoryInStream(inStream));
@@ -116,14 +129,11 @@ public class AutoTaggingProcessor {
         structTreeRoot.setKey(ASAtom.PARENT_TREE, parentTree);
         COSObject nums = COSArray.construct();
         parentTree.setKey(ASAtom.NUMS, nums);
-        for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
-            nums.add(COSInteger.construct(pageNumber));
+        for (Map.Entry<OperatorStreamKey, List<COSObject>> entry : structParents.entrySet()) {
+            nums.add(COSInteger.construct(structParentsIntegers.get(entry.getKey())));
             COSObject array = COSArray.construct();
-            List<COSObject> pageStructParents = structParents.get(pageNumber);
-            if (pageStructParents != null) {
-                for (COSObject structParent : pageStructParents) {
-                    array.add(structParent);
-                }
+            for (COSObject structParent : entry.getValue()) {
+                array.add(structParent);
             }
             nums.add(array);
         }
@@ -316,110 +326,79 @@ public class AutoTaggingProcessor {
         aObject.add(newADictionary);
     }
 
-    protected static List<Object> getTokens(PDContentStream pdContentStream) {
-        if (pdContentStream != null) {
-            try {
-                COSObject contentStream = pdContentStream.getContents();
-                if (contentStream.getType() == COSObjType.COS_STREAM || contentStream.getType() == COSObjType.COS_ARRAY) {
-                    try (ASInputStream opStream = contentStream.getDirectBase().getData(COSStream.FilterFlags.DECODE)) {
-                        try (PDFStreamParser streamParser = new PDFStreamParser(opStream)) {
-                            streamParser.parseTokens();
-                            return streamParser.getTokens();
-                        }
-                    }
-                }
-            } catch (IOException e) {
-            }
-        }
-        return Collections.emptyList();
-    }
-
     private static void processTextNode(SemanticTextNode textNode, COSObject cosObject) {
-        Set<Integer> operatorIndexes = new LinkedHashSet<>();
+        List<StreamInfo> streamInfos = new ArrayList<>();
         for (TextColumn textColumn : textNode.getColumns()) {
             for (TextLine textLine : textColumn.getLines()) {
                 for (TextChunk textChunk : textLine.getTextChunks()) {
-                    operatorIndexes.addAll(textChunk.getOperatorIndexes());
+                    streamInfos.addAll(textChunk.getStreamInfos());
                 }
             }
         }
-        addMcidChildren(operatorIndexes, textNode.getPageNumber(), cosObject);
+        addMcidChildren(streamInfos, textNode.getPageNumber(), cosObject);
     }
 
     private static void processImageNode(ImageChunk imageChunk, COSObject cosObject) {
-        addMcidChildren(new LinkedHashSet<>(imageChunk.getOperatorIndexes()), imageChunk.getPageNumber(), cosObject);
+        addMcidChildren(imageChunk.getStreamInfos(), imageChunk.getPageNumber(), cosObject);
     }
 
-    private static void addMcidChildren(Set<Integer> operatorIndexes, Integer pageNumber, COSObject cosObject) {
-        List<Integer> pageOperatorIndexes = AutoTaggingProcessor.operatorIndexes.computeIfAbsent(pageNumber, x -> new ArrayList<>());
-        pageOperatorIndexes.addAll(operatorIndexes);
-        for (int index : operatorIndexes) {
-            structParents.computeIfAbsent(pageNumber, x -> new ArrayList<>()).add(cosObject);
+    private static void addMcidChildren(List<StreamInfo> streamInfos, Integer pageNumber, COSObject cosObject) {
+        COSObject array = COSArray.construct();
+        if (streamInfos.isEmpty()) {
+            return;
         }
-        if (!operatorIndexes.isEmpty()) {
-            COSObject array = COSArray.construct();
-            cosObject.setKey(ASAtom.K, array);
-            for (Integer operatorIndex : operatorIndexes) {
-                array.add(COSInteger.construct(pageOperatorIndexes.indexOf(operatorIndex)));
+        cosObject.setKey(ASAtom.K, array);
+        List<StreamInfo> streamInfoList = getMergedStreamInfos(streamInfos);
+        for (StreamInfo streamInfo : streamInfoList) {
+            OperatorStreamKey operatorStreamKey = new OperatorStreamKey(pageNumber, streamInfo.getXObjectName());
+            List<COSObject> list = structParents.computeIfAbsent(operatorStreamKey, x -> new ArrayList<>());
+            int mcid = list.size();
+            COSObject mcidObject = COSInteger.construct(mcid);
+            streamInfo.setMcid(mcid);
+            operatorIndexesToStreamInfosMap.computeIfAbsent(operatorStreamKey, x -> new HashMap<>())
+                .computeIfAbsent(streamInfo.getOperatorIndex(), x -> new TreeSet<>()).add(streamInfo);
+            list.add(cosObject);
+            if (streamInfo.getXObjectName() != null) {
+                PDXObject pdxObject = StaticResources.getDocument().getPage(pageNumber).getResources()
+                    .getXObject(ASAtom.getASAtom(streamInfo.getXObjectName()));
+                COSObject mcrDictionary = COSDictionary.construct();
+                mcrDictionary.setKey(ASAtom.TYPE, COSName.construct(ASAtom.MCR));
+                mcrDictionary.setKey(ASAtom.MCID, mcidObject);
+                mcrDictionary.setKey(ASAtom.STM, pdxObject.getObject());
+                array.add(mcrDictionary);
+            } else {
+                array.add(mcidObject);
             }
         }
     }
 
-    protected static List<Object> processTokens(List<Object> processTokens, int pageNumber) {
-        List<Integer> pageOperatorIndexes = operatorIndexes.computeIfAbsent(pageNumber, x -> new ArrayList<>());
-        List<Object> result = new ArrayList<>();
-        List<Object> arguments = new ArrayList<>();
-        for (int index = 0; index < processTokens.size(); index++) {
-            Object token = processTokens.get(index);
-            if (token instanceof COSBase) {
-                arguments.add(token);
-            } else if (token instanceof Operator) {
-                String operatorName = ((Operator) token).getOperator();
-                if (Operators.BDC.equals(operatorName) || Operators.EMC.equals(operatorName) ||
-                    Operators.BMC.equals(operatorName)) {
-                    arguments.clear();
-                    continue;
-                }
-                if (operatorsForContents.contains(operatorName)) {
-                    if (pageOperatorIndexes.contains(index)) {
-                        if (Operators.BI.equals(operatorName) || Operators.DO.equals(operatorName)) {
-                            result.add(COSName.construct(TaggedPDFConstants.FIGURE).getDirectBase());
-                        } else {
-                            result.add(COSName.construct(TaggedPDFConstants.SPAN).getDirectBase());
-                        }
-                        COSObject dictionary = COSDictionary.construct();
-                        dictionary.setKey(ASAtom.MCID, COSInteger.construct(pageOperatorIndexes.indexOf(index)));
-                        result.add(dictionary.getDirectBase());
-                        result.add(Operator.getOperator(Operators.BDC));
-                    } else {
-                        result.add(COSName.construct(TaggedPDFConstants.ARTIFACT).getDirectBase());
-                        result.add(Operator.getOperator(Operators.BMC));
-                    }
-                }
-                result.addAll(arguments);
-                arguments.clear();
-                result.add(token);
-                if (operatorsForContents.contains(operatorName)) {
-                    result.add(Operator.getOperator(Operators.EMC));
-                }
+    private static List<StreamInfo> getMergedStreamInfos(List<StreamInfo> streamInfos) {
+        List<StreamInfo> streamInfoList = new ArrayList<>();
+        Iterator<StreamInfo> streamInfoIterator = streamInfos.iterator();
+        StreamInfo previousInfo = streamInfoIterator.next();
+        streamInfoList.add(previousInfo);
+        while (streamInfoIterator.hasNext()) {
+            StreamInfo currentStreamInfo = streamInfoIterator.next();
+            if (previousInfo.getOperatorIndex() == currentStreamInfo.getOperatorIndex() &&
+                previousInfo.getEndIndex() == currentStreamInfo.getStartIndex()) {
+                previousInfo.setEndIndex(currentStreamInfo.getEndIndex());
+            } else {
+                streamInfoList.add(currentStreamInfo);
+                previousInfo = currentStreamInfo;
             }
         }
-        return result;
+        return streamInfoList;
     }
 
-    static {
-        operatorsForContents.add(Operators.TJ_SHOW);
-        operatorsForContents.add(Operators.TJ_SHOW_POS);
-        operatorsForContents.add(Operators.QUOTE);
-        operatorsForContents.add(Operators.DOUBLE_QUOTE);
-        operatorsForContents.add(Operators.BI);
-        operatorsForContents.add(Operators.DO);//image or form?
-        operatorsForContents.add(Operators.F_FILL);
-        operatorsForContents.add(Operators.F_FILL_OBSOLETE);
-        operatorsForContents.add(Operators.F_STAR_FILL);
-        operatorsForContents.add(Operators.B_CLOSEPATH_FILL_STROKE);
-        operatorsForContents.add(Operators.B_STAR_CLOSEPATH_EOFILL_STROKE);
-        operatorsForContents.add(Operators.S_CLOSE_STROKE);
-        operatorsForContents.add(Operators.S_STROKE);
+    public static Map<OperatorStreamKey, Integer> getStructParentsIntegers() {
+        return structParentsIntegers;
+    }
+
+    public static Map<OperatorStreamKey, List<COSObject>> getStructParents() {
+        return structParents;
+    }
+
+    public static Map<OperatorStreamKey, Map<Integer, Set<StreamInfo>>> getOperatorIndexesToStreamInfosMap() {
+        return operatorIndexesToStreamInfosMap;
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -50,8 +50,8 @@ public class AutoTaggingProcessor {
         PDCatalog catalog = document.getCatalog();
         COSObject structTreeRoot = createStructTreeRoot(catalog, cosDocument, document);
         COSObject seDocument = createStructureTreeElements(contents, structTreeRoot, cosDocument);
-        createLinkAnnotationStructElements(document, cosDocument, seDocument);
         updatePages(document, cosDocument);
+        createLinkAnnotationStructElements(document, cosDocument, seDocument);
         createParentTree(cosDocument, structTreeRoot);
         String outputFileName = outputFolder + File.separator +
             inputPDF.getName().substring(0, inputPDF.getName().length() - 4) + "_tagged.pdf";
@@ -309,16 +309,28 @@ public class AutoTaggingProcessor {
 
     private static void createLinkAnnotationStructElements(PDDocument document, COSDocument cosDocument, COSObject seDocument) {
         List<PDPage> pages = document.getPages();
-        // Annotation StructParent integers start after the page range
-        int annotStructParentKey = document.getNumberOfPages();
+        // Annotation StructParent integers must start after all page StructParents.
+        // structParentsIntegers is populated by updatePages() which runs before this method.
+        int annotStructParentKey = structParentsIntegers.isEmpty() ? 0
+                : structParentsIntegers.values().stream().mapToInt(Integer::intValue).max().getAsInt() + 1;
         for (int pageNum = 0; pageNum < pages.size(); pageNum++) {
             PDPage page = pages.get(pageNum);
             List<PDAnnotation> annotations = page.getAnnotations();
             if (annotations == null) continue;
+            boolean pageChanged = false;
             for (PDAnnotation annotation : annotations) {
                 if (!ASAtom.getASAtom("Link").equals(annotation.getSubtype())) continue;
                 COSObject annotObj = annotation.getObject();
                 if (annotObj == null || annotObj.empty()) continue;
+                // For indirect annotations, resolve the canonical COSObject via its key
+                // so that setKey writes go to the same instance that the writer will flush.
+                org.verapdf.cos.COSKey cosKey = annotObj.getObjectKey();
+                if (cosKey != null) {
+                    COSObject canonical = cosDocument.getObject(cosKey);
+                    if (canonical != null && !canonical.empty()) {
+                        annotObj = canonical;
+                    }
+                }
                 // Get URI from action if available
                 String uriString = null;
                 try {
@@ -341,13 +353,14 @@ public class AutoTaggingProcessor {
                 // Assign StructParent integer to annotation and register in parent tree
                 int structParentInt = annotStructParentKey++;
                 annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
-                // Set Contents on annotation if absent — do both key writes before addChangedObject
+                // Set Contents on annotation if absent.
                 if (annotation.getContents() == null || annotation.getContents().isEmpty()) {
                     annotObj.setKey(ASAtom.CONTENTS,
                         COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
                 }
                 annotationStructParents.put(structParentInt, linkElem);
                 cosDocument.addChangedObject(annotObj);
+                pageChanged = true;
                 // Create OBJR pointing to the annotation
                 COSObject objr = COSDictionary.construct();
                 objr.setKey(ASAtom.TYPE, COSName.construct(ASAtom.getASAtom("OBJR")));
@@ -357,6 +370,15 @@ public class AutoTaggingProcessor {
                 kArray.add(objr);
                 linkElem.setKey(ASAtom.K, kArray);
                 cosDocument.addObject(linkElem);
+            }
+            // Flush the Annots array (may be an indirect object separate from the page)
+            // so that direct-object annotation dicts inside it (StructParent + Contents) are saved.
+            if (pageChanged) {
+                COSObject annotsObj = page.getKey(ASAtom.ANNOTS);
+                if (annotsObj != null && !annotsObj.empty()) {
+                    cosDocument.addChangedObject(annotsObj);
+                }
+                cosDocument.addChangedObject(page.getObject());
             }
         }
     }
@@ -568,11 +590,15 @@ public class AutoTaggingProcessor {
             if (streamInfo.getXObjectName() != null) {
                 PDXObject pdxObject = StaticResources.getDocument().getPage(pageNumber).getResources()
                     .getXObject(ASAtom.getASAtom(streamInfo.getXObjectName()));
-                COSObject mcrDictionary = COSDictionary.construct();
-                mcrDictionary.setKey(ASAtom.TYPE, COSName.construct(ASAtom.MCR));
-                mcrDictionary.setKey(ASAtom.MCID, mcidObject);
-                mcrDictionary.setKey(ASAtom.STM, pdxObject.getObject());
-                array.add(mcrDictionary);
+                if (pdxObject != null) {
+                    COSObject mcrDictionary = COSDictionary.construct();
+                    mcrDictionary.setKey(ASAtom.TYPE, COSName.construct(ASAtom.MCR));
+                    mcrDictionary.setKey(ASAtom.MCID, mcidObject);
+                    mcrDictionary.setKey(ASAtom.STM, pdxObject.getObject());
+                    array.add(mcrDictionary);
+                } else {
+                    array.add(mcidObject);
+                }
             } else {
                 array.add(mcidObject);
             }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -642,7 +642,7 @@ public class AutoTaggingProcessor {
         while (streamInfoIterator.hasNext()) {
             StreamInfo currentStreamInfo = streamInfoIterator.next();
             if (previousInfo.getOperatorIndex() == currentStreamInfo.getOperatorIndex() &&
-                previousInfo.getEndIndex() == currentStreamInfo.getStartIndex()) {
+                previousInfo.getEndIndex() <= currentStreamInfo.getStartIndex()) {
                 previousInfo.setEndIndex(currentStreamInfo.getEndIndex());
             } else {
                 streamInfoList.add(currentStreamInfo);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -21,6 +21,7 @@ import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextColumn;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
 import org.verapdf.wcag.algorithms.entities.lists.ListItem;
 import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
@@ -39,6 +40,8 @@ public class AutoTaggingProcessor {
     private static final Map<OperatorStreamKey, Integer> structParentsIntegers = new HashMap<>();
     // annotation StructParent entries: int key -> single struct element (Link)
     private static final Map<Integer, COSObject> annotationStructParents = new HashMap<>();
+    // Caption elements keyed by their linked content ID (Raman's approach from #377)
+    private static final Map<Long, SemanticCaption> structElementIdToCaptionMap = new HashMap<>();
     private static boolean isPDF2_0 = false;
     private static final int MAX_TOKENS_PER_STREAM = 100_000;
 
@@ -47,6 +50,7 @@ public class AutoTaggingProcessor {
         structParents.clear();
         structParentsIntegers.clear();
         annotationStructParents.clear();
+        structElementIdToCaptionMap.clear();
         imageChunkFigureCounter = 0;
         if (document.getVersion() == 2.0F) {
             isPDF2_0 = true;
@@ -156,10 +160,18 @@ public class AutoTaggingProcessor {
     }
 
     private static COSObject addStructElement(COSObject parent, COSDocument cosDocument, String type, Integer pageNumber) {
+        return addStructElement(parent, cosDocument, type, pageNumber, false);
+    }
+
+    private static COSObject addStructElement(COSObject parent, COSDocument cosDocument, String type, Integer pageNumber, boolean isFirstKid) {
         COSObject structElement = COSIndirect.construct(COSDictionary.construct(), cosDocument);
         COSObject k = parent.getKey(ASAtom.K);
         if (k.getType() == COSObjType.COS_ARRAY) {
-            k.add(structElement);
+            if (isFirstKid) {
+                k.insert(0, structElement);
+            } else {
+                k.add(structElement);
+            }
         } else {
             k = COSArray.construct();
             parent.setKey(ASAtom.K, k);
@@ -179,90 +191,71 @@ public class AutoTaggingProcessor {
     public static COSObject createStructureTreeElements(List<List<IObject>> contents, COSObject structTreeRoot, COSDocument cosDocument) {
         COSObject seDocument = addStructElement(structTreeRoot, cosDocument, TaggedPDFConstants.DOCUMENT, null);
         Map<SemanticHeading, Integer> normalizedLevels = buildNormalizedHeadingLevels(contents);
-        // Flatten all top-level content into a single ordered list for caption association.
-        List<IObject> flat = new ArrayList<>();
         for (List<IObject> pageContents : contents) {
-            flat.addAll(pageContents);
-        }
-        // Pre-compute which Caption maps to which float (Table/Figure) and whether it's
-        // a pre-caption (goes first) or post-caption (goes last).
-        // PDF/UA-2 §8.2.5.27: Caption must be first or last child of its parent.
-        // §Table5: Document must not directly contain Caption.
-        // Map each Caption index to its nearest adjacent float (Table/Figure) index.
-        // Captions will be attached as last child of their float parent regardless of
-        // source order, satisfying §8.2.5.27 (first or last child).
-        Map<Integer, Integer> captionToFloat = new HashMap<>();  // caption index → float index
-        for (int i = 0; i < flat.size(); i++) {
-            if (!(flat.get(i) instanceof SemanticCaption)) continue;
-            // Look ahead for next Table/Figure (within 2 items, skipping other captions)
-            for (int j = i + 1; j < flat.size() && j <= i + 2; j++) {
-                IObject next = flat.get(j);
-                if (isFloatElement(next)) { captionToFloat.put(i, j); break; }
-                if (!(next instanceof SemanticCaption)) break;
-            }
-            if (captionToFloat.containsKey(i)) continue;
-            // Look behind for previous Table/Figure
-            for (int j = i - 1; j >= 0 && j >= i - 2; j--) {
-                IObject prev = flat.get(j);
-                if (isFloatElement(prev)) { captionToFloat.put(i, j); break; }
-                if (!(prev instanceof SemanticCaption)) break;
-            }
-        }
-        // Build float index → struct element map (created on demand during iteration)
-        Map<Integer, COSObject> floatStructElems = new HashMap<>();
-        // First pass: create all non-Caption elements; defer Captions
-        for (int i = 0; i < flat.size(); i++) {
-            IObject content = flat.get(i);
-            if (content instanceof SemanticCaption) {
-                continue; // deferred — handled after its float is created
-            }
-            COSObject elem;
-            if (content instanceof SemanticHeading) {
-                elem = null;
-                createHeadingStructElem((SemanticHeading) content, seDocument, cosDocument,
-                        normalizedLevels.get(content));
-            } else if (content instanceof ImageChunk) {
-                elem = createFigureStructElemReturning((ImageChunk) content, seDocument, cosDocument);
-                floatStructElems.put(i, elem);
-            } else if (content instanceof TableBorder) {
-                TableBorder table = (TableBorder) content;
-                if (table.isTextBlock()) {
-                    createPartStructElemForTextBlock(table, seDocument, cosDocument);
-                    elem = null;
-                } else if (!table.isOneCellTable()) {
-                    elem = createTableStructElemReturning(table, seDocument, cosDocument);
-                    floatStructElems.put(i, elem);
-                } else {
-                    elem = null;
-                }
-            } else {
-                createStructElem(content, seDocument, cosDocument);
-                elem = null;
-            }
-        }
-        // Second pass: attach Captions to their float parent
-        for (int i = 0; i < flat.size(); i++) {
-            IObject content = flat.get(i);
-            if (!(content instanceof SemanticCaption)) continue;
-            Integer floatIdx = captionToFloat.get(i);
-            COSObject floatElem = floatIdx != null ? floatStructElems.get(floatIdx) : null;
-            if (floatElem != null) {
-                createCaptionStructElem((SemanticCaption) content, floatElem, cosDocument);
-            } else {
-                // No adjacent float found — add directly to Document as fallback
-                createCaptionStructElem((SemanticCaption) content, seDocument, cosDocument);
-            }
+            addKids(pageContents, seDocument, cosDocument, normalizedLevels);
         }
         return seDocument;
     }
 
-    private static boolean isFloatElement(IObject obj) {
-        if (obj instanceof ImageChunk) return true;
-        if (obj instanceof TableBorder) {
-            TableBorder t = (TableBorder) obj;
-            return !t.isTextBlock() && !t.isOneCellTable();
+    /**
+     * Adds child struct elements, collecting Captions and attaching them to their
+     * linked float (Figure/Table/List) via addCaptionIfPresent().
+     * Based on Raman Kakhnovich's approach from origin/auto_tagging #377.
+     */
+    private static void addKids(List<IObject> contents, COSObject parentStructElem, COSDocument cosDocument,
+                                 Map<SemanticHeading, Integer> normalizedLevels) {
+        // First pass: collect Caption → linkedContentId mappings
+        for (IObject content : contents) {
+            if (content instanceof SemanticCaption) {
+                structElementIdToCaptionMap.put(
+                    ((SemanticCaption) content).getLinkedContentId(), (SemanticCaption) content);
+            }
         }
-        return false;
+        // Second pass: create struct elements (skipping Captions — they are attached by addCaptionIfPresent)
+        for (IObject content : contents) {
+            if (content instanceof SemanticCaption) {
+                continue;
+            }
+            if (content instanceof SemanticHeading && normalizedLevels != null) {
+                createHeadingStructElem((SemanticHeading) content, parentStructElem, cosDocument,
+                    normalizedLevels.get(content));
+            } else {
+                createStructElem(content, parentStructElem, cosDocument);
+            }
+        }
+    }
+
+    /** Overload for nested contexts (list items, table cells) where heading normalization is not applicable. */
+    private static void addKids(List<IObject> contents, COSObject parentStructElem, COSDocument cosDocument) {
+        addKids(contents, parentStructElem, cosDocument, null);
+    }
+
+    /**
+     * If a Caption is linked to this content element, attach it as first or last child
+     * of the struct element based on spatial position.
+     */
+    private static void addCaptionIfPresent(IObject content, COSObject linkedObject, COSDocument cosDocument) {
+        Long linkedContentId = content.getRecognizedStructureId();
+        if (linkedContentId != null && structElementIdToCaptionMap.containsKey(linkedContentId)) {
+            SemanticCaption caption = structElementIdToCaptionMap.get(linkedContentId);
+            boolean isFirst = isCaptionFirstChild(caption.getBoundingBox(), content.getBoundingBox());
+            createCaptionStructElem(caption, linkedObject, cosDocument, isFirst);
+        }
+    }
+
+    /**
+     * Determines if the caption should be the first child (above/before) or last child
+     * (below/after) of its parent struct element.
+     */
+    private static boolean isCaptionFirstChild(BoundingBox caption, BoundingBox parent) {
+        if (caption == null || parent == null) return true;
+        if (caption.getCenterY() > parent.getTopY()) {
+            return true;
+        } else if (caption.getCenterY() < parent.getBottomY()) {
+            return false;
+        } else {
+            return caption.getCenterX() < parent.getCenterX();
+        }
     }
 
     /**
@@ -390,8 +383,6 @@ public class AutoTaggingProcessor {
                     ((SemanticHeading) object).getHeadingLevel());
         } else if (object instanceof SemanticParagraph) {
             createParagraphStructElem((SemanticParagraph) object, parentStructElem, cosDocument);
-        } else if (object instanceof SemanticCaption) {
-            createCaptionStructElem((SemanticCaption) object, parentStructElem, cosDocument);
         } else if (object instanceof PDFList) {
             createListStructElem((PDFList) object, parentStructElem, cosDocument);
         } else if (object instanceof TableBorder) {
@@ -424,8 +415,8 @@ public class AutoTaggingProcessor {
         processTextNode(paragraph, paragraphObject);
     }
 
-    private static void createCaptionStructElem(SemanticCaption caption, COSObject parent, COSDocument cosDocument) {
-        COSObject captionObject = addStructElement(parent, cosDocument, TaggedPDFConstants.CAPTION, caption.getPageNumber());
+    private static void createCaptionStructElem(SemanticCaption caption, COSObject parent, COSDocument cosDocument, boolean isFirstChild) {
+        COSObject captionObject = addStructElement(parent, cosDocument, TaggedPDFConstants.CAPTION, caption.getPageNumber(), isFirstChild);
         processTextNode(caption, captionObject);
     }
 
@@ -448,6 +439,7 @@ public class AutoTaggingProcessor {
                 COSString.construct(altText.getBytes(StandardCharsets.UTF_16), false));
         cosDocument.addChangedObject(figureObject);
         processImageNode(image, figureObject);
+        addCaptionIfPresent(image, figureObject, cosDocument);
         return figureObject;
     }
 
@@ -494,10 +486,9 @@ public class AutoTaggingProcessor {
                     listItem.getFirstLine().getValue().length()));
             }
             processTextNode(lBodyTextNode, lBodyObject);
-            for (IObject content : listItem.getContents()) {
-                createStructElem(content, lBodyObject, cosDocument);
-            }
+            addKids(listItem.getContents(), lBodyObject, cosDocument);
         }
+        addCaptionIfPresent(list, listObject, cosDocument);
     }
 
     private static void createTableStructElem(TableBorder table, COSObject parent, COSDocument cosDocument) {
@@ -525,21 +516,19 @@ public class AutoTaggingProcessor {
                     if (cell.getRowSpan() != 1) {
                         addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.ROW_SPAN, COSInteger.construct(cell.getRowSpan()));
                     }
-                    for (IObject cellContent : cell.getContents()) {
-                        createStructElem(cellContent, cellObject, cosDocument);
-                    }
+                    addKids(cell.getContents(), cellObject, cosDocument);
                 }
             }
         }
+        addCaptionIfPresent(table, tableObject, cosDocument);
         return tableObject;
     }
 
     private static void createPartStructElemForTextBlock(TableBorder table, COSObject parent, COSDocument cosDocument) {
         COSObject partObject = addStructElement(parent, cosDocument, TaggedPDFConstants.PART, table.getPageNumber());
         TableBorderCell cell = table.getCell(0,0);
-        for (IObject cellContent : cell.getContents()) {
-            createStructElem(cellContent, partObject, cosDocument);
-        }
+        addKids(cell.getContents(), partObject, cosDocument);
+        addCaptionIfPresent(table, partObject, cosDocument);
     }
 
     private static void addAttributeToStructElem(COSObject structElement, ASAtom ownerASAtom, ASAtom attributeName,

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -403,7 +403,7 @@ public class AutoTaggingProcessor {
         } else if (object instanceof TableBorder) {
             TableBorder table = (TableBorder) object;
             if (table.isTextBlock()) {
-                createPartStructElemForTextBlock(table, parentStructElem, cosDocument);
+                createAsideStructElemForTextBlock(table, parentStructElem, cosDocument);
             } else if (!table.isOneCellTable()) {
                 createTableStructElem(table, parentStructElem, cosDocument);
             }
@@ -539,8 +539,8 @@ public class AutoTaggingProcessor {
         return tableObject;
     }
 
-    private static void createPartStructElemForTextBlock(TableBorder table, COSObject parent, COSDocument cosDocument) {
-        COSObject partObject = addStructElement(parent, cosDocument, TaggedPDFConstants.PART, table.getPageNumber());
+    private static void createAsideStructElemForTextBlock(TableBorder table, COSObject parent, COSDocument cosDocument) {
+        COSObject partObject = addStructElement(parent, cosDocument, TaggedPDFConstants.ASIDE, table.getPageNumber());
         TableBorderCell cell = table.getCell(0,0);
         addKids(cell.getContents(), partObject, cosDocument);
         addCaptionIfPresent(table, partObject, cosDocument);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -3,6 +3,7 @@ package org.opendataloader.pdf.processors;
 import org.opendataloader.pdf.autotagging.ChunksWriter;
 import org.opendataloader.pdf.autotagging.OperatorStreamKey;
 import org.opendataloader.pdf.entities.EnrichedImageChunk;
+import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.verapdf.as.ASAtom;
 import org.verapdf.as.io.ASMemoryInStream;
@@ -405,6 +406,8 @@ public class AutoTaggingProcessor {
             } else if (!table.isOneCellTable()) {
                 createTableStructElem(table, parentStructElem, cosDocument);
             }
+        } else if (object instanceof SemanticFormula) {
+            createFormulaStructElem((SemanticFormula) object, parentStructElem, cosDocument);
         } else if (object instanceof ImageChunk) {
             createFigureStructElem((ImageChunk) object, parentStructElem, cosDocument);
         }
@@ -451,6 +454,17 @@ public class AutoTaggingProcessor {
         cosDocument.addChangedObject(figureObject);
         processImageNode(image, figureObject);
         return figureObject;
+    }
+
+    private static void createFormulaStructElem(SemanticFormula formula, COSObject parent, COSDocument cosDocument) {
+        COSObject formulaObject = addStructElement(parent, cosDocument, "Formula", formula.getPageNumber());
+        double[] bbox = {formula.getLeftX(), formula.getBottomY(), formula.getRightX(), formula.getTopY()};
+        addAttributeToStructElem(formulaObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
+        String altText = formula.getLatex().isEmpty() ? "formula" : formula.getLatex();
+        formulaObject.setKey(ASAtom.ALT,
+                COSString.construct(altText.getBytes(StandardCharsets.UTF_16), false));
+        cosDocument.addChangedObject(formulaObject);
+        addMcidChildren(formula.getStreamInfos(), formula.getPageNumber(), formulaObject);
     }
 
     private static void createListStructElem(PDFList list, COSObject parent, COSDocument cosDocument) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -179,17 +179,90 @@ public class AutoTaggingProcessor {
     public static COSObject createStructureTreeElements(List<List<IObject>> contents, COSObject structTreeRoot, COSDocument cosDocument) {
         COSObject seDocument = addStructElement(structTreeRoot, cosDocument, TaggedPDFConstants.DOCUMENT, null);
         Map<SemanticHeading, Integer> normalizedLevels = buildNormalizedHeadingLevels(contents);
+        // Flatten all top-level content into a single ordered list for caption association.
+        List<IObject> flat = new ArrayList<>();
         for (List<IObject> pageContents : contents) {
-            for (IObject content : pageContents) {
-                if (content instanceof SemanticHeading) {
-                    createHeadingStructElem((SemanticHeading) content, seDocument, cosDocument,
-                            normalizedLevels.get(content));
+            flat.addAll(pageContents);
+        }
+        // Pre-compute which Caption maps to which float (Table/Figure) and whether it's
+        // a pre-caption (goes first) or post-caption (goes last).
+        // PDF/UA-2 §8.2.5.27: Caption must be first or last child of its parent.
+        // §Table5: Document must not directly contain Caption.
+        // Map each Caption index to its nearest adjacent float (Table/Figure) index.
+        // Captions will be attached as last child of their float parent regardless of
+        // source order, satisfying §8.2.5.27 (first or last child).
+        Map<Integer, Integer> captionToFloat = new HashMap<>();  // caption index → float index
+        for (int i = 0; i < flat.size(); i++) {
+            if (!(flat.get(i) instanceof SemanticCaption)) continue;
+            // Look ahead for next Table/Figure (within 2 items, skipping other captions)
+            for (int j = i + 1; j < flat.size() && j <= i + 2; j++) {
+                IObject next = flat.get(j);
+                if (isFloatElement(next)) { captionToFloat.put(i, j); break; }
+                if (!(next instanceof SemanticCaption)) break;
+            }
+            if (captionToFloat.containsKey(i)) continue;
+            // Look behind for previous Table/Figure
+            for (int j = i - 1; j >= 0 && j >= i - 2; j--) {
+                IObject prev = flat.get(j);
+                if (isFloatElement(prev)) { captionToFloat.put(i, j); break; }
+                if (!(prev instanceof SemanticCaption)) break;
+            }
+        }
+        // Build float index → struct element map (created on demand during iteration)
+        Map<Integer, COSObject> floatStructElems = new HashMap<>();
+        // First pass: create all non-Caption elements; defer Captions
+        for (int i = 0; i < flat.size(); i++) {
+            IObject content = flat.get(i);
+            if (content instanceof SemanticCaption) {
+                continue; // deferred — handled after its float is created
+            }
+            COSObject elem;
+            if (content instanceof SemanticHeading) {
+                elem = null;
+                createHeadingStructElem((SemanticHeading) content, seDocument, cosDocument,
+                        normalizedLevels.get(content));
+            } else if (content instanceof ImageChunk) {
+                elem = createFigureStructElemReturning((ImageChunk) content, seDocument, cosDocument);
+                floatStructElems.put(i, elem);
+            } else if (content instanceof TableBorder) {
+                TableBorder table = (TableBorder) content;
+                if (table.isTextBlock()) {
+                    createPartStructElemForTextBlock(table, seDocument, cosDocument);
+                    elem = null;
+                } else if (!table.isOneCellTable()) {
+                    elem = createTableStructElemReturning(table, seDocument, cosDocument);
+                    floatStructElems.put(i, elem);
                 } else {
-                    createStructElem(content, seDocument, cosDocument);
+                    elem = null;
                 }
+            } else {
+                createStructElem(content, seDocument, cosDocument);
+                elem = null;
+            }
+        }
+        // Second pass: attach Captions to their float parent
+        for (int i = 0; i < flat.size(); i++) {
+            IObject content = flat.get(i);
+            if (!(content instanceof SemanticCaption)) continue;
+            Integer floatIdx = captionToFloat.get(i);
+            COSObject floatElem = floatIdx != null ? floatStructElems.get(floatIdx) : null;
+            if (floatElem != null) {
+                createCaptionStructElem((SemanticCaption) content, floatElem, cosDocument);
+            } else {
+                // No adjacent float found — add directly to Document as fallback
+                createCaptionStructElem((SemanticCaption) content, seDocument, cosDocument);
             }
         }
         return seDocument;
+    }
+
+    private static boolean isFloatElement(IObject obj) {
+        if (obj instanceof ImageChunk) return true;
+        if (obj instanceof TableBorder) {
+            TableBorder t = (TableBorder) obj;
+            return !t.isTextBlock() && !t.isOneCellTable();
+        }
+        return false;
     }
 
     /**
@@ -268,6 +341,11 @@ public class AutoTaggingProcessor {
                 // Assign StructParent integer to annotation and register in parent tree
                 int structParentInt = annotStructParentKey++;
                 annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
+                // Set Contents on annotation if absent — do both key writes before addChangedObject
+                if (annotation.getContents() == null || annotation.getContents().isEmpty()) {
+                    annotObj.setKey(ASAtom.CONTENTS,
+                        COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                }
                 annotationStructParents.put(structParentInt, linkElem);
                 cosDocument.addChangedObject(annotObj);
                 // Create OBJR pointing to the annotation
@@ -279,11 +357,6 @@ public class AutoTaggingProcessor {
                 kArray.add(objr);
                 linkElem.setKey(ASAtom.K, kArray);
                 cosDocument.addObject(linkElem);
-                // Set Contents on annotation if absent
-                if (annotation.getContents() == null || annotation.getContents().isEmpty()) {
-                    annotObj.setKey(ASAtom.CONTENTS,
-                        COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
-                }
             }
         }
     }
@@ -333,11 +406,15 @@ public class AutoTaggingProcessor {
     }
 
     private static void createFigureStructElem(ImageChunk image, COSObject parent, COSDocument cosDocument) {
+        createFigureStructElemReturning(image, parent, cosDocument);
+    }
+
+    private static COSObject createFigureStructElemReturning(ImageChunk image, COSObject parent, COSDocument cosDocument) {
         COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE, image.getPageNumber());
         double[] bbox = {image.getLeftX(), image.getBottomY(), image.getRightX(), image.getTopY()};
         addAttributeToStructElem(figureObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         processImageNode(image, figureObject);
-        //TODO: add height and width attributes
+        return figureObject;
     }
 
     private static void createListStructElem(PDFList list, COSObject parent, COSDocument cosDocument) {
@@ -379,6 +456,10 @@ public class AutoTaggingProcessor {
     }
 
     private static void createTableStructElem(TableBorder table, COSObject parent, COSDocument cosDocument) {
+        createTableStructElemReturning(table, parent, cosDocument);
+    }
+
+    private static COSObject createTableStructElemReturning(TableBorder table, COSObject parent, COSDocument cosDocument) {
         COSObject tableObject = addStructElement(parent, cosDocument, TaggedPDFConstants.TABLE, table.getPageNumber());
         for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
             TableBorderRow row = table.getRow(rowNumber);
@@ -399,6 +480,7 @@ public class AutoTaggingProcessor {
                 }
             }
         }
+        return tableObject;
     }
 
     private static void createPartStructElemForTextBlock(TableBorder table, COSObject parent, COSDocument cosDocument) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -178,12 +178,60 @@ public class AutoTaggingProcessor {
 
     public static COSObject createStructureTreeElements(List<List<IObject>> contents, COSObject structTreeRoot, COSDocument cosDocument) {
         COSObject seDocument = addStructElement(structTreeRoot, cosDocument, TaggedPDFConstants.DOCUMENT, null);
+        Map<SemanticHeading, Integer> normalizedLevels = buildNormalizedHeadingLevels(contents);
         for (List<IObject> pageContents : contents) {
             for (IObject content : pageContents) {
-                createStructElem(content, seDocument, cosDocument);
+                if (content instanceof SemanticHeading) {
+                    createHeadingStructElem((SemanticHeading) content, seDocument, cosDocument,
+                            normalizedLevels.get(content));
+                } else {
+                    createStructElem(content, seDocument, cosDocument);
+                }
             }
         }
         return seDocument;
+    }
+
+    /**
+     * Normalizes heading levels across the document so that:
+     * - The first heading is always H1.
+     * - A heading may not skip levels going down (e.g., H1→H3 becomes H1→H2).
+     * - A heading may jump back up freely (e.g., H3→H1 is fine).
+     * This satisfies PDF/UA-1 §7.4.2 (strict descending sequence, no skipping).
+     */
+    private static Map<SemanticHeading, Integer> buildNormalizedHeadingLevels(List<List<IObject>> contents) {
+        // Collect headings in document order
+        List<SemanticHeading> headings = new ArrayList<>();
+        for (List<IObject> page : contents) {
+            for (IObject obj : page) {
+                if (obj instanceof SemanticHeading) {
+                    headings.add((SemanticHeading) obj);
+                }
+            }
+        }
+        Map<SemanticHeading, Integer> result = new IdentityHashMap<>();
+        if (headings.isEmpty()) {
+            return result;
+        }
+        // Two-pass: first map original levels to a dense 1-based sequence,
+        // then assign normalized levels avoiding skips.
+        int currentNormalized = 1;
+        int prevOriginal = headings.get(0).getHeadingLevel();
+        result.put(headings.get(0), 1);
+        for (int i = 1; i < headings.size(); i++) {
+            int orig = headings.get(i).getHeadingLevel();
+            if (orig > prevOriginal) {
+                // Going deeper — allow only one step at a time
+                currentNormalized = Math.min(currentNormalized + 1, 6);
+            } else if (orig < prevOriginal) {
+                // Going back up — allow freely, but don't go below 1
+                currentNormalized = Math.max(currentNormalized - (prevOriginal - orig), 1);
+            }
+            // else same level — keep currentNormalized
+            result.put(headings.get(i), currentNormalized);
+            prevOriginal = orig;
+        }
+        return result;
     }
 
     private static void createLinkAnnotationStructElements(PDDocument document, COSDocument cosDocument, COSObject seDocument) {
@@ -242,7 +290,9 @@ public class AutoTaggingProcessor {
 
     private static void createStructElem(IObject object, COSObject parentStructElem, COSDocument cosDocument) {
         if (object instanceof SemanticHeading) {
-            createHeadingStructElem((SemanticHeading) object, parentStructElem, cosDocument);
+            // Fallback: heading inside a nested context (list/table) — use original level
+            createHeadingStructElem((SemanticHeading) object, parentStructElem, cosDocument,
+                    ((SemanticHeading) object).getHeadingLevel());
         } else if (object instanceof SemanticParagraph) {
             createParagraphStructElem((SemanticParagraph) object, parentStructElem, cosDocument);
         } else if (object instanceof SemanticCaption) {
@@ -261,12 +311,13 @@ public class AutoTaggingProcessor {
         }
     }
 
-    private static void createHeadingStructElem(SemanticHeading heading, COSObject parent, COSDocument cosDocument) {
-        // Always use H1-H6 — PDF/UA-1 §7.4.4 requires H to be the only child of
-        // its parent, which is violated when multiple headings share a parent.
-        // H1-H6 are valid in both PDF 1.x (via role map) and PDF 2.0.
+    private static void createHeadingStructElem(SemanticHeading heading, COSObject parent, COSDocument cosDocument,
+                                                int normalizedLevel) {
+        // Use the normalized level (1–6) so that:
+        // - PDF/UA-1 §7.4.4: H is the only child of its parent (satisfied by H1-H6)
+        // - PDF/UA-1 §7.4.2: heading levels do not skip (satisfied by normalization)
         COSObject headingObject = addStructElement(parent, cosDocument,
-            TaggedPDFConstants.H + heading.getHeadingLevel(),
+            TaggedPDFConstants.H + normalizedLevel,
             heading.getPageNumber());
         processTextNode(heading, headingObject);
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -36,7 +36,7 @@ public class AutoTaggingProcessor {
     private static boolean isPDF2_0 = false;
     private static final int MAX_TOKENS_PER_STREAM = 100_000;
 
-    public static void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
+    public static synchronized void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
         operatorIndexesToStreamInfosMap.clear();
         structParents.clear();
         structParentsIntegers.clear();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -35,9 +35,9 @@ import java.util.*;
 
 public class AutoTaggingProcessor {
 
-    private static final Map<OperatorStreamKey, Map<Integer, Set<StreamInfo>>> operatorIndexesToStreamInfosMap = new HashMap<>();
-    private static final Map<OperatorStreamKey, List<COSObject>> structParents = new HashMap<>();
-    private static final Map<OperatorStreamKey, Integer> structParentsIntegers = new HashMap<>();
+    private static final Map<OperatorStreamKey, Map<Integer, Set<StreamInfo>>> operatorIndexesToStreamInfosMap = new LinkedHashMap<>();
+    private static final Map<OperatorStreamKey, List<COSObject>> structParents = new LinkedHashMap<>();
+    private static final Map<OperatorStreamKey, Integer> structParentsIntegers = new LinkedHashMap<>();
     // annotation StructParent entries: int key -> single struct element (Link)
     private static final Map<Integer, COSObject> annotationStructParents = new HashMap<>();
     // Caption elements keyed by their linked content ID (Raman's approach from #377)
@@ -60,9 +60,7 @@ public class AutoTaggingProcessor {
         annotationStructParents.clear();
         structElementIdToCaptionMap.clear();
         imageChunkFigureCounter = 0;
-        if (document.getVersion() == 2.0F) {
-            isPDF2_0 = true;
-        }
+        isPDF2_0 = document.getVersion() == 2.0F;
         COSDocument cosDocument = document.getDocument();
         PDCatalog catalog = document.getCatalog();
         COSObject structTreeRoot = createStructTreeRoot(catalog, cosDocument, document);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -106,6 +106,7 @@ public class AutoTaggingProcessor {
                     cosDocument.addChangedObject(contentsObject);
                 } else {
                     page.getObject().setKey(ASAtom.CONTENTS, createContentsIndirect(cosDocument, processedTokens));
+                    cosDocument.addChangedObject(page.getObject());
                 }
             } else {
                 COSObject streamsArray = COSArray.construct();
@@ -116,6 +117,7 @@ public class AutoTaggingProcessor {
                     streamsArray.add(streamIndirect);
                 }
                 page.getObject().setKey(ASAtom.CONTENTS, streamsArray);
+                cosDocument.addChangedObject(page.getObject());
             }
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -33,6 +33,8 @@ public class AutoTaggingProcessor {
     private static final Map<OperatorStreamKey, Map<Integer, Set<StreamInfo>>> operatorIndexesToStreamInfosMap = new HashMap<>();
     private static final Map<OperatorStreamKey, List<COSObject>> structParents = new HashMap<>();
     private static final Map<OperatorStreamKey, Integer> structParentsIntegers = new HashMap<>();
+    // annotation StructParent entries: int key -> single struct element (Link)
+    private static final Map<Integer, COSObject> annotationStructParents = new HashMap<>();
     private static boolean isPDF2_0 = false;
     private static final int MAX_TOKENS_PER_STREAM = 100_000;
 
@@ -40,6 +42,7 @@ public class AutoTaggingProcessor {
         operatorIndexesToStreamInfosMap.clear();
         structParents.clear();
         structParentsIntegers.clear();
+        annotationStructParents.clear();
         if (document.getVersion() == 2.0F) {
             isPDF2_0 = true;
         }
@@ -132,14 +135,24 @@ public class AutoTaggingProcessor {
         structTreeRoot.setKey(ASAtom.PARENT_TREE, parentTree);
         COSObject nums = COSArray.construct();
         parentTree.setKey(ASAtom.NUMS, nums);
+        int nextKey = 0;
         for (Map.Entry<OperatorStreamKey, List<COSObject>> entry : structParents.entrySet()) {
-            nums.add(COSInteger.construct(structParentsIntegers.get(entry.getKey())));
+            int key = structParentsIntegers.get(entry.getKey());
+            nums.add(COSInteger.construct(key));
             COSObject array = COSArray.construct();
             for (COSObject structParent : entry.getValue()) {
                 array.add(structParent);
             }
             nums.add(array);
+            if (key >= nextKey) nextKey = key + 1;
         }
+        // Add single-entry annotations (Link annotations) to parent tree
+        for (Map.Entry<Integer, COSObject> entry : annotationStructParents.entrySet()) {
+            nums.add(COSInteger.construct(entry.getKey()));
+            nums.add(entry.getValue());
+            if (entry.getKey() >= nextKey) nextKey = entry.getKey() + 1;
+        }
+        structTreeRoot.setKey(ASAtom.PARENT_TREE_NEXT_KEY, COSInteger.construct(nextKey));
     }
 
     private static COSObject addStructElement(COSObject parent, COSDocument cosDocument, String type, Integer pageNumber) {
@@ -175,6 +188,8 @@ public class AutoTaggingProcessor {
 
     private static void createLinkAnnotationStructElements(PDDocument document, COSDocument cosDocument, COSObject seDocument) {
         List<PDPage> pages = document.getPages();
+        // Annotation StructParent integers start after the page range
+        int annotStructParentKey = document.getNumberOfPages();
         for (int pageNum = 0; pageNum < pages.size(); pageNum++) {
             PDPage page = pages.get(pageNum);
             List<PDAnnotation> annotations = page.getAnnotations();
@@ -202,6 +217,11 @@ public class AutoTaggingProcessor {
                 // Set Alt text to URI or "Link"
                 String altText = uriString != null ? uriString : "Link";
                 linkElem.setKey(ASAtom.ALT, COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                // Assign StructParent integer to annotation and register in parent tree
+                int structParentInt = annotStructParentKey++;
+                annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
+                annotationStructParents.put(structParentInt, linkElem);
+                cosDocument.addChangedObject(annotObj);
                 // Create OBJR pointing to the annotation
                 COSObject objr = COSDictionary.construct();
                 objr.setKey(ASAtom.TYPE, COSName.construct(ASAtom.getASAtom("OBJR")));
@@ -215,7 +235,6 @@ public class AutoTaggingProcessor {
                 if (annotation.getContents() == null || annotation.getContents().isEmpty()) {
                     annotObj.setKey(ASAtom.CONTENTS,
                         COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
-                    cosDocument.addChangedObject(annotObj);
                 }
             }
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -262,8 +262,11 @@ public class AutoTaggingProcessor {
     }
 
     private static void createHeadingStructElem(SemanticHeading heading, COSObject parent, COSDocument cosDocument) {
+        // Always use H1-H6 — PDF/UA-1 §7.4.4 requires H to be the only child of
+        // its parent, which is violated when multiple headings share a parent.
+        // H1-H6 are valid in both PDF 1.x (via role map) and PDF 2.0.
         COSObject headingObject = addStructElement(parent, cosDocument,
-            isPDF2_0 ? TaggedPDFConstants.H + heading.getHeadingLevel() : TaggedPDFConstants.H,
+            TaggedPDFConstants.H + heading.getHeadingLevel(),
             heading.getPageNumber());
         processTextNode(heading, headingObject);
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -71,7 +71,6 @@ public class AutoTaggingProcessor {
                 continue;
             }
             page.getObject().setKey(ASAtom.STRUCT_PARENTS, COSInteger.construct(structParent));
-            cosDocument.addChangedObject(page.getObject());
             COSObject contentsObject = page.getKey(ASAtom.CONTENTS);
             ResourceHandler resourceHandler = ResourceHandler.getInstance(page.getResources());
             List<Object> processedTokens = new ChunksWriter(new GraphicsState(resourceHandler),
@@ -81,7 +80,8 @@ public class AutoTaggingProcessor {
                     setUpContents(contentsObject, processedTokens);
                     cosDocument.addChangedObject(contentsObject);
                 } else {
-                    createContentsIndirect(cosDocument, processedTokens);
+                    page.getObject().setKey(ASAtom.CONTENTS, createContentsIndirect(cosDocument, processedTokens));
+                    cosDocument.addChangedObject(page.getObject());
                 }
             } else {
                 COSObject streamsArray = COSArray.construct();
@@ -92,6 +92,7 @@ public class AutoTaggingProcessor {
                     streamsArray.add(streamIndirect);
                 }
                 page.getObject().setKey(ASAtom.CONTENTS, streamsArray);
+                cosDocument.addChangedObject(page.getObject());
             }
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -9,6 +9,7 @@ import org.verapdf.cos.*;
 import org.verapdf.gf.model.factory.chunks.GraphicsState;
 import org.verapdf.gf.model.impl.sa.util.ResourceHandler;
 import org.verapdf.pd.*;
+import org.verapdf.pd.actions.PDAction;
 import org.verapdf.pd.images.PDXObject;
 import org.verapdf.tools.StaticResources;
 import org.verapdf.tools.TaggedPDFConstants;
@@ -45,7 +46,8 @@ public class AutoTaggingProcessor {
         COSDocument cosDocument = document.getDocument();
         PDCatalog catalog = document.getCatalog();
         COSObject structTreeRoot = createStructTreeRoot(catalog, cosDocument, document);
-        createStructureTreeElements(contents, structTreeRoot, cosDocument);
+        COSObject seDocument = createStructureTreeElements(contents, structTreeRoot, cosDocument);
+        createLinkAnnotationStructElements(document, cosDocument, seDocument);
         updatePages(document, cosDocument);
         createParentTree(cosDocument, structTreeRoot);
         String outputFileName = outputFolder + File.separator +
@@ -161,11 +163,57 @@ public class AutoTaggingProcessor {
     }
 
 
-    public static void createStructureTreeElements(List<List<IObject>> contents, COSObject structTreeRoot, COSDocument cosDocument) {
+    public static COSObject createStructureTreeElements(List<List<IObject>> contents, COSObject structTreeRoot, COSDocument cosDocument) {
         COSObject seDocument = addStructElement(structTreeRoot, cosDocument, TaggedPDFConstants.DOCUMENT, null);
         for (List<IObject> pageContents : contents) {
             for (IObject content : pageContents) {
                 createStructElem(content, seDocument, cosDocument);
+            }
+        }
+        return seDocument;
+    }
+
+    private static void createLinkAnnotationStructElements(PDDocument document, COSDocument cosDocument, COSObject seDocument) {
+        List<PDPage> pages = document.getPages();
+        for (int pageNum = 0; pageNum < pages.size(); pageNum++) {
+            PDPage page = pages.get(pageNum);
+            List<PDAnnotation> annotations = page.getAnnotations();
+            if (annotations == null) continue;
+            for (PDAnnotation annotation : annotations) {
+                if (!ASAtom.getASAtom("Link").equals(annotation.getSubtype())) continue;
+                // Get URI from action if available
+                String uriString = null;
+                try {
+                    PDAction action = annotation.getA();
+                    if (action != null && ASAtom.getASAtom("URI").equals(action.getSubtype())) {
+                        COSObject uriObj = action.getObject().getKey(ASAtom.URI);
+                        if (!uriObj.empty()) {
+                            uriString = uriObj.getString();
+                        }
+                    }
+                } catch (Exception e) {
+                    // ignore — URI not critical
+                }
+                // Create Link struct element
+                COSObject linkElem = addStructElement(seDocument, cosDocument, TaggedPDFConstants.LINK, pageNum);
+                // Set Alt text to URI or "Link"
+                String altText = uriString != null ? uriString : "Link";
+                linkElem.setKey(ASAtom.ALT, COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                // Create OBJR pointing to the annotation
+                COSObject objr = COSDictionary.construct();
+                objr.setKey(ASAtom.TYPE, COSName.construct(ASAtom.getASAtom("OBJR")));
+                objr.setKey(ASAtom.OBJ, annotation.getObject());
+                objr.setKey(ASAtom.PG, page.getObject());
+                COSObject kArray = COSArray.construct();
+                kArray.add(objr);
+                linkElem.setKey(ASAtom.K, kArray);
+                cosDocument.addObject(linkElem);
+                // Set Contents on annotation if absent
+                if (annotation.getContents() == null || annotation.getContents().isEmpty()) {
+                    annotation.getObject().setKey(ASAtom.CONTENTS,
+                        COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                    cosDocument.addChangedObject(annotation.getObject());
+                }
             }
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -45,7 +45,15 @@ public class AutoTaggingProcessor {
     private static boolean isPDF2_0 = false;
     private static final int MAX_TOKENS_PER_STREAM = 100_000;
 
-    public static synchronized void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
+    /**
+     * Tag a PDF document in-memory without saving to disk.
+     * Adds structure tree, marked content references, and parent tree to the document.
+     *
+     * @param inputPDF  the original PDF file (used for metadata only)
+     * @param document  the PDDocument to tag (modified in place)
+     * @param contents  extracted content by page
+     */
+    public static synchronized void tagDocument(File inputPDF, PDDocument document, List<List<IObject>> contents) throws IOException {
         operatorIndexesToStreamInfosMap.clear();
         structParents.clear();
         structParentsIntegers.clear();
@@ -63,6 +71,13 @@ public class AutoTaggingProcessor {
         createLinkAnnotationStructElements(document, cosDocument, seDocument);
         createParentTree(cosDocument, structTreeRoot);
         cosDocument.getTrailer().removeKey(ASAtom.ENCRYPT);
+    }
+
+    /**
+     * Tag a PDF document and save to disk. Existing behavior preserved.
+     */
+    public static synchronized void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
+        tagDocument(inputPDF, document, contents);
         String outputFileName = outputFolder + File.separator +
             inputPDF.getName().substring(0, inputPDF.getName().length() - 4) + "_tagged.pdf";
         document.saveAs(outputFileName);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -181,13 +181,16 @@ public class AutoTaggingProcessor {
             if (annotations == null) continue;
             for (PDAnnotation annotation : annotations) {
                 if (!ASAtom.getASAtom("Link").equals(annotation.getSubtype())) continue;
+                COSObject annotObj = annotation.getObject();
+                if (annotObj == null || annotObj.empty()) continue;
                 // Get URI from action if available
                 String uriString = null;
                 try {
                     PDAction action = annotation.getA();
-                    if (action != null && ASAtom.getASAtom("URI").equals(action.getSubtype())) {
+                    if (action != null && action.getObject() != null && !action.getObject().empty()
+                            && ASAtom.getASAtom("URI").equals(action.getSubtype())) {
                         COSObject uriObj = action.getObject().getKey(ASAtom.URI);
-                        if (!uriObj.empty()) {
+                        if (uriObj != null && !uriObj.empty()) {
                             uriString = uriObj.getString();
                         }
                     }
@@ -202,7 +205,7 @@ public class AutoTaggingProcessor {
                 // Create OBJR pointing to the annotation
                 COSObject objr = COSDictionary.construct();
                 objr.setKey(ASAtom.TYPE, COSName.construct(ASAtom.getASAtom("OBJR")));
-                objr.setKey(ASAtom.OBJ, annotation.getObject());
+                objr.setKey(ASAtom.OBJ, annotObj);
                 objr.setKey(ASAtom.PG, page.getObject());
                 COSObject kArray = COSArray.construct();
                 kArray.add(objr);
@@ -210,9 +213,9 @@ public class AutoTaggingProcessor {
                 cosDocument.addObject(linkElem);
                 // Set Contents on annotation if absent
                 if (annotation.getContents() == null || annotation.getContents().isEmpty()) {
-                    annotation.getObject().setKey(ASAtom.CONTENTS,
+                    annotObj.setKey(ASAtom.CONTENTS,
                         COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
-                    cosDocument.addChangedObject(annotation.getObject());
+                    cosDocument.addChangedObject(annotObj);
                 }
             }
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -72,10 +72,10 @@ public class AutoTaggingProcessor {
             PDPage page = rawPages.get(pageNumber);
             OperatorStreamKey operatorStreamKey = new OperatorStreamKey(pageNumber, null);
             Integer structParent = structParentsIntegers.get(operatorStreamKey);
-            if (structParent == null) {
-                continue;
+            if (structParent != null) {
+                page.getObject().setKey(ASAtom.STRUCT_PARENTS, COSInteger.construct(structParent));
+                cosDocument.addChangedObject(page.getObject());
             }
-            page.getObject().setKey(ASAtom.STRUCT_PARENTS, COSInteger.construct(structParent));
             COSObject contentsObject = page.getKey(ASAtom.CONTENTS);
             ResourceHandler resourceHandler = ResourceHandler.getInstance(page.getResources());
             List<Object> processedTokens = new ChunksWriter(new GraphicsState(resourceHandler),

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -2,6 +2,8 @@ package org.opendataloader.pdf.processors;
 
 import org.opendataloader.pdf.autotagging.ChunksWriter;
 import org.opendataloader.pdf.autotagging.OperatorStreamKey;
+import org.opendataloader.pdf.entities.EnrichedImageChunk;
+import org.opendataloader.pdf.entities.SemanticPicture;
 import org.verapdf.as.ASAtom;
 import org.verapdf.as.io.ASMemoryInStream;
 import org.verapdf.cos.*;
@@ -26,6 +28,7 @@ import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.StreamInfo;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class AutoTaggingProcessor {
@@ -43,6 +46,7 @@ public class AutoTaggingProcessor {
         structParents.clear();
         structParentsIntegers.clear();
         annotationStructParents.clear();
+        imageChunkFigureCounter = 0;
         if (document.getVersion() == 2.0F) {
             isPDF2_0 = true;
         }
@@ -431,10 +435,20 @@ public class AutoTaggingProcessor {
         createFigureStructElemReturning(image, parent, cosDocument);
     }
 
+    // imageChunkCounter is per-call; tracked via the figureObject index across a document
+    private static int imageChunkFigureCounter = 0;
+
     private static COSObject createFigureStructElemReturning(ImageChunk image, COSObject parent, COSDocument cosDocument) {
         COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE, image.getPageNumber());
         double[] bbox = {image.getLeftX(), image.getBottomY(), image.getRightX(), image.getTopY()};
         addAttributeToStructElem(figureObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
+        // Use enriched description if available, otherwise fallback "image N"
+        String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
+                ? ((EnrichedImageChunk) image).sanitizeDescription()
+                : "image " + (++imageChunkFigureCounter);
+        figureObject.setKey(ASAtom.ALT,
+                COSString.construct(altText.getBytes(StandardCharsets.UTF_16), false));
+        cosDocument.addChangedObject(figureObject);
         processImageNode(image, figureObject);
         return figureObject;
     }
@@ -486,10 +500,16 @@ public class AutoTaggingProcessor {
         for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
             TableBorderRow row = table.getRow(rowNumber);
             COSObject rowObject = addStructElement(tableObject, cosDocument, TaggedPDFConstants.TR, row.getPageNumber());
+            boolean isHeaderRow = (rowNumber == 0);
             for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
                 TableBorderCell cell = row.getCell(colNumber);
                 if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
-                    COSObject cellObject = addStructElement(rowObject, cosDocument, TaggedPDFConstants.TD, cell.getPageNumber());
+                    String cellTag = isHeaderRow ? "TH" : TaggedPDFConstants.TD;
+                    COSObject cellObject = addStructElement(rowObject, cosDocument, cellTag, cell.getPageNumber());
+                    if (isHeaderRow) {
+                        addAttributeToStructElem(cellObject, ASAtom.TABLE,
+                            ASAtom.getASAtom("Scope"), COSName.construct(ASAtom.getASAtom("Column")));
+                    }
                     if (cell.getColSpan() != 1) {
                         addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.COL_SPAN, COSInteger.construct(cell.getColSpan()));
                     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -324,16 +324,25 @@ public class DocumentProcessor {
                     if (structured) {
                         pageContents = ListProcessor.processListsFromTextNodes(pageContents);
                         HeadingProcessor.processHeadings(pageContents, false);
-                        CaptionProcessor.processCaptions(pageContents);
                     }
                     contents.set(pageNumber, pageContents);
                 })
             ).get();
 
-            // Sequential ID assignment (must be in page order)
+            // Sequential ID assignment (must be in page order, before CaptionProcessor)
             for (int pageNumber = 0; pageNumber < totalPages; pageNumber++) {
                 if (shouldProcessPage(pageNumber, pagesToProcess)) {
                     setIDs(contents.get(pageNumber));
+                }
+            }
+
+            // Caption detection runs after setIDs so that recognizedStructureId is available
+            // for linking captions to figures/tables
+            if (structured) {
+                for (int pageNumber = 0; pageNumber < totalPages; pageNumber++) {
+                    if (shouldProcessPage(pageNumber, pagesToProcess)) {
+                        CaptionProcessor.processCaptions(contents.get(pageNumber));
+                    }
                 }
             }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -89,7 +89,31 @@ public class DocumentProcessor {
      * @throws IOException if unable to process the file
      */
     public static ProcessingResult processFileWithResult(String inputPdfName, Config config) throws IOException {
-        // --- Extraction (steps 1-5): parsing + layout analysis + content extraction ---
+        // Phase 1: Extract
+        ExtractionResult extraction = extractContents(inputPdfName, config);
+
+        // Phase 2: Output (JSON/MD/HTML/PDF/Text)
+        long t0 = System.nanoTime();
+        generateOutputs(inputPdfName, extraction.getContents(), config);
+        long outputNs = System.nanoTime() - t0;
+
+        return new ProcessingResult(extraction.getHybridTimings(), extraction.getExtractionNs(), outputNs);
+    }
+
+    /**
+     * Run the extraction pipeline only (preprocessing + content extraction + sanitization).
+     * Does not generate any output files. The returned {@link ExtractionResult} can be
+     * passed to {@link org.opendataloader.pdf.api.AutoTagger} or used to generate
+     * specific output formats.
+     *
+     * <p>Structured processing (headings, lists, tables, captions) is always enabled
+     * because auto-tagging and all structured output formats depend on it.
+     *
+     * @param inputPdfName path to the input PDF file
+     * @param config       configuration
+     * @return extraction result with contents and timing metadata
+     */
+    public static ExtractionResult extractContents(String inputPdfName, Config config) throws IOException {
         long t0 = System.nanoTime();
         preprocessing(inputPdfName, config);
         calculateDocumentInfo();
@@ -102,62 +126,13 @@ public class DocumentProcessor {
         } else {
             contents = processDocument(inputPdfName, config, pagesToProcess);
         }
-        if (config.needsStructuredProcessing()) {
-            sortContents(contents, config);
-        }
+        sortContents(contents, config);
         ContentSanitizer contentSanitizer = new ContentSanitizer(config.getFilterConfig().getFilterRules(),
             config.getFilterConfig().isFilterSensitiveData());
         contentSanitizer.sanitizeContents(contents);
         long extractionNs = System.nanoTime() - t0;
 
-        // --- Output (step 6): auto-tagging + JSON/MD/HTML export ---
-        t0 = System.nanoTime();
-        generateOutputs(inputPdfName, contents, config);
-        long outputNs = System.nanoTime() - t0;
-
-        return new ProcessingResult(HybridDocumentProcessor.getLastHybridTimings(), extractionNs, outputNs);
-    }
-
-    /**
-     * Run the extraction pipeline only (preprocessing + content extraction + sanitization).
-     * Does not generate any output files. Used by {@link org.opendataloader.pdf.api.AutoTagger}.
-     *
-     * @param inputPdfName path to the input PDF file
-     * @param config       configuration
-     * @return extraction result with contents and timing metadata
-     */
-    public static ExtractionResult extractContents(String inputPdfName, Config config) throws IOException {
-        // Auto-tagging always needs structured processing (headings, lists, tables, captions).
-        // Temporarily enable a structured output flag so processDocument() runs HeadingProcessor etc.
-        boolean hadStructured = config.needsStructuredProcessing();
-        if (!hadStructured) {
-            config.setGenerateJSON(true);
-        }
-        try {
-            long t0 = System.nanoTime();
-            preprocessing(inputPdfName, config);
-            calculateDocumentInfo();
-            Set<Integer> pagesToProcess = getValidPageNumbers(config);
-            List<List<IObject>> contents;
-            if (StaticLayoutContainers.isUseStructTree()) {
-                contents = TaggedDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);
-            } else if (config.isHybridEnabled()) {
-                contents = HybridDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);
-            } else {
-                contents = processDocument(inputPdfName, config, pagesToProcess);
-            }
-            sortContents(contents, config);
-            ContentSanitizer contentSanitizer = new ContentSanitizer(config.getFilterConfig().getFilterRules(),
-                config.getFilterConfig().isFilterSensitiveData());
-            contentSanitizer.sanitizeContents(contents);
-            long extractionNs = System.nanoTime() - t0;
-
-            return new ExtractionResult(contents, extractionNs, HybridDocumentProcessor.getLastHybridTimings());
-        } finally {
-            if (!hadStructured) {
-                config.setGenerateJSON(false);
-            }
-        }
+        return new ExtractionResult(contents, extractionNs, HybridDocumentProcessor.getLastHybridTimings());
     }
 
     /**
@@ -278,7 +253,9 @@ public class DocumentProcessor {
                 }
             }
 
-            boolean structured = config.needsStructuredProcessing();
+            // Structured processing is always enabled — auto-tagging needs headings,
+            // lists, tables, and captions regardless of output format flags.
+            boolean structured = true;
 
             // ClusterTableProcessor: whole-document (must be sequential)
             if (structured && config.isClusterTableMethod()) {
@@ -404,6 +381,10 @@ public class DocumentProcessor {
             StaticLayoutContainers.setImagesDirectory(imagesDirectory);
             ImagesUtils imagesUtils = new ImagesUtils();
             imagesUtils.write(contents, inputPdfName, config.getPassword());
+        }
+        if (config.isGenerateTaggedPDF()) {
+            AutoTaggingProcessor.createTaggedPDF(inputPDF, config.getOutputFolder(),
+                StaticResources.getDocument(), contents);
         }
         if (config.isGeneratePDF()) {
             PDFWriter pdfWriter = new PDFWriter();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -119,6 +119,38 @@ public class DocumentProcessor {
     }
 
     /**
+     * Run the extraction pipeline only (preprocessing + content extraction + sanitization).
+     * Does not generate any output files. Used by {@link org.opendataloader.pdf.api.AutoTagger}.
+     *
+     * @param inputPdfName path to the input PDF file
+     * @param config       configuration
+     * @return extraction result with contents and timing metadata
+     */
+    public static ExtractionResult extractContents(String inputPdfName, Config config) throws IOException {
+        long t0 = System.nanoTime();
+        preprocessing(inputPdfName, config);
+        calculateDocumentInfo();
+        Set<Integer> pagesToProcess = getValidPageNumbers(config);
+        List<List<IObject>> contents;
+        if (StaticLayoutContainers.isUseStructTree()) {
+            contents = TaggedDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);
+        } else if (config.isHybridEnabled()) {
+            contents = HybridDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);
+        } else {
+            contents = processDocument(inputPdfName, config, pagesToProcess);
+        }
+        if (config.needsStructuredProcessing()) {
+            sortContents(contents, config);
+        }
+        ContentSanitizer contentSanitizer = new ContentSanitizer(config.getFilterConfig().getFilterRules(),
+            config.getFilterConfig().isFilterSensitiveData());
+        contentSanitizer.sanitizeContents(contents);
+        long extractionNs = System.nanoTime() - t0;
+
+        return new ExtractionResult(contents, extractionNs, HybridDocumentProcessor.getLastHybridTimings());
+    }
+
+    /**
      * Validates and filters page numbers from config against actual document pages.
      * Logs warnings for pages that don't exist in the document.
      *

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -76,6 +76,21 @@ public class DocumentProcessor {
      * @throws IOException if unable to process the file
      */
     public static void processFile(String inputPdfName, Config config) throws IOException {
+        processFileWithResult(inputPdfName, config);
+    }
+
+    /**
+     * Processes a PDF file and returns a {@link ProcessingResult} containing
+     * metadata collected during processing (e.g., hybrid server timings).
+     *
+     * @param inputPdfName the path to the input PDF file
+     * @param config the configuration settings
+     * @return processing result with optional metadata
+     * @throws IOException if unable to process the file
+     */
+    public static ProcessingResult processFileWithResult(String inputPdfName, Config config) throws IOException {
+        // --- Extraction (steps 1-5): parsing + layout analysis + content extraction ---
+        long t0 = System.nanoTime();
         preprocessing(inputPdfName, config);
         calculateDocumentInfo();
         Set<Integer> pagesToProcess = getValidPageNumbers(config);
@@ -93,7 +108,14 @@ public class DocumentProcessor {
         ContentSanitizer contentSanitizer = new ContentSanitizer(config.getFilterConfig().getFilterRules(),
             config.getFilterConfig().isFilterSensitiveData());
         contentSanitizer.sanitizeContents(contents);
+        long extractionNs = System.nanoTime() - t0;
+
+        // --- Output (step 6): auto-tagging + JSON/MD/HTML export ---
+        t0 = System.nanoTime();
         generateOutputs(inputPdfName, contents, config);
+        long outputNs = System.nanoTime() - t0;
+
+        return new ProcessingResult(HybridDocumentProcessor.getLastHybridTimings(), extractionNs, outputNs);
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -127,6 +127,13 @@ public class DocumentProcessor {
      * @return extraction result with contents and timing metadata
      */
     public static ExtractionResult extractContents(String inputPdfName, Config config) throws IOException {
+        // Auto-tagging always needs structured processing (headings, lists, tables, captions).
+        // Force a structured output flag so processDocument() runs HeadingProcessor etc.
+        boolean hadStructured = config.needsStructuredProcessing();
+        if (!hadStructured) {
+            config.setGenerateJSON(true);
+        }
+
         long t0 = System.nanoTime();
         preprocessing(inputPdfName, config);
         calculateDocumentInfo();
@@ -139,8 +146,11 @@ public class DocumentProcessor {
         } else {
             contents = processDocument(inputPdfName, config, pagesToProcess);
         }
-        if (config.needsStructuredProcessing()) {
-            sortContents(contents, config);
+        sortContents(contents, config);
+
+        // Restore config
+        if (!hadStructured) {
+            config.setGenerateJSON(false);
         }
         ContentSanitizer contentSanitizer = new ContentSanitizer(config.getFilterConfig().getFilterRules(),
             config.getFilterConfig().isFilterSensitiveData());

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -332,6 +332,7 @@ public class DocumentProcessor {
             ImagesUtils imagesUtils = new ImagesUtils();
             imagesUtils.write(contents, inputPdfName, config.getPassword());
         }
+        AutoTaggingProcessor.createTaggedPDF(inputPDF, config.getOutputFolder(), StaticResources.getDocument(), contents);
         if (config.isGeneratePDF()) {
             PDFWriter pdfWriter = new PDFWriter();
             pdfWriter.updatePDF(inputPDF, config.getPassword(), config.getOutputFolder(), contents);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -128,36 +128,36 @@ public class DocumentProcessor {
      */
     public static ExtractionResult extractContents(String inputPdfName, Config config) throws IOException {
         // Auto-tagging always needs structured processing (headings, lists, tables, captions).
-        // Force a structured output flag so processDocument() runs HeadingProcessor etc.
+        // Temporarily enable a structured output flag so processDocument() runs HeadingProcessor etc.
         boolean hadStructured = config.needsStructuredProcessing();
         if (!hadStructured) {
             config.setGenerateJSON(true);
         }
+        try {
+            long t0 = System.nanoTime();
+            preprocessing(inputPdfName, config);
+            calculateDocumentInfo();
+            Set<Integer> pagesToProcess = getValidPageNumbers(config);
+            List<List<IObject>> contents;
+            if (StaticLayoutContainers.isUseStructTree()) {
+                contents = TaggedDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);
+            } else if (config.isHybridEnabled()) {
+                contents = HybridDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);
+            } else {
+                contents = processDocument(inputPdfName, config, pagesToProcess);
+            }
+            sortContents(contents, config);
+            ContentSanitizer contentSanitizer = new ContentSanitizer(config.getFilterConfig().getFilterRules(),
+                config.getFilterConfig().isFilterSensitiveData());
+            contentSanitizer.sanitizeContents(contents);
+            long extractionNs = System.nanoTime() - t0;
 
-        long t0 = System.nanoTime();
-        preprocessing(inputPdfName, config);
-        calculateDocumentInfo();
-        Set<Integer> pagesToProcess = getValidPageNumbers(config);
-        List<List<IObject>> contents;
-        if (StaticLayoutContainers.isUseStructTree()) {
-            contents = TaggedDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);
-        } else if (config.isHybridEnabled()) {
-            contents = HybridDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);
-        } else {
-            contents = processDocument(inputPdfName, config, pagesToProcess);
+            return new ExtractionResult(contents, extractionNs, HybridDocumentProcessor.getLastHybridTimings());
+        } finally {
+            if (!hadStructured) {
+                config.setGenerateJSON(false);
+            }
         }
-        sortContents(contents, config);
-
-        // Restore config
-        if (!hadStructured) {
-            config.setGenerateJSON(false);
-        }
-        ContentSanitizer contentSanitizer = new ContentSanitizer(config.getFilterConfig().getFilterRules(),
-            config.getFilterConfig().isFilterSensitiveData());
-        contentSanitizer.sanitizeContents(contents);
-        long extractionNs = System.nanoTime() - t0;
-
-        return new ExtractionResult(contents, extractionNs, HybridDocumentProcessor.getLastHybridTimings());
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -386,7 +386,6 @@ public class DocumentProcessor {
             ImagesUtils imagesUtils = new ImagesUtils();
             imagesUtils.write(contents, inputPdfName, config.getPassword());
         }
-        AutoTaggingProcessor.createTaggedPDF(inputPDF, config.getOutputFolder(), StaticResources.getDocument(), contents);
         if (config.isGeneratePDF()) {
             PDFWriter pdfWriter = new PDFWriter();
             pdfWriter.updatePDF(inputPDF, config.getPassword(), config.getOutputFolder(), contents);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ExtractionResult.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ExtractionResult.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.processors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.verapdf.wcag.algorithms.entities.IObject;
+
+import java.util.List;
+
+/**
+ * Internal result of the extraction pipeline (preprocessing + content extraction + sanitization).
+ * Carries the extracted contents and timing metadata for use by AutoTagger.
+ */
+public class ExtractionResult {
+
+    private final List<List<IObject>> contents;
+    private final long extractionNs;
+    private final JsonNode hybridTimings;
+
+    public ExtractionResult(List<List<IObject>> contents, long extractionNs, JsonNode hybridTimings) {
+        this.contents = contents;
+        this.extractionNs = extractionNs;
+        this.hybridTimings = hybridTimings;
+    }
+
+    public List<List<IObject>> getContents() {
+        return contents;
+    }
+
+    public long getExtractionNs() {
+        return extractionNs;
+    }
+
+    public JsonNode getHybridTimings() {
+        return hybridTimings;
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -664,11 +664,11 @@ public class HybridDocumentProcessor {
                 enrichSingleTextNode((SemanticTextNode) obj, javaTextChunks, usedJavaIndices);
             } else if (obj instanceof TableBorder) {
                 TableBorder table = (TableBorder) obj;
-                for (int r = 0; r < table.getNumberOfRows(); r++) {
-                    TableBorderRow row = table.getRow(r);
-                    for (int c = 0; c < table.getNumberOfColumns(); c++) {
-                        TableBorderCell cell = row.getCell(c);
-                        if (cell.getRowNumber() == r && cell.getColNumber() == c) {
+                for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
+                    TableBorderRow row = table.getRow(rowNumber);
+                    for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
+                        TableBorderCell cell = row.getCell(colNumber);
+                        if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
                             enrichTextStreamInfosRecursive(cell.getContents(), javaTextChunks, usedJavaIndices);
                         }
                     }
@@ -700,8 +700,8 @@ public class HybridDocumentProcessor {
             TextChunk javaChunk = javaTextChunks.get(i);
             if (javaChunk.getStreamInfos().isEmpty()) continue;
 
-            double jCx = (javaChunk.getLeftX() + javaChunk.getRightX()) / 2.0;
-            double jCy = (javaChunk.getBottomY() + javaChunk.getTopY()) / 2.0;
+            double jCx = javaChunk.getCenterX();
+            double jCy = javaChunk.getCenterY();
 
             if (jCx >= nLeft - tol && jCx <= nRight + tol && jCy >= nBottom - tol && jCy <= nTop + tol) {
                 matched.add(javaChunk);
@@ -746,8 +746,8 @@ public class HybridDocumentProcessor {
 
             for (TextChunk javaChunk : javaTextChunks) {
                 if (javaChunk.getStreamInfos().isEmpty()) continue;
-                double jCx = (javaChunk.getLeftX() + javaChunk.getRightX()) / 2.0;
-                double jCy = (javaChunk.getBottomY() + javaChunk.getTopY()) / 2.0;
+                double jCx = javaChunk.getCenterX();
+                double jCy = javaChunk.getCenterY();
 
                 if (jCx >= fLeft - tol && jCx <= fRight + tol && jCy >= fBottom - tol && jCy <= fTop + tol) {
                     formula.getStreamInfos().addAll(javaChunk.getStreamInfos());
@@ -768,15 +768,13 @@ public class HybridDocumentProcessor {
 
         ImageChunk best = null;
         double bestDist = Double.MAX_VALUE;
-        double picCx = (picLeft + picRight) / 2.0;
-        double picCy = (picBottom + picTop) / 2.0;
 
         for (ImageChunk chunk : candidates) {
-            double cx = (chunk.getLeftX() + chunk.getRightX()) / 2.0;
-            double cy = (chunk.getBottomY() + chunk.getTopY()) / 2.0;
+            double cx = chunk.getCenterX();
+            double cy = chunk.getCenterY();
             // Center-point containment (with 1pt tolerance)
             if (cx >= picLeft - 1 && cx <= picRight + 1 && cy >= picBottom - 1 && cy <= picTop + 1) {
-                double dist = Math.hypot(cx - picCx, cy - picCy);
+                double dist = Math.hypot(cx - picture.getCenterX(), cy - picture.getCenterY());
                 if (dist < bestDist) {
                     bestDist = dist;
                     best = chunk;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -21,7 +21,6 @@ import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.hybrid.DoclingSchemaTransformer;
-import org.opendataloader.pdf.hybrid.HancomAISchemaTransformer;
 import org.opendataloader.pdf.hybrid.HancomSchemaTransformer;
 import org.opendataloader.pdf.hybrid.HybridClient;
 import org.opendataloader.pdf.hybrid.HybridClientFactory;
@@ -528,11 +527,6 @@ public class HybridDocumentProcessor {
         // hancom uses HancomSchemaTransformer
         if (Config.HYBRID_HANCOM.equals(hybrid)) {
             return new HancomSchemaTransformer();
-        }
-
-        // hancom-ai uses HancomAISchemaTransformer
-        if (Config.HYBRID_HANCOM_AI.equals(hybrid)) {
-            return new HancomAISchemaTransformer();
         }
 
         throw new IllegalArgumentException("Unsupported hybrid backend: " + hybrid);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -21,12 +21,14 @@ import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.hybrid.DoclingSchemaTransformer;
+import org.opendataloader.pdf.hybrid.HancomAISchemaTransformer;
 import org.opendataloader.pdf.hybrid.HancomSchemaTransformer;
 import org.opendataloader.pdf.hybrid.HybridClient;
 import org.opendataloader.pdf.hybrid.HybridClientFactory;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridRequest;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
 import org.opendataloader.pdf.hybrid.HybridClient.OutputFormat;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.opendataloader.pdf.hybrid.HybridConfig;
 import org.opendataloader.pdf.hybrid.HybridSchemaTransformer;
 import org.opendataloader.pdf.hybrid.TriageLogger;
@@ -83,6 +85,17 @@ public class HybridDocumentProcessor {
     private static final Logger LOGGER = Logger.getLogger(HybridDocumentProcessor.class.getCanonicalName());
 
     /**
+     * Stores the last hybrid server timings collected during {@link #processBackendPath}.
+     * Accumulated across all chunks. Reset at the start of each {@code processDocument} call.
+     */
+    private static volatile JsonNode lastHybridTimings;
+
+    /** Returns the hybrid server timings from the most recent {@link #processDocument} call. */
+    public static JsonNode getLastHybridTimings() {
+        return lastHybridTimings;
+    }
+
+    /**
      * Maximum number of pages to send to the backend in a single request.
      * Large scanned PDFs (100+ pages) cause the backend to hang when sent all at once
      * due to non-linear memory/processing scaling in the AI pipeline.
@@ -128,6 +141,8 @@ public class HybridDocumentProcessor {
             Config config,
             Set<Integer> pagesToProcess,
             Path outputDir) throws IOException {
+
+        lastHybridTimings = null; // Reset for this processing run
 
         int totalPages = StaticContainers.getDocument().getNumberOfPages();
         LOGGER.log(Level.INFO, "Starting hybrid processing for {0} pages", totalPages);
@@ -427,6 +442,12 @@ public class HybridDocumentProcessor {
                 HybridRequest request = HybridRequest.forPages(pdfBytes, chunkPages1Indexed, outputFormats);
                 HybridResponse response = client.convert(request);
 
+                // Capture hybrid server pipeline timings (last chunk wins for now;
+                // in single-chunk documents this is exact)
+                if (response.getTimings() != null) {
+                    lastHybridTimings = response.getTimings();
+                }
+
                 // Collect failed pages (convert from 1-indexed to 0-indexed)
                 if (response.hasFailedPages()) {
                     for (int failedPage1Indexed : response.getFailedPages()) {
@@ -507,6 +528,11 @@ public class HybridDocumentProcessor {
         // hancom uses HancomSchemaTransformer
         if (Config.HYBRID_HANCOM.equals(hybrid)) {
             return new HancomSchemaTransformer();
+        }
+
+        // hancom-ai uses HancomAISchemaTransformer
+        if (Config.HYBRID_HANCOM_AI.equals(hybrid)) {
+            return new HancomAISchemaTransformer();
         }
 
         throw new IllegalArgumentException("Unsupported hybrid backend: " + hybrid);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -37,6 +37,11 @@ import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.SemanticTextNode;
 import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
 import org.verapdf.wcag.algorithms.entities.content.LineChunk;
+import org.verapdf.wcag.algorithms.entities.lists.PDFList;
+import org.verapdf.wcag.algorithms.entities.lists.ListItem;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextColumn;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
@@ -616,44 +621,74 @@ public class HybridDocumentProcessor {
         if (javaTextChunks.isEmpty()) return;
 
         Set<Integer> usedJavaIndices = new HashSet<>();
+        enrichTextStreamInfosRecursive(backendPage, javaTextChunks, usedJavaIndices);
+    }
 
-        for (IObject obj : backendPage) {
-            if (!(obj instanceof SemanticTextNode)) continue;
-            SemanticTextNode textNode = (SemanticTextNode) obj;
+    /**
+     * Recursively walks the IObject tree and replaces TextChunks in SemanticTextNodes
+     * with Java TextChunks that carry StreamInfo. Handles TableBorder cells, PDFList items,
+     * and any other container that holds nested IObjects.
+     */
+    private static void enrichTextStreamInfosRecursive(
+            List<IObject> objects, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices) {
 
-            // Get the bounding box of the entire SemanticTextNode
-            double nLeft = textNode.getLeftX();
-            double nRight = textNode.getRightX();
-            double nBottom = textNode.getBottomY();
-            double nTop = textNode.getTopY();
-
-            // Find all Java TextChunks whose center is within this node's bbox
-            List<TextChunk> matched = new ArrayList<>();
-            double tol = 5.0;
-            for (int i = 0; i < javaTextChunks.size(); i++) {
-                if (usedJavaIndices.contains(i)) continue;
-                TextChunk javaChunk = javaTextChunks.get(i);
-                if (javaChunk.getStreamInfos().isEmpty()) continue;
-
-                double jCx = (javaChunk.getLeftX() + javaChunk.getRightX()) / 2.0;
-                double jCy = (javaChunk.getBottomY() + javaChunk.getTopY()) / 2.0;
-
-                if (jCx >= nLeft - tol && jCx <= nRight + tol && jCy >= nBottom - tol && jCy <= nTop + tol) {
-                    matched.add(javaChunk);
-                    usedJavaIndices.add(i);
+        for (IObject obj : objects) {
+            if (obj instanceof SemanticTextNode) {
+                enrichSingleTextNode((SemanticTextNode) obj, javaTextChunks, usedJavaIndices);
+            } else if (obj instanceof TableBorder) {
+                TableBorder table = (TableBorder) obj;
+                for (int r = 0; r < table.getNumberOfRows(); r++) {
+                    TableBorderRow row = table.getRow(r);
+                    for (int c = 0; c < table.getNumberOfColumns(); c++) {
+                        TableBorderCell cell = row.getCell(c);
+                        if (cell.getRowNumber() == r && cell.getColNumber() == c) {
+                            enrichTextStreamInfosRecursive(cell.getContents(), javaTextChunks, usedJavaIndices);
+                        }
+                    }
+                }
+            } else if (obj instanceof PDFList) {
+                PDFList list = (PDFList) obj;
+                for (ListItem item : list.getListItems()) {
+                    enrichTextStreamInfosRecursive(item.getContents(), javaTextChunks, usedJavaIndices);
                 }
             }
+        }
+    }
 
-            if (!matched.isEmpty()) {
-                // Replace the node's columns with a single column containing
-                // the matched Java TextChunks (each as its own TextLine)
-                textNode.getColumns().clear();
-                TextColumn newCol = new TextColumn();
-                for (TextChunk tc : matched) {
-                    newCol.add(new TextLine(tc));
-                }
-                textNode.getColumns().add(newCol);
+    /**
+     * Replaces a single SemanticTextNode's TextChunks with matching Java TextChunks.
+     */
+    private static void enrichSingleTextNode(
+            SemanticTextNode textNode, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices) {
+
+        double nLeft = textNode.getLeftX();
+        double nRight = textNode.getRightX();
+        double nBottom = textNode.getBottomY();
+        double nTop = textNode.getTopY();
+
+        List<TextChunk> matched = new ArrayList<>();
+        double tol = 5.0;
+        for (int i = 0; i < javaTextChunks.size(); i++) {
+            if (usedJavaIndices.contains(i)) continue;
+            TextChunk javaChunk = javaTextChunks.get(i);
+            if (javaChunk.getStreamInfos().isEmpty()) continue;
+
+            double jCx = (javaChunk.getLeftX() + javaChunk.getRightX()) / 2.0;
+            double jCy = (javaChunk.getBottomY() + javaChunk.getTopY()) / 2.0;
+
+            if (jCx >= nLeft - tol && jCx <= nRight + tol && jCy >= nBottom - tol && jCy <= nTop + tol) {
+                matched.add(javaChunk);
+                usedJavaIndices.add(i);
             }
+        }
+
+        if (!matched.isEmpty()) {
+            textNode.getColumns().clear();
+            TextColumn newCol = new TextColumn();
+            for (TextChunk tc : matched) {
+                newCol.add(new TextLine(tc));
+            }
+            textNode.getColumns().add(newCol);
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -18,6 +18,7 @@ package org.opendataloader.pdf.processors;
 import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.opendataloader.pdf.entities.EnrichedImageChunk;
+import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.hybrid.DoclingSchemaTransformer;
 import org.opendataloader.pdf.hybrid.HancomSchemaTransformer;
@@ -569,9 +570,11 @@ public class HybridDocumentProcessor {
                 entry.setValue(enriched);
             }
 
-            // Replace backend TextChunks with Java TextChunks that carry StreamInfo
+            // Replace backend TextChunks with Java TextChunks that carry StreamInfo,
+            // and copy StreamInfos to SemanticFormula objects
             if (!javaTextChunks.isEmpty()) {
                 enrichTextStreamInfos(backendPage, javaTextChunks);
+                enrichFormulaStreamInfos(backendPage, javaTextChunks);
             }
         }
     }
@@ -650,6 +653,40 @@ public class HybridDocumentProcessor {
                     newCol.add(new TextLine(tc));
                 }
                 textNode.getColumns().add(newCol);
+            }
+        }
+    }
+
+    /**
+     * Copies StreamInfos from Java TextChunks to SemanticFormula objects by bbox overlap.
+     *
+     * <p>SemanticFormula (from backend) has no StreamInfo. We find all Java TextChunks
+     * whose centers fall within the formula's bbox and copy their StreamInfos directly
+     * to the formula's StreamInfo list (inherited from BaseObject).
+     */
+    private static void enrichFormulaStreamInfos(List<IObject> backendPage, List<TextChunk> javaTextChunks) {
+        // Collect indices already used by enrichTextStreamInfos — we need a fresh scan
+        // because formulas may overlap with text regions that were already assigned.
+        // However, for formulas we allow reuse since formula content often IS the text content.
+        for (IObject obj : backendPage) {
+            if (!(obj instanceof SemanticFormula)) continue;
+            SemanticFormula formula = (SemanticFormula) obj;
+            if (!formula.getStreamInfos().isEmpty()) continue;
+
+            double fLeft = formula.getLeftX();
+            double fRight = formula.getRightX();
+            double fBottom = formula.getBottomY();
+            double fTop = formula.getTopY();
+            double tol = 5.0;
+
+            for (TextChunk javaChunk : javaTextChunks) {
+                if (javaChunk.getStreamInfos().isEmpty()) continue;
+                double jCx = (javaChunk.getLeftX() + javaChunk.getRightX()) / 2.0;
+                double jCy = (javaChunk.getBottomY() + javaChunk.getTopY()) / 2.0;
+
+                if (jCx >= fLeft - tol && jCx <= fRight + tol && jCy >= fBottom - tol && jCy <= fTop + tol) {
+                    formula.getStreamInfos().addAll(javaChunk.getStreamInfos());
+                }
             }
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -660,7 +660,10 @@ public class HybridDocumentProcessor {
             List<IObject> objects, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices) {
 
         for (IObject obj : objects) {
-            if (obj instanceof SemanticTextNode) {
+            if (obj instanceof SemanticFormula) {
+                // Formula inside table/list — enrich StreamInfos by bbox overlap
+                enrichSingleFormula((SemanticFormula) obj, javaTextChunks);
+            } else if (obj instanceof SemanticTextNode) {
                 enrichSingleTextNode((SemanticTextNode) obj, javaTextChunks, usedJavaIndices);
             } else if (obj instanceof TableBorder) {
                 TableBorder table = (TableBorder) obj;
@@ -763,35 +766,40 @@ public class HybridDocumentProcessor {
      * to the formula's StreamInfo list (inherited from BaseObject).
      */
     private static void enrichFormulaStreamInfos(List<IObject> backendPage, List<TextChunk> javaTextChunks) {
-        // Collect indices already used by enrichTextStreamInfos — we need a fresh scan
-        // because formulas may overlap with text regions that were already assigned.
-        // However, for formulas we allow reuse since formula content often IS the text content.
         for (IObject obj : backendPage) {
-            if (!(obj instanceof SemanticFormula)) continue;
-            SemanticFormula formula = (SemanticFormula) obj;
-            if (!formula.getStreamInfos().isEmpty()) continue;
+            if (obj instanceof SemanticFormula) {
+                enrichSingleFormula((SemanticFormula) obj, javaTextChunks);
+            }
+        }
+    }
 
-            double fLeft = formula.getLeftX();
-            double fRight = formula.getRightX();
-            double fBottom = formula.getBottomY();
-            double fTop = formula.getTopY();
-            double tol = 5.0;
+    /**
+     * Copies StreamInfos from Java TextChunks to a SemanticFormula by bbox overlap.
+     * Allows reuse of Java chunks since formula content often IS the text content.
+     */
+    private static void enrichSingleFormula(SemanticFormula formula, List<TextChunk> javaTextChunks) {
+        if (!formula.getStreamInfos().isEmpty()) return;
 
-            for (TextChunk javaChunk : javaTextChunks) {
-                if (javaChunk.getStreamInfos().isEmpty()) continue;
-                double jCx = javaChunk.getCenterX();
-                double jCy = javaChunk.getCenterY();
+        double fLeft = formula.getLeftX();
+        double fRight = formula.getRightX();
+        double fBottom = formula.getBottomY();
+        double fTop = formula.getTopY();
+        double tol = 5.0;
 
-                if (jCx >= fLeft - tol && jCx <= fRight + tol && jCy >= fBottom - tol && jCy <= fTop + tol) {
-                    formula.getStreamInfos().addAll(javaChunk.getStreamInfos());
-                }
+        for (TextChunk javaChunk : javaTextChunks) {
+            if (javaChunk.getStreamInfos().isEmpty()) continue;
+            double jCx = javaChunk.getCenterX();
+            double jCy = javaChunk.getCenterY();
+
+            if (jCx >= fLeft - tol && jCx <= fRight + tol && jCy >= fBottom - tol && jCy <= fTop + tol) {
+                formula.getStreamInfos().addAll(javaChunk.getStreamInfos());
             }
         }
     }
 
     /**
      * Finds the ImageChunk whose center point lies within the SemanticPicture's bounding box.
-     * Falls back to the closest ImageChunk by center-to-center distance if none is contained.
+     * Returns null if no candidate's center is contained (with 1pt tolerance).
      */
     private static ImageChunk findMatchingImageChunk(SemanticPicture picture, List<ImageChunk> candidates) {
         double picLeft = picture.getLeftX();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -17,6 +17,8 @@ package org.opendataloader.pdf.processors;
 
 import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.entities.EnrichedImageChunk;
+import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.hybrid.DoclingSchemaTransformer;
 import org.opendataloader.pdf.hybrid.HancomSchemaTransformer;
 import org.opendataloader.pdf.hybrid.HybridClient;
@@ -31,8 +33,14 @@ import org.opendataloader.pdf.hybrid.TriageProcessor;
 import org.opendataloader.pdf.hybrid.TriageProcessor.TriageDecision;
 import org.opendataloader.pdf.hybrid.TriageProcessor.TriageResult;
 import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.SemanticTextNode;
+import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
 import org.verapdf.wcag.algorithms.entities.content.LineChunk;
+import org.verapdf.wcag.algorithms.entities.content.TextChunk;
+import org.verapdf.wcag.algorithms.entities.content.TextColumn;
+import org.verapdf.wcag.algorithms.entities.content.TextLine;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+import org.verapdf.wcag.algorithms.semanticalgorithms.utils.StreamInfo;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 
 import java.io.IOException;
@@ -181,6 +189,8 @@ public class HybridDocumentProcessor {
         Set<Integer> backendFailedPages = new HashSet<>();
         try {
             backendResults = processBackendPath(inputPdfName, backendPages, config, backendFailedPages);
+            // Enrich backend results: copy StreamInfos from Java-extracted content for MCID linkage
+            enrichBackendResults(backendResults, filteredContents);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Backend processing failed: {0}", e.getMessage());
             if (config.getHybridConfig().isFallbackToJava()) {
@@ -515,6 +525,165 @@ public class HybridDocumentProcessor {
     /**
      * Merges Java and backend results into the final contents list.
      */
+    /**
+     * Enriches backend results with MCID/StreamInfo data from Java-extracted content.
+     *
+     * <p>Backend-generated IObjects (from docling) lack StreamInfo, which is required
+     * for PDF struct-tree tagging. This method:
+     * <ol>
+     *   <li>Replaces SemanticPicture with EnrichedImageChunk (copies StreamInfo + description)</li>
+     *   <li>Copies StreamInfo from Java TextChunks to backend TextChunks by bbox overlap</li>
+     * </ol>
+     */
+    private static void enrichBackendResults(
+            Map<Integer, List<IObject>> backendResults,
+            Map<Integer, List<IObject>> filteredContents) {
+
+        for (Map.Entry<Integer, List<IObject>> entry : backendResults.entrySet()) {
+            int pageNumber = entry.getKey();
+            List<IObject> backendPage = entry.getValue();
+
+            List<IObject> javaPage = filteredContents.getOrDefault(pageNumber, List.of());
+
+            // Collect Java-extracted ImageChunks and TextChunks for matching
+            List<ImageChunk> javaImageChunks = new ArrayList<>();
+            List<TextChunk> javaTextChunks = new ArrayList<>();
+            collectJavaChunks(javaPage, javaImageChunks, javaTextChunks);
+
+            // Replace SemanticPicture entries with matched EnrichedImageChunk
+            if (!javaImageChunks.isEmpty()) {
+                List<IObject> enriched = new ArrayList<>(backendPage.size());
+                for (IObject obj : backendPage) {
+                    if (obj instanceof SemanticPicture) {
+                        SemanticPicture picture = (SemanticPicture) obj;
+                        ImageChunk matched = findMatchingImageChunk(picture, javaImageChunks);
+                        if (matched != null) {
+                            enriched.add(new EnrichedImageChunk(matched, picture.getDescription()));
+                        }
+                        // If no match: drop (vector graphic not in filteredContents)
+                    } else {
+                        enriched.add(obj);
+                    }
+                }
+                backendPage = enriched;
+                entry.setValue(enriched);
+            }
+
+            // Replace backend TextChunks with Java TextChunks that carry StreamInfo
+            if (!javaTextChunks.isEmpty()) {
+                enrichTextStreamInfos(backendPage, javaTextChunks);
+            }
+        }
+    }
+
+    /**
+     * Collects ImageChunks and TextChunks from Java-filtered page contents.
+     */
+    private static void collectJavaChunks(List<IObject> javaPage,
+                                           List<ImageChunk> imageChunks,
+                                           List<TextChunk> textChunks) {
+        for (IObject obj : javaPage) {
+            if (obj instanceof ImageChunk) {
+                imageChunks.add((ImageChunk) obj);
+            } else if (obj instanceof TextChunk) {
+                // Raw TextChunk from ContentFilterProcessor (pre-paragraph processing)
+                textChunks.add((TextChunk) obj);
+            } else if (obj instanceof SemanticTextNode) {
+                // TextChunks wrapped in SemanticTextNode (post-paragraph processing)
+                SemanticTextNode textNode = (SemanticTextNode) obj;
+                for (TextColumn col : textNode.getColumns()) {
+                    for (TextLine line : col.getLines()) {
+                        textChunks.addAll(line.getTextChunks());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Replaces backend TextChunks with Java TextChunks that have StreamInfo.
+     *
+     * <p>Backend-generated TextChunks lack StreamInfo (needed for MCID/struct-tree).
+     * For each backend SemanticTextNode, we find Java TextChunks whose centers fall
+     * within the node's bbox and replace the backend TextChunk with the Java ones.
+     * This preserves the backend's structural decisions (heading/paragraph/reading order)
+     * while using the Java TextChunks that carry StreamInfo.
+     */
+    private static void enrichTextStreamInfos(List<IObject> backendPage, List<TextChunk> javaTextChunks) {
+        if (javaTextChunks.isEmpty()) return;
+
+        Set<Integer> usedJavaIndices = new HashSet<>();
+
+        for (IObject obj : backendPage) {
+            if (!(obj instanceof SemanticTextNode)) continue;
+            SemanticTextNode textNode = (SemanticTextNode) obj;
+
+            // Get the bounding box of the entire SemanticTextNode
+            double nLeft = textNode.getLeftX();
+            double nRight = textNode.getRightX();
+            double nBottom = textNode.getBottomY();
+            double nTop = textNode.getTopY();
+
+            // Find all Java TextChunks whose center is within this node's bbox
+            List<TextChunk> matched = new ArrayList<>();
+            double tol = 5.0;
+            for (int i = 0; i < javaTextChunks.size(); i++) {
+                if (usedJavaIndices.contains(i)) continue;
+                TextChunk javaChunk = javaTextChunks.get(i);
+                if (javaChunk.getStreamInfos().isEmpty()) continue;
+
+                double jCx = (javaChunk.getLeftX() + javaChunk.getRightX()) / 2.0;
+                double jCy = (javaChunk.getBottomY() + javaChunk.getTopY()) / 2.0;
+
+                if (jCx >= nLeft - tol && jCx <= nRight + tol && jCy >= nBottom - tol && jCy <= nTop + tol) {
+                    matched.add(javaChunk);
+                    usedJavaIndices.add(i);
+                }
+            }
+
+            if (!matched.isEmpty()) {
+                // Replace the node's columns with a single column containing
+                // the matched Java TextChunks (each as its own TextLine)
+                textNode.getColumns().clear();
+                TextColumn newCol = new TextColumn();
+                for (TextChunk tc : matched) {
+                    newCol.add(new TextLine(tc));
+                }
+                textNode.getColumns().add(newCol);
+            }
+        }
+    }
+
+    /**
+     * Finds the ImageChunk whose center point lies within the SemanticPicture's bounding box.
+     * Falls back to the closest ImageChunk by center-to-center distance if none is contained.
+     */
+    private static ImageChunk findMatchingImageChunk(SemanticPicture picture, List<ImageChunk> candidates) {
+        double picLeft = picture.getLeftX();
+        double picRight = picture.getRightX();
+        double picBottom = picture.getBottomY();
+        double picTop = picture.getTopY();
+
+        ImageChunk best = null;
+        double bestDist = Double.MAX_VALUE;
+        double picCx = (picLeft + picRight) / 2.0;
+        double picCy = (picBottom + picTop) / 2.0;
+
+        for (ImageChunk chunk : candidates) {
+            double cx = (chunk.getLeftX() + chunk.getRightX()) / 2.0;
+            double cy = (chunk.getBottomY() + chunk.getTopY()) / 2.0;
+            // Center-point containment (with 1pt tolerance)
+            if (cx >= picLeft - 1 && cx <= picRight + 1 && cy >= picBottom - 1 && cy <= picTop + 1) {
+                double dist = Math.hypot(cx - picCx, cy - picCy);
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    best = chunk;
+                }
+            }
+        }
+        return best;
+    }
+
     private static void mergeResults(
             List<List<IObject>> contents,
             Map<Integer, List<IObject>> javaResults,

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -676,6 +676,15 @@ public class HybridDocumentProcessor {
             } else if (obj instanceof PDFList) {
                 PDFList list = (PDFList) obj;
                 for (ListItem item : list.getListItems()) {
+                    // Enrich ListItem's own text lines (used by AutoTaggingProcessor for Lbl/LBody)
+                    for (TextLine line : item.getLines()) {
+                        for (TextChunk backendChunk : line.getTextChunks()) {
+                            if (backendChunk.getStreamInfos().isEmpty()) {
+                                matchAndReplaceStreamInfos(backendChunk, javaTextChunks, usedJavaIndices);
+                            }
+                        }
+                    }
+                    // Enrich nested contents (images, paragraphs, sub-lists)
                     enrichTextStreamInfosRecursive(item.getContents(), javaTextChunks, usedJavaIndices);
                 }
             }
@@ -719,6 +728,30 @@ public class HybridDocumentProcessor {
         } else {
             LOGGER.fine(() -> "enrichSingleTextNode: no Java TextChunk matched for backend node at bbox ["
                 + String.format("%.1f,%.1f,%.1f,%.1f", nLeft, nBottom, nRight, nTop) + "]");
+        }
+    }
+
+    /**
+     * Copies StreamInfos from matching Java TextChunks to a backend TextChunk that lacks them.
+     * Used for ListItem lines where the text is stored directly in TextLine/TextChunk
+     * rather than in a SemanticTextNode wrapper.
+     */
+    private static void matchAndReplaceStreamInfos(
+            TextChunk backendChunk, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices) {
+        double bCx = backendChunk.getCenterX();
+        double bCy = backendChunk.getCenterY();
+        double tol = 5.0;
+        for (int i = 0; i < javaTextChunks.size(); i++) {
+            if (usedJavaIndices.contains(i)) continue;
+            TextChunk javaChunk = javaTextChunks.get(i);
+            if (javaChunk.getStreamInfos().isEmpty()) continue;
+            double jCx = javaChunk.getCenterX();
+            double jCy = javaChunk.getCenterY();
+            if (Math.abs(bCx - jCx) <= tol && Math.abs(bCy - jCy) <= tol) {
+                backendChunk.getStreamInfos().addAll(javaChunk.getStreamInfos());
+                usedJavaIndices.add(i);
+                return;
+            }
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -585,8 +585,10 @@ public class HybridDocumentProcessor {
                         ImageChunk matched = findMatchingImageChunk(picture, javaImageChunks);
                         if (matched != null) {
                             enriched.add(new EnrichedImageChunk(matched, picture.getDescription()));
+                        } else {
+                            LOGGER.fine(() -> "Page " + pageNumber + ": dropped SemanticPicture (no matching ImageChunk) at bbox ["
+                                + String.format("%.1f,%.1f,%.1f,%.1f", picture.getLeftX(), picture.getBottomY(), picture.getRightX(), picture.getTopY()) + "]");
                         }
-                        // If no match: drop (vector graphic not in filteredContents)
                     } else {
                         enriched.add(obj);
                     }
@@ -601,6 +603,11 @@ public class HybridDocumentProcessor {
                 enrichTextStreamInfos(backendPage, javaTextChunks);
                 enrichFormulaStreamInfos(backendPage, javaTextChunks);
             }
+
+            final int pg = pageNumber;
+            final int javaTotal = javaTextChunks.size();
+            LOGGER.fine(() -> "Page " + pg + ": enrichment complete — "
+                + javaTotal + " Java TextChunks available");
         }
     }
 
@@ -709,6 +716,9 @@ public class HybridDocumentProcessor {
                 newCol.add(new TextLine(tc));
             }
             textNode.getColumns().add(newCol);
+        } else {
+            LOGGER.fine(() -> "enrichSingleTextNode: no Java TextChunk matched for backend node at bbox ["
+                + String.format("%.1f,%.1f,%.1f,%.1f", nLeft, nBottom, nRight, nTop) + "]");
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -16,6 +16,7 @@
 package org.opendataloader.pdf.processors;
 
 import org.opendataloader.pdf.utils.BulletedParagraphUtils;
+import org.verapdf.as.ASAtom;
 import org.verapdf.wcag.algorithms.entities.INode;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.SemanticTextNode;
@@ -33,6 +34,7 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ChunksMergeUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ListLabelsUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ListUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.NodeUtils;
+import org.verapdf.wcag.algorithms.semanticalgorithms.utils.listLabelsDetection.ListLabelsDetectionAlgorithm;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.listLabelsDetection.NumberingStyleNames;
 
 import java.util.*;
@@ -55,6 +57,25 @@ public class ListProcessor {
      * Prevents O(n²) scaling on large documents. A higher value is safer but slower.
      */
     private static final int MAX_LIST_INTERVAL_LOOKBACK = 500;
+
+    private static final Map<String, ASAtom> listNumberingMap = new HashMap<>();
+
+    static {
+        listNumberingMap.put(NumberingStyleNames.ENGLISH_LETTERS, ASAtom.ORDERED);
+        listNumberingMap.put(NumberingStyleNames.ENGLISH_LETTERS_UPPER_CASE, ASAtom.UPPER_ALPHA);
+        listNumberingMap.put(NumberingStyleNames.ENGLISH_LETTERS_LOWER_CASE, ASAtom.LOWER_ALPHA);
+        listNumberingMap.put(NumberingStyleNames.ROMAN_NUMBERS_LOWER_CASE, ASAtom.LOWER_ROMAN);
+        listNumberingMap.put(NumberingStyleNames.ROMAN_NUMBERS, ASAtom.ORDERED);
+        listNumberingMap.put(NumberingStyleNames.ROMAN_NUMBERS_UPPER_CASE, ASAtom.UPPER_ROMAN);
+        listNumberingMap.put(NumberingStyleNames.KOREAN_LETTERS, ASAtom.ORDERED);
+        listNumberingMap.put(NumberingStyleNames.ARABIC_NUMBERS, ASAtom.DECIMAL);
+        listNumberingMap.put(NumberingStyleNames.CIRCLED_ARABIC_NUMBERS, ASAtom.ORDERED);
+        listNumberingMap.put(NumberingStyleNames.UNORDERED,ASAtom.UNORDERED);
+    }
+
+    public static ASAtom getListNumbering(String numberingStyle) {
+        return listNumberingMap.get(numberingStyle);
+    }
 
     public static void processLists(List<List<IObject>> contents, boolean isTableCell) {
         List<TextListInterval> intervalsList = getTextLabelListIntervals(contents);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -94,6 +94,7 @@ public class ListProcessor {
             Integer currentPageNumber = interval.getListItemsInfos().get(0).getPageNumber();
             int index = 0;
             PDFList previousList = null;
+            interval.setCommonSuffixLengthToAllInfos();
             for (int i = 0; i < interval.getNumberOfListItems(); i++) {
                 ListItemInfo currentInfo = interval.getListItemsInfos().get(i);
                 if (!Objects.equals(currentInfo.getPageNumber(), currentPageNumber)) {
@@ -234,7 +235,7 @@ public class ListProcessor {
         list.setCommonPrefix(interval.getCommonPrefix());
         boolean isListSet = false;
         for (int index = startIndex; index <= endIndex; index++) {
-            ListItemInfo currentInfo = interval.getListItemsInfos().get(index);
+            ListItemTextInfo currentInfo = interval.getListItemsInfos().get(index);
             int nextIndex = index != endIndex ? interval.getListItemsInfos().get(index + 1).getIndex() : pageContents.size();
             ListItem listItem = new ListItem(new BoundingBox(), null);
             IObject object = pageContents.get(currentInfo.getIndex());
@@ -258,6 +259,7 @@ public class ListProcessor {
             } else {
                 addContentToLastPageListItem(nextIndex, currentInfo, pageContents, listItem);
             }
+            listItem.setLabelLength(currentInfo.getLabelLength());
             list.add(listItem);
         }
         if (list.getListItems().isEmpty()) {
@@ -390,6 +392,7 @@ public class ListProcessor {
             if (!isCorrectList(textListInterval)) {
                 continue;
             }
+            textListInterval.setCommonSuffixLengthToAllInfos();
             PDFList list = calculateList(textListInterval, 0, interval.getNumberOfListItems() - 1, contents);
             for (ListItem listItem : list.getListItems()) {
                 processTextNodeListItemContent(listItem.getContents());

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -34,7 +34,6 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ChunksMergeUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ListLabelsUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ListUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.NodeUtils;
-import org.verapdf.wcag.algorithms.semanticalgorithms.utils.listLabelsDetection.ListLabelsDetectionAlgorithm;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.listLabelsDetection.NumberingStyleNames;
 
 import java.util.*;
@@ -71,6 +70,7 @@ public class ListProcessor {
         listNumberingMap.put(NumberingStyleNames.ARABIC_NUMBERS, ASAtom.DECIMAL);
         listNumberingMap.put(NumberingStyleNames.CIRCLED_ARABIC_NUMBERS, ASAtom.ORDERED);
         listNumberingMap.put(NumberingStyleNames.UNORDERED,ASAtom.UNORDERED);
+        listNumberingMap.put(NumberingStyleNames.UNKNOWN, ASAtom.NONE);
     }
 
     public static ASAtom getListNumbering(String numberingStyle) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/PDFStreamWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/PDFStreamWriter.java
@@ -32,62 +32,65 @@ public class PDFStreamWriter {
 
     private void write(Object rawToken, PrintWriter printWriter, OutputStream out) throws IOException {
         if (rawToken instanceof COSArray) {
-            printWriter.write("[");
+            out.write("[".getBytes());
             for (COSObject item : (COSArray) rawToken) {
                 write(item.getDirectBase(), printWriter, out);
             }
-            printWriter.write("]");
-            printWriter.write(" ");
+            out.write("]".getBytes());
+            out.write(" ".getBytes());
         } else if (rawToken instanceof COSDictionary) {
-                printWriter.write("<<");
-                for (Map.Entry<ASAtom, COSObject> item : ((COSDictionary)rawToken).getEntrySet()) {
-                    printWriter.write(item.getKey().toString());
-                    printWriter.write(" ");
-                    write(item.getValue(), printWriter, out);
-                }
-                printWriter.write(">>");
-                printWriter.write(" ");
+            out.write("<<".getBytes());
+            for (Map.Entry<ASAtom, COSObject> item : ((COSDictionary)rawToken).getEntrySet()) {
+                out.write(item.getKey().toString().getBytes());
+                out.write(" ".getBytes());
+                write(item.getValue(), printWriter, out);
+            }
+            out.write(">>".getBytes());
+            out.write(" ".getBytes());
         } else if (rawToken instanceof COSString) {
             COSString string = (COSString) rawToken;
             if (string.isHexadecimal()) {
-                printWriter.write("<");
-                printWriter.write(string.getHexString());
-                printWriter.write(">");
-                printWriter.write(" ");
+                out.write("<".getBytes());
+                out.write(string.getHexString().getBytes());
+                out.write(">".getBytes());
+                out.write(" ".getBytes());
             } else {
-                printWriter.write("(");
+                out.write("(".getBytes());
                 byte[] bytes = ((COSString) rawToken).get();
                 for (byte currentByte : bytes) {
-                    if (currentByte == 40 || currentByte == 41) {
-                        printWriter.write('\\');
+                    if (currentByte == 40 || currentByte == 41 || currentByte == 92) {
+                        out.write('\\');
                     }
-                    printWriter.write(currentByte);
+                    out.write(currentByte);
                 }
-                printWriter.write(")");
-                printWriter.write(" ");
+                out.write(")".getBytes());
+                out.write(" ".getBytes());
             }
         } else if (rawToken instanceof COSBoolean) {
-            printWriter.write(((COSBoolean) rawToken).getBoolean().toString());
-            printWriter.write(" ");
+            out.write(((COSBoolean) rawToken).getBoolean().toString().getBytes());
+            out.write(" ".getBytes());
         } else if (rawToken instanceof COSBase) {
-            printWriter.write(rawToken.toString());
-            printWriter.write(" ");
+            out.write(rawToken.toString().getBytes());
+            out.write(" ".getBytes());
         } else if (rawToken instanceof COSObject) {
             write(((COSObject) rawToken).getDirectBase(), printWriter, out);
         } else if (rawToken instanceof Operator) {
             Operator operator = (Operator) rawToken;
-            printWriter.println(((Operator) rawToken).getOperator());
+            out.write(((Operator) rawToken).getOperator().getBytes());
+            out.write("\n".getBytes());
             if (Operators.BI.equals(operator.getOperator())) {
                 InlineImageOperator inlineImageOperator = (InlineImageOperator) operator;
                 for (Map.Entry<ASAtom, COSObject> item : inlineImageOperator.getImageParameters().getEntrySet()) {
-                    printWriter.write(item.getKey().toString());
-                    printWriter.write(" ");
+                    out.write(item.getKey().toString().getBytes());
+                    out.write(" ".getBytes());
                     write(item.getValue(), printWriter, out);
                 }
-                printWriter.println(Operators.ID);
+                out.write(Operators.ID.getBytes());
+                out.write("\n".getBytes());
                 IOUtils.copy(inlineImageOperator.getImageData(), out);
-                printWriter.write("\n");
-                printWriter.println(Operators.EI);
+                out.write("\n".getBytes());
+                out.write(Operators.EI.getBytes());
+                out.write("\n".getBytes());
             }
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/PDFStreamWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/PDFStreamWriter.java
@@ -1,0 +1,94 @@
+package org.opendataloader.pdf.processors;
+
+import org.apache.pdfbox.io.IOUtils;
+import org.verapdf.as.ASAtom;
+import org.verapdf.cos.*;
+import org.verapdf.operator.InlineImageOperator;
+import org.verapdf.operator.Operator;
+import org.verapdf.parser.Operators;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
+
+public class PDFStreamWriter {
+
+	public PDFStreamWriter() {
+
+	}
+
+	public byte[] write(List<Object> tokens) throws IOException {
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             PrintWriter printWriter = new PrintWriter(out)) {
+			for (Object rawToken : tokens) {
+                write(rawToken, printWriter, out);
+			}
+			return out.toByteArray();
+		}
+	}
+
+    private void write(Object rawToken, PrintWriter printWriter, OutputStream out) throws IOException {
+        if (rawToken instanceof COSArray) {
+            printWriter.write("[");
+            for (COSObject item : (COSArray) rawToken) {
+                write(item.getDirectBase(), printWriter, out);
+            }
+            printWriter.write("]");
+            printWriter.write(" ");
+        } else if (rawToken instanceof COSDictionary) {
+                printWriter.write("<<");
+                for (Map.Entry<ASAtom, COSObject> item : ((COSDictionary)rawToken).getEntrySet()) {
+                    printWriter.write(item.getKey().toString());
+                    printWriter.write(" ");
+                    write(item.getValue(), printWriter, out);
+                }
+                printWriter.write(">>");
+                printWriter.write(" ");
+        } else if (rawToken instanceof COSString) {
+            COSString string = (COSString) rawToken;
+            if (string.isHexadecimal()) {
+                printWriter.write("<");
+                printWriter.write(string.getHexString());
+                printWriter.write(">");
+                printWriter.write(" ");
+            } else {
+                printWriter.write("(");
+                byte[] bytes = ((COSString) rawToken).get();
+                for (byte currentByte : bytes) {
+                    if (currentByte == 40 || currentByte == 41) {
+                        printWriter.write('\\');
+                    }
+                    printWriter.write(currentByte);
+                }
+                printWriter.write(")");
+                printWriter.write(" ");
+            }
+        } else if (rawToken instanceof COSBoolean) {
+            printWriter.write(((COSBoolean) rawToken).getBoolean().toString());
+            printWriter.write(" ");
+        } else if (rawToken instanceof COSBase) {
+            printWriter.write(rawToken.toString());
+            printWriter.write(" ");
+        } else if (rawToken instanceof COSObject) {
+            write(((COSObject) rawToken).getDirectBase(), printWriter, out);
+        } else if (rawToken instanceof Operator) {
+            Operator operator = (Operator) rawToken;
+            printWriter.println(((Operator) rawToken).getOperator());
+            if (Operators.BI.equals(operator.getOperator())) {
+                InlineImageOperator inlineImageOperator = (InlineImageOperator) operator;
+                for (Map.Entry<ASAtom, COSObject> item : inlineImageOperator.getImageParameters().getEntrySet()) {
+                    printWriter.write(item.getKey().toString());
+                    printWriter.write(" ");
+                    write(item.getValue(), printWriter, out);
+                }
+                printWriter.println(Operators.ID);
+                IOUtils.copy(inlineImageOperator.getImageData(), out);
+                printWriter.write("\n");
+                printWriter.println(Operators.EI);
+            }
+        }
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ProcessingResult.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ProcessingResult.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.processors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Result of {@link DocumentProcessor#processFile} containing optional metadata
+ * collected during processing.
+ *
+ * <p>Currently carries hybrid-server pipeline timings when hybrid mode is used.
+ * The timings JSON has the structure:
+ * <pre>{
+ *   "layout":          {"total_s": 1.2, "avg_s": 0.12, "count": 10},
+ *   "ocr":             {"total_s": 2.1, "avg_s": 0.21, "count": 10},
+ *   "table_structure":  {"total_s": 0.8, "avg_s": 0.40, "count": 2},
+ *   "doc_enrich":       {"total_s": 5.3, "avg_s": 5.30, "count": 1},
+ *   ...
+ * }</pre>
+ */
+public class ProcessingResult {
+
+    private static final ProcessingResult EMPTY = new ProcessingResult(null, 0, 0);
+
+    private final JsonNode hybridTimings;
+    private final long extractionNs;
+    private final long outputNs;
+
+    public ProcessingResult(JsonNode hybridTimings, long extractionNs, long outputNs) {
+        this.hybridTimings = hybridTimings;
+        this.extractionNs = extractionNs;
+        this.outputNs = outputNs;
+    }
+
+    /** Returns an empty result. */
+    public static ProcessingResult empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Per-step pipeline timings from the hybrid server, or {@code null} if
+     * hybrid mode was not used or the server did not return timings.
+     */
+    public JsonNode getHybridTimings() {
+        return hybridTimings;
+    }
+
+    /** Time spent on data extraction (parsing + layout analysis + content extraction), in nanoseconds. */
+    public long getExtractionNs() {
+        return extractionNs;
+    }
+
+    /** Time spent on output generation (auto-tagging + JSON/MD/HTML export), in nanoseconds. */
+    public long getOutputNs() {
+        return outputNs;
+    }
+
+    /** Extraction time in milliseconds. */
+    public long getExtractionMs() {
+        return extractionNs / 1_000_000;
+    }
+
+    /** Output generation time in milliseconds. */
+    public long getOutputMs() {
+        return outputNs / 1_000_000;
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/AutoTaggerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/AutoTaggerTest.java
@@ -1,0 +1,62 @@
+package org.opendataloader.pdf.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.verapdf.pd.PDDocument;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AutoTaggerTest {
+
+    private static final String TEST_PDF = new File("src/test/resources/cid-font-no-tounicode.pdf").getAbsolutePath();
+
+    @Test
+    void tagReturnsDocumentWithStructTree() throws Exception {
+        Config config = new Config();
+
+        try (TaggingResult result = AutoTagger.tag(TEST_PDF, config)) {
+            PDDocument doc = result.getDocument();
+            assertThat(doc).isNotNull();
+            assertThat(doc.getCatalog().getKey(org.verapdf.as.ASAtom.STRUCT_TREE_ROOT).empty())
+                .as("Tagged PDF should have StructTreeRoot")
+                .isFalse();
+        }
+    }
+
+    @Test
+    void tagTimingsArePositive() throws Exception {
+        Config config = new Config();
+
+        try (TaggingResult result = AutoTagger.tag(TEST_PDF, config)) {
+            assertThat(result.getExtractionNs()).isGreaterThan(0);
+            assertThat(result.getTaggingNs()).isGreaterThan(0);
+        }
+    }
+
+    @Test
+    void saveToWritesFile(@TempDir Path tempDir) throws Exception {
+        Config config = new Config();
+        String outputPath = tempDir.resolve("output_tagged.pdf").toString();
+
+        try (TaggingResult result = AutoTagger.tag(TEST_PDF, config)) {
+            result.saveTo(outputPath);
+        }
+
+        assertThat(new File(outputPath)).exists();
+        assertThat(new File(outputPath).length()).isGreaterThan(0);
+    }
+
+    @Test
+    void tagIgnoresOutputFormatFlags() throws Exception {
+        Config config = new Config();
+        config.setGenerateJSON(true);
+        config.setGenerateMarkdown(true);
+
+        try (TaggingResult result = AutoTagger.tag(TEST_PDF, config)) {
+            assertThat(result.getDocument()).isNotNull();
+        }
+    }
+}

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -9,7 +9,7 @@ import { Command } from 'commander';
 export function registerCliOptions(program: Command): void {
   program.option('-o, --output-dir <value>', 'Directory where output files are written. Default: input file directory');
   program.option('-p, --password <value>', 'Password for encrypted PDF files');
-  program.option('-f, --format <value>', 'Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images. Default: json');
+  program.option('-f, --format <value>', 'Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images, tagged-pdf. Default: json');
   program.option('-q, --quiet', 'Suppress console logging output');
   program.option('--content-safety-off <value>', 'Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg');
   program.option('--sanitize', 'Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -9,7 +9,7 @@ export interface ConvertOptions {
   outputDir?: string;
   /** Password for encrypted PDF files */
   password?: string;
-  /** Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images. Default: json */
+  /** Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images, tagged-pdf. Default: json */
   format?: string | string[];
   /** Suppress console logging output */
   quiet?: boolean;

--- a/options.json
+++ b/options.json
@@ -22,7 +22,7 @@
       "type": "string",
       "required": false,
       "default": null,
-      "description": "Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images. Default: json"
+      "description": "Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images, tagged-pdf. Default: json"
     },
     {
       "name": "quiet",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -34,7 +34,7 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "type": "string",
         "required": False,
         "default": None,
-        "description": "Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images. Default: json",
+        "description": "Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images, tagged-pdf. Default: json",
     },
     {
         "name": "quiet",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -45,7 +45,7 @@ def convert(
         input_path: One or more input PDF file paths or directories
         output_dir: Directory where output files are written. Default: input file directory
         password: Password for encrypted PDF files
-        format: Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images. Default: json
+        format: Output formats (comma-separated). Values: json, text, html, pdf, markdown, markdown-with-html, markdown-with-images, tagged-pdf. Default: json
         quiet: Suppress console logging output
         content_safety_off: Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg
         sanitize: Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders

--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -60,6 +60,10 @@ import tempfile
 import threading
 import time
 import traceback
+
+# Enable docling per-step pipeline profiling (layout, ocr, table_structure, etc.)
+# Must be set before docling settings singleton is instantiated.
+os.environ.setdefault("DOCLING_DEBUG_PROFILE_PIPELINE_TIMINGS", "true")
 from contextlib import asynccontextmanager
 from typing import Any, Optional
 
@@ -96,6 +100,30 @@ _convert_lock = threading.Lock()
 _INVALID_UNICODE_RE = re.compile(r"[\ud800-\udfff\x00]")
 
 
+def extract_timings(result: Any) -> dict[str, Any]:
+    """Extract per-step pipeline timings from a Docling ConversionResult.
+
+    Requires DOCLING_DEBUG_PROFILE_PIPELINE_TIMINGS=true (set at module level).
+    Returns a dict keyed by step name (e.g. "layout", "ocr", "table_structure")
+    with total_s, avg_s, and count for each step.
+    """
+    timings_out: dict[str, Any] = {}
+    raw_timings = getattr(result, "timings", None)
+    if not raw_timings:
+        return timings_out
+    for name, item in raw_timings.items():
+        try:
+            timings_out[name] = {
+                "total_s": round(item.total(), 4),
+                "avg_s": round(item.avg(), 4) if item.count > 0 else 0.0,
+                "count": item.count,
+            }
+        except Exception:
+            # Gracefully skip if ProfilingItem API changes
+            pass
+    return timings_out
+
+
 def build_conversion_response(
     status_value: str,
     json_content: dict,
@@ -103,6 +131,7 @@ def build_conversion_response(
     errors: list[str],
     requested_pages: tuple[int, int] | None,
     total_pages: int | None = None,
+    timings: dict[str, Any] | None = None,
 ) -> dict:
     """Build a structured conversion response with status and failed page info.
 
@@ -159,6 +188,9 @@ def build_conversion_response(
         "errors": errors,
         "failed_pages": failed_pages,
     }
+
+    if timings:
+        response["timings"] = timings
 
     return response
 
@@ -315,6 +347,9 @@ def create_app(
     from fastapi import FastAPI, File, Form, UploadFile
     from fastapi.responses import JSONResponse
 
+    # Profile converters: initialized lazily on first /v1/profile/file request
+    profile_converters: dict[str, Any] = {}
+
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
         """Lifespan context manager for startup and shutdown events."""
@@ -449,6 +484,9 @@ def create_app(
                     len(errors),
                 )
 
+            # Extract per-step pipeline timings (layout, ocr, table_structure, etc.)
+            step_timings = extract_timings(result)
+
             response = build_conversion_response(
                 status_value=status_value,
                 json_content=json_content,
@@ -456,6 +494,7 @@ def create_app(
                 errors=errors,
                 requested_pages=page_range_tuple,
                 total_pages=input_page_count,
+                timings=step_timings,
             )
 
             return JSONResponse(response)
@@ -467,6 +506,94 @@ def create_app(
                     "status": "failure",
                     "errors": ["PDF conversion failed. Check server logs for details."],
                 },
+                status_code=500,
+            )
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def _ensure_profile_converters():
+        """Lazily initialize profile converters on first use."""
+        if profile_converters:
+            return
+        profiles = {
+            "base": dict(enrich_formula=False, enrich_picture_description=False),
+            "picture": dict(enrich_formula=False, enrich_picture_description=True),
+            "formula": dict(enrich_formula=True, enrich_picture_description=False),
+        }
+        for name, opts in profiles.items():
+            logger.info(f"Initializing profile converter: {name} ({opts})")
+            t0 = time.perf_counter()
+            profile_converters[name] = create_converter(
+                force_full_page_ocr=force_ocr,
+                ocr_lang=ocr_lang,
+                picture_description_prompt=picture_description_prompt,
+                device=device,
+                **opts,
+            )
+            logger.info(f"  {name} initialized in {time.perf_counter() - t0:.2f}s")
+
+    @app.post("/v1/profile/file")
+    async def profile_file(
+        files: UploadFile = File(...),
+    ):
+        """Run the same PDF through base / +picture / +picture+formula converters.
+
+        Returns per-profile timings for cost comparison.
+        """
+        _ensure_profile_converters()
+
+        # Stream upload to temp file
+        tmp_path = None
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp_path = tmp.name
+            while True:
+                chunk = await files.read(UPLOAD_CHUNK_SIZE)
+                if not chunk:
+                    break
+                tmp.write(chunk)
+
+        try:
+            results = {}
+            for profile_name, conv in profile_converters.items():
+                def _run(c=conv):
+                    with _convert_lock:
+                        t0 = time.perf_counter()
+                        res = c.convert(tmp_path)
+                        return res, time.perf_counter() - t0
+
+                result, wall_time = await asyncio.to_thread(_run)
+                timings = extract_timings(result)
+
+                # Count pictures and formulas
+                json_content = result.document.export_to_dict()
+                pictures = json_content.get("pictures", [])
+                pics_total = len(pictures)
+                pics_described = sum(
+                    1 for p in pictures
+                    if p.get("captions") or p.get("annotations")
+                )
+                texts = json_content.get("texts", [])
+                formulas_total = sum(1 for t in texts if t.get("label") == "formula")
+                tables_total = len(json_content.get("tables", []))
+
+                results[profile_name] = {
+                    "wall_time_s": round(wall_time, 3),
+                    "timings": timings,
+                    "pictures": {
+                        "total": pics_total,
+                        "with_description": pics_described,
+                    },
+                    "formulas": formulas_total,
+                    "tables": tables_total,
+                }
+
+            return JSONResponse({"status": "success", "profiles": results})
+
+        except Exception as e:
+            logger.error(f"Profile failed: {e}\n{traceback.format_exc()}")
+            return JSONResponse(
+                {"status": "failure", "errors": [str(e)]},
                 status_code=500,
             )
         finally:

--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -223,9 +223,6 @@ def _check_dependencies():
         )
 
 
-DEFAULT_PICTURE_DESCRIPTION_PROMPT = "Describe what you see in this image. Include any text, numbers, labels, and data values visible."
-
-
 def create_converter(
     force_full_page_ocr: bool = False,
     ocr_lang: list[str] | None = None,
@@ -250,6 +247,7 @@ def create_converter(
     from docling.datamodel.accelerator_options import AcceleratorOptions
     from docling.datamodel.base_models import InputFormat
     from docling.datamodel.pipeline_options import (
+        AcceleratorOptions,
         EasyOcrOptions,
         PdfPipelineOptions,
         PictureDescriptionVlmOptions,
@@ -265,11 +263,8 @@ def create_converter(
     # Configure picture description options with custom prompt
     picture_description_options = None
     if enrich_picture_description:
-        prompt = picture_description_prompt or DEFAULT_PICTURE_DESCRIPTION_PROMPT
         picture_description_options = PictureDescriptionVlmOptions(
             repo_id="HuggingFaceTB/SmolVLM-256M-Instruct",
-            prompt=prompt,
-            generation_config={"max_new_tokens": 300, "do_sample": False},
         )
 
     pipeline_kwargs = {
@@ -284,6 +279,9 @@ def create_converter(
     }
     if picture_description_options is not None:
         pipeline_kwargs["picture_description_options"] = picture_description_options
+
+    if device != "auto":
+        pipeline_kwargs["accelerator_options"] = AcceleratorOptions(device=device)
 
     pipeline_options = PdfPipelineOptions(**pipeline_kwargs)
 


### PR DESCRIPTION
## Objective

opendataloader-pdf can extract document structure (headings, tables, lists, figures, captions) but cannot produce a tagged PDF from it. Users who need accessible PDFs must use external tools. odl-pdf-remediation had to call the full extraction pipeline, write a tagged PDF to disk, then re-read it — wasting I/O and coupling to internal APIs.

## Approach

Add auto-tagging as a core capability that writes PDF structure trees (StructTreeRoot, marked content, parent tree) from extracted content. Two consumption paths:

- **CLI**: `--format tagged-pdf` produces `{file}_tagged.pdf` — same pattern as `--format json` or `--format markdown`
- **Java API**: `AutoTagger.tag(inputPdf, config)` returns a `TaggingResult` with an in-memory `PDDocument` — no disk I/O, no intermediate files

The tagging engine maps extracted content to PDF/UA-2 structure elements:

| Content | Structure Element |
|---------|------------------|
| Heading (L1–L6) | `/H1`–`/H6` (normalized, no level skipping) |
| Paragraph | `/P` |
| Table | `/Table` > `/TR` > `/TH` (with Scope) / `/TD` |
| List | `/L` > `/LI` > `/Lbl` + `/LBody` |
| Figure | `/Figure` (with `/Alt` text) |
| Caption | `/Caption` (child of `/Figure` or `/Table`) |
| Link annotation | `/Link` + OBJR |
| Text block (sidebar) | `/Aside` |
| Formula | `Formula` (with LaTeX alt text) |

Key design decisions:
- `AutoTagger.tag()` accepts the existing `Config` class directly — a separate `AutoTaggingConfig` was considered but rejected because 12 of 30+ fields affect extraction results, making a wrapper class a near-duplicate with identical defaults
- `AutoTaggingProcessor.createTaggedPDF()` split into `tagDocument()` (in-memory) + `createTaggedPDF()` (delegates + saves) for backward compatibility
- `--format tagged-pdf` is standalone — cannot be combined with other formats since it uses a separate pipeline path

## Evidence

Ran `--format tagged-pdf` on 200 benchmark documents from opendataloader-bench:

| Scenario | Expected | Actual |
|----------|----------|--------|
| 200 PDFs, `--format tagged-pdf` | 200 tagged PDFs, no failures | 200/200 produced, 0 empty files |
| Heading detection | H1–H6 in structure tree | H1: 191, H2: 43, H3: 12, H4: 1 docs |
| Caption → Figure linking | `/Caption` as child of `/Figure` | 79 captions linked across 200 docs |
| Table structure | `/Table` > `/TR` > `/TH`/`/TD` | 38 tables with full row/cell hierarchy |
| List structure | `/L` > `/LI` > `/Lbl` + `/LBody` | 107 lists with label/body separation |
| Link annotations | `/Link` + OBJR | 677 links tagged |
| Text blocks | `/Aside` (not `/Part`) | 25 aside elements, 0 `/Part` remaining |
| `--format json` (no tagged PDF leak) | Only `.json` output | 0 `_tagged.pdf` files in json output dir |
| `--format pdf` (no tagged PDF leak) | Only `_annotated.pdf` | 0 `_tagged.pdf` files in annot output dir |
| JSON vs tagged-pdf consistency | All JSON content types present in struct tree | 185/200 exact match, 15 expected differences (1x1 tables filtered, link/paragraph count differences from struct decomposition) |
| Full test suite | All pass | 502 tests, 0 failures |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tagged-pdf output to generate accessible tagged PDFs and an option to enable its generation.
  * In-memory auto-tagging that returns downloadable tagged documents with extraction and tagging timing metadata.
  * HTML/Markdown/JSON outputs now include image alt text when available.
  * New profiling API endpoint to collect per-step pipeline timings.

* **Documentation**
  * CLI docs and generated clients updated to document the tagged-pdf format.

* **Tests**
  * Added tests covering auto-tagging, timing metadata, and output persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->