### PR TITLE
fix: prevent StackOverflowError in LevelProcessor mutual recursion

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/LevelProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/LevelProcessor.java
@@ -36,13 +36,19 @@ public class LevelProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(LevelProcessor.class.getCanonicalName());
 
+    private static final int MAX_DEPTH = 50;
+
     private static boolean isDocTitleSet = false;
 
     public static void detectLevels(List<List<IObject>> contents) {
-        setLevels(contents, new Stack<>());
+        setLevels(contents, new Stack<>(), 0);
     }
 
-    private static void setLevels(List<List<IObject>> contents, Stack<LevelInfo> levelInfos) {
+    private static void setLevels(List<List<IObject>> contents, Stack<LevelInfo> levelInfos, int depth) {
+        if (depth > MAX_DEPTH) {
+            LOGGER.log(Level.WARNING, "Maximum nesting depth exceeded in setLevels, skipping further processing");
+            return;
+        }
         int levelInfosSize = levelInfos.size();
         for (List<IObject> pageContents : contents) {
             for (IObject content : pageContents) {
@@ -75,7 +81,7 @@ public class LevelProcessor {
                     }
                     if (index == null) {
                         TableBorder table = (TableBorder) content;
-                        setLevelForTable(table);
+                        setLevelForTable(table, depth + 1);
                         if (!table.isTextBlock()) {
                             levelInfo = new TableLevelInfo(table);
                         }
@@ -106,7 +112,7 @@ public class LevelProcessor {
                 }
                 if (content instanceof PDFList) {
                     for (ListItem listItem : ((PDFList) content).getListItems()) {
-                        setLevels(Collections.singletonList(listItem.getContents()), levelInfos);
+                        setLevels(Collections.singletonList(listItem.getContents()), levelInfos, depth + 1);
                     }
                 }
             }
@@ -133,13 +139,13 @@ public class LevelProcessor {
         return null;
     }
 
-    private static void setLevelForTable(TableBorder tableBorder) {
+    private static void setLevelForTable(TableBorder tableBorder, int depth) {
         for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
             TableBorderRow row = tableBorder.getRow(rowNumber);
             for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
                 TableBorderCell tableBorderCell = row.getCell(colNumber);
                 if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
-                    setLevels(Collections.singletonList(tableBorderCell.getContents()), new Stack<>());
+                    setLevels(Collections.singletonList(tableBorderCell.getContents()), new Stack<>(), depth);
                 }
             }
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/BulletedParagraphUtils.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/BulletedParagraphUtils.java
@@ -18,8 +18,11 @@ package org.opendataloader.pdf.utils;
 import org.verapdf.wcag.algorithms.entities.SemanticTextNode;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Utility class for detecting and processing bulleted paragraphs and list items.
@@ -31,7 +34,7 @@ public class BulletedParagraphUtils {
             "◎●◐◑◒◓◔◕◖◗◘◙◢◣◤◥◦◧◨◩◪◫◬◭◮◯◰◱◲◳◴◵◶◷◸◹◺◻◼◽◾◿★☆☐☑☒☓☛☞♠♡♢♣♤♥♦♧⚪⚫⚬✓✔✕✖✗✘✙✚✛✜✝✞✟✦✧✨❍❏❐❑" +
             "❒❖➔➙➛➜➝➞➟➠➡➢➣➤➥➦➧➨➩➪➭➮➯➱⬛⬜⬝⬞⬟⬠⬡⬢⬣⬤⬥⬦⬧⬨⬩⬪⬫⬬⬭⬮⬯⭐⭑⭒⭓⭔⭕⭖⭗⭘⭙⯀⯁⯂⯃⯄⯅⯆⯇⯈⯌⯍⯎⯏⯐〇" +
             "󰁾󰋪󰋫󰋬󰋭󰋮󰋯󰋰󰋱󰋲󰋳󰋴󰋵󰋶󰋷󰋸󰋹󰋺󰋻󰋼";
-    private static final Set<String> BULLET_REGEXES = new HashSet<>();
+    private static final List<Pattern> BULLET_PATTERNS = new ArrayList<>();
     private static final Set<String> ARABIC_NUMBER_REGEXES = new HashSet<>();
     private static final String KOREAN_NUMBERS_REGEX = "[가나다라마바사아자차카타파하거너더러머버서어저처커터퍼허고노도로모보소오조초코토포호구누두루무부수우주추쿠투푸후그느드르므브스으즈츠크트프흐기니디리미비시이지치키티피히]";
     /** Regular expression for Korean chapter patterns like 제1장, 제2조, 제3절. */
@@ -88,8 +91,8 @@ public class BulletedParagraphUtils {
         if (textLine.getConnectedLineArtLabel() != null) {
             return true;
         }
-        for (String regex : BULLET_REGEXES) {
-            if (value.matches(regex)) {
+        for (Pattern pattern : BULLET_PATTERNS) {
+            if (pattern.matcher(value).matches()) {
                 return true;
             }
         }
@@ -114,9 +117,9 @@ public class BulletedParagraphUtils {
      */
     public static String getLabelRegex(SemanticTextNode textNode) {
         String value = textNode.getFirstLine().getValue();
-        for (String regex : BULLET_REGEXES) {
-            if (value.matches(regex)) {
-                return regex;
+        for (Pattern pattern : BULLET_PATTERNS) {
+            if (pattern.matcher(value).matches()) {
+                return pattern.pattern();
             }
         }
         return null;
@@ -124,37 +127,37 @@ public class BulletedParagraphUtils {
 
     static {
         ARABIC_NUMBER_REGEXES.add("^\\d+[ \\.\\]\\)>].*");
-        BULLET_REGEXES.add("^\\(\\d+\\).*");
+        BULLET_PATTERNS.add(Pattern.compile("^\\(\\d+\\).*"));
         ARABIC_NUMBER_REGEXES.add("^<\\d+>.*");
         ARABIC_NUMBER_REGEXES.add("^\\[\\d+\\].*");
         ARABIC_NUMBER_REGEXES.add("^{\\d+}.*");
         ARABIC_NUMBER_REGEXES.add("^【\\d+】.*");
-        BULLET_REGEXES.add("^\\d+[\\.\\)]\\s+.*");
-        BULLET_REGEXES.add("^[ㄱㄴㄷㄹㅁㅂㅅㅇㅈㅊㅋㅌㅍㅎ][\\.\\)\\]>].*");
-        BULLET_REGEXES.add("^" + KOREAN_NUMBERS_REGEX + "\\..+");
-        BULLET_REGEXES.add("^" + KOREAN_NUMBERS_REGEX + "[)\\]>].*");
-        BULLET_REGEXES.add("^" + KOREAN_NUMBERS_REGEX + "(-\\d+).*");
-        BULLET_REGEXES.add("^\\(" + KOREAN_NUMBERS_REGEX + "\\).*");
-        BULLET_REGEXES.add("^<" + KOREAN_NUMBERS_REGEX + ">.*");
-        BULLET_REGEXES.add("^\\[" + KOREAN_NUMBERS_REGEX + "\\].*");
-        BULLET_REGEXES.add("^[{]" + KOREAN_NUMBERS_REGEX + "[}].*");
-        BULLET_REGEXES.add(KOREAN_CHAPTER_REGEX);
-        BULLET_REGEXES.add("^법\\.(제\\d+조).*");
-        BULLET_REGEXES.add("^[\u0049]\\..*");//"^[Ⅰ-Ⅻ]"
-        BULLET_REGEXES.add("^[\u2160-\u216B].*");//"^[Ⅰ-Ⅻ]"
-        BULLET_REGEXES.add("^[\u2170-\u217B].*");//"^[ⅰ-ⅻ]"
-        BULLET_REGEXES.add("^[\u2460-\u2473].*");//"^[①-⑳]"
-        BULLET_REGEXES.add("^[\u2474-\u2487].*");//"^[⑴-⒇]"
-        BULLET_REGEXES.add("^[\u2488-\u249B].*");//"^[⒈-⒛]"
-        BULLET_REGEXES.add("^[\u249C-\u24B5].*");//"^[⒜-⒵]"
-        BULLET_REGEXES.add("^[\u24B6-\u24CF].*");//"^[Ⓐ-Ⓩ]"
-        BULLET_REGEXES.add("^[\u24D0-\u24E9].*");//"^[ⓐ-ⓩ]"
-        BULLET_REGEXES.add("^[\u24F5-\u24FE].*");//"^[⓵-⓾]"
-        BULLET_REGEXES.add("^[\u2776-\u277F].*");//"^[❶-❿]"
-        BULLET_REGEXES.add("^[\u2780-\u2789].*");//"^[➀-➉]"
-        BULLET_REGEXES.add("^[\u278A-\u2793].*");//"^[➊-➓]"
-        BULLET_REGEXES.add("^[\u326E-\u327B].*");//"^[㉮-㉻]"
-        BULLET_REGEXES.add("^[\uF081-\uF08A].*");//"^[-]"
-        BULLET_REGEXES.add("^[\uF08C-\uF095].*");//"^[-]"
+        BULLET_PATTERNS.add(Pattern.compile("^\\d+[\\.\\)]\\s+.*"));
+        BULLET_PATTERNS.add(Pattern.compile("^[ㄱㄴㄷㄹㅁㅂㅅㅇㅈㅊㅋㅌㅍㅎ][\\.\\)\\]>].*"));
+        BULLET_PATTERNS.add(Pattern.compile("^" + KOREAN_NUMBERS_REGEX + "\\..+"));
+        BULLET_PATTERNS.add(Pattern.compile("^" + KOREAN_NUMBERS_REGEX + "[)\\]>].*"));
+        BULLET_PATTERNS.add(Pattern.compile("^" + KOREAN_NUMBERS_REGEX + "(-\\d+).*"));
+        BULLET_PATTERNS.add(Pattern.compile("^\\(" + KOREAN_NUMBERS_REGEX + "\\).*"));
+        BULLET_PATTERNS.add(Pattern.compile("^<" + KOREAN_NUMBERS_REGEX + ">.*"));
+        BULLET_PATTERNS.add(Pattern.compile("^\\[" + KOREAN_NUMBERS_REGEX + "\\].*"));
+        BULLET_PATTERNS.add(Pattern.compile("^[{]" + KOREAN_NUMBERS_REGEX + "[}].*"));
+        BULLET_PATTERNS.add(Pattern.compile(KOREAN_CHAPTER_REGEX));
+        BULLET_PATTERNS.add(Pattern.compile("^법\\.(제\\d+조).*"));
+        BULLET_PATTERNS.add(Pattern.compile("^[\u0049]\\..*"));//"^[Ⅰ-Ⅻ]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u2160-\u216B].*"));//"^[Ⅰ-Ⅻ]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u2170-\u217B].*"));//"^[ⅰ-ⅻ]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u2460-\u2473].*"));//"^[①-⑳]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u2474-\u2487].*"));//"^[⑴-⒇]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u2488-\u249B].*"));//"^[⒈-⒛]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u249C-\u24B5].*"));//"^[⒜-⒵]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u24B6-\u24CF].*"));//"^[Ⓐ-Ⓩ]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u24D0-\u24E9].*"));//"^[ⓐ-ⓩ]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u24F5-\u24FE].*"));//"^[⓵-⓾]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u2776-\u277F].*"));//"^[❶-❿]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u2780-\u2789].*"));//"^[➀-➉]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u278A-\u2793].*"));//"^[➊-➓]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\u326E-\u327B].*"));//"^[㉮-㉻]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\uF081-\uF08A].*"));//"^[-]"
+        BULLET_PATTERNS.add(Pattern.compile("^[\uF08C-\uF095].*"));//"^[-]"
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/LevelProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/LevelProcessorTest.java
@@ -156,4 +156,40 @@ public class LevelProcessorTest {
         Assertions.assertEquals("1", contents.get(0).get(0).getLevel());
         Assertions.assertEquals("2", contents.get(1).get(0).getLevel());
     }
+
+    @Test
+    public void testDeeplyNestedTablesDoNotCauseStackOverflow() {
+        StaticContainers.setIsDataLoader(true);
+        StaticLayoutContainers.setHeadings(new ArrayList<>());
+        List<List<IObject>> contents = new ArrayList<>();
+        List<IObject> pageContents = new ArrayList<>();
+        contents.add(pageContents);
+
+        // Build a chain of 100 nested tables (table -> cell -> table -> cell -> ...)
+        TableBorder outerTable = createSingleCellTable(0, 10.0, 10.0, 200.0, 200.0);
+        TableBorder current = outerTable;
+        for (int i = 1; i <= 100; i++) {
+            TableBorder innerTable = createSingleCellTable(0,
+                    10.0 + i, 10.0 + i, 200.0 - i, 200.0 - i);
+            current.getRow(0).getCell(0).getContents().add(innerTable);
+            current = innerTable;
+        }
+        pageContents.add(outerTable);
+
+        Assertions.assertDoesNotThrow(() -> LevelProcessor.detectLevels(contents));
+    }
+
+    private TableBorder createSingleCellTable(int pageNumber,
+                                               double leftX, double bottomY,
+                                               double rightX, double topY) {
+        TableBorder table = new TableBorder(1, 1);
+        table.setRecognizedStructureId(0l);
+        table.setBoundingBox(new BoundingBox(pageNumber, leftX, bottomY, rightX, topY));
+        TableBorderRow row = new TableBorderRow(0, 1, 0l);
+        row.setBoundingBox(new BoundingBox(pageNumber, leftX, bottomY, rightX, topY));
+        row.getCells()[0] = new TableBorderCell(0, 0, 1, 1, 0l);
+        row.getCells()[0].setBoundingBox(new BoundingBox(pageNumber, leftX, bottomY, rightX, topY));
+        table.getRows()[0] = row;
+        return table;
+    }
 }


### PR DESCRIPTION
## Summary

- Add max depth guard (50) to `LevelProcessor.setLevels()` / `setLevelForTable()` mutual recursion to prevent `StackOverflowError` on deeply nested table structures
- Precompile 30+ regex patterns in `BulletedParagraphUtils` from `String.matches()` (recompiles every call) to pre-compiled `Pattern` objects, reducing stack consumption and improving performance
- Add unit test verifying 100-level nested tables do not cause `StackOverflowError`

## Root Cause

`setLevels()` → `setLevelForTable()` → `setLevels()` mutual recursion had no depth limit. PDFs with deeply nested table-in-table structures caused unbounded recursion, overflowing the stack even with `-Xss16m`.

## Changes

| File | Change |
|------|--------|
| `LevelProcessor.java` | Add `MAX_DEPTH=50`, propagate `depth` parameter through `setLevels()`/`setLevelForTable()`, log warning and return on overflow |
| `BulletedParagraphUtils.java` | `Set<String> BULLET_REGEXES` → `List<Pattern> BULLET_PATTERNS`, `value.matches(regex)` → `pattern.matcher(value).matches()` |
| `LevelProcessorTest.java` | Add `testDeeplyNestedTablesDoNotCauseStackOverflow()` |

## Test plan

- [x] Existing `LevelProcessorTest` (3 tests) pass — no regressions
- [x] New `testDeeplyNestedTablesDoNotCauseStackOverflow` passes
- [x] Full `opendataloader-pdf-core` test suite passes (BUILD SUCCESS)
- [ ] Integration test with real PDF containing deeply nested tables (no sample PDF attached to issue)

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential stack overflow errors when processing PDF documents with deeply nested table structures.

* **Performance**
  * Optimized bullet point detection to improve text processing speed.

* **Tests**
  * Added test coverage for deeply nested table structure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->