### PR TITLE
Fix #430: add input validation to OpenDataLoaderPDF.processFile

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
@@ -86,19 +86,21 @@ public final class OpenDataLoaderPDF {
             throw new IllegalArgumentException("Invalid file path: " + ex.getReason(), ex);
         }
 
+        final String fileName = path.getFileName().toString();
+
         if (!Files.exists(path)) {
-            LOGGER.log(Level.WARNING, "PDF file does not exist: {0}", path.getFileName());
-            throw new IllegalArgumentException("File does not exist: " + inputPdfName);
+            LOGGER.log(Level.WARNING, "PDF file does not exist: {0}", fileName);
+            throw new IllegalArgumentException("File does not exist: " + fileName);
         }
 
         if (!Files.isRegularFile(path)) {
-            LOGGER.log(Level.WARNING, "Path does not point to a regular file: {0}", path.getFileName());
-            throw new IllegalArgumentException("Path is not a regular file: " + inputPdfName);
+            LOGGER.log(Level.WARNING, "Path does not point to a regular file: {0}", fileName);
+            throw new IllegalArgumentException("Path is not a regular file: " + fileName);
         }
 
-        if (!path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".pdf")) {
-            LOGGER.log(Level.WARNING, "File does not have a .pdf extension: {0}", path.getFileName());
-            throw new IllegalArgumentException("File must have a .pdf extension: " + inputPdfName);
+        if (!fileName.toLowerCase(Locale.ROOT).endsWith(".pdf")) {
+            LOGGER.log(Level.WARNING, "File does not have a .pdf extension: {0}", fileName);
+            throw new IllegalArgumentException("File must have a .pdf extension: " + fileName);
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
@@ -86,7 +86,12 @@ public final class OpenDataLoaderPDF {
             throw new IllegalArgumentException("Invalid file path: " + ex.getReason(), ex);
         }
 
-        final String fileName = path.getFileName().toString();
+        final Path fileNamePath = path.getFileName();
+        if (fileNamePath == null) {
+            LOGGER.log(Level.WARNING, "Path has no file name component (root path not allowed)");
+            throw new IllegalArgumentException("Path has no file name component: " + path);
+        }
+        final String fileName = fileNamePath.toString();
 
         if (!Files.exists(path)) {
             LOGGER.log(Level.WARNING, "PDF file does not exist: {0}", fileName);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
@@ -89,7 +89,7 @@ public final class OpenDataLoaderPDF {
         final Path fileNamePath = path.getFileName();
         if (fileNamePath == null) {
             LOGGER.log(Level.WARNING, "Path has no file name component (root path not allowed)");
-            throw new IllegalArgumentException("Path has no file name component: " + path);
+            throw new IllegalArgumentException("Path has no file name component (root paths are not allowed)");
         }
         final String fileName = fileNamePath.toString();
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
@@ -19,6 +19,13 @@ import org.opendataloader.pdf.hybrid.HybridClientFactory;
 import org.opendataloader.pdf.processors.DocumentProcessor;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The main entry point for the opendataloader-pdf library.
@@ -26,18 +33,73 @@ import java.io.IOException;
  */
 public final class OpenDataLoaderPDF {
 
+    private static final Logger LOGGER = Logger.getLogger(OpenDataLoaderPDF.class.getName());
+
     private OpenDataLoaderPDF() {
     }
 
     /**
      * Processes a PDF file to extract its content and structure based on the provided configuration.
      *
+     * <p>Input validation is performed before processing. Callers may catch
+     * {@link IllegalArgumentException} to skip invalid entries in a batch loop:
+     * <pre>{@code
+     * for (String pdf : paths) {
+     *     try {
+     *         OpenDataLoaderPDF.processFile(pdf, config);
+     *     } catch (IllegalArgumentException e) {
+     *         // skip invalid path and continue
+     *     }
+     * }
+     * }</pre>
+     *
      * @param inputPdfName The path to the input PDF file.
      * @param config       The configuration object specifying output formats and other options.
-     * @throws IOException If an error occurs during file reading or processing.
+     * @throws IllegalArgumentException if {@code inputPdfName} is null, blank, syntactically
+     *                                  invalid, does not exist, is not a regular file, or does
+     *                                  not have a {@code .pdf} extension.
+     * @throws IOException              If an error occurs during file reading or processing.
      */
     public static void processFile(String inputPdfName, Config config) throws IOException {
+        validateInputFile(inputPdfName);
         DocumentProcessor.processFile(inputPdfName, config);
+    }
+
+    /**
+     * Validates that {@code inputPdfName} refers to an existing, regular PDF file.
+     *
+     * @param inputPdfName the path string to validate
+     * @throws IllegalArgumentException if the path is null, blank, syntactically invalid,
+     *                                  non-existent, not a regular file, or lacks a {@code .pdf} extension
+     */
+    private static void validateInputFile(String inputPdfName) {
+        if (inputPdfName == null || inputPdfName.isBlank()) {
+            LOGGER.log(Level.WARNING, "Input PDF path is null or blank");
+            throw new IllegalArgumentException("Input PDF path must not be null or blank");
+        }
+
+        final Path path;
+        try {
+            path = Paths.get(inputPdfName);
+        } catch (InvalidPathException ex) {
+            LOGGER.log(Level.WARNING, "Syntactically invalid path supplied");
+            throw new IllegalArgumentException("Invalid file path: " + ex.getReason(), ex);
+        }
+
+        if (!Files.exists(path)) {
+            LOGGER.log(Level.WARNING, "PDF file does not exist: {0}", path.getFileName());
+            throw new IllegalArgumentException("File does not exist: " + inputPdfName);
+        }
+
+        if (!Files.isRegularFile(path)) {
+            LOGGER.log(Level.WARNING, "Path does not point to a regular file: {0}", path.getFileName());
+            throw new IllegalArgumentException("Path is not a regular file: " + inputPdfName);
+        }
+
+        if (!path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".pdf")) {
+            LOGGER.log(Level.WARNING, "File does not have a .pdf extension: {0}", path.getFileName());
+            throw new IllegalArgumentException("File must have a .pdf extension: " + inputPdfName);
+        }
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OpenDataLoaderPDF.java
@@ -35,6 +35,7 @@ public final class OpenDataLoaderPDF {
 
     private static final Logger LOGGER = Logger.getLogger(OpenDataLoaderPDF.class.getName());
 
+    /** Utility class; do not instantiate. */
     private OpenDataLoaderPDF() {
     }
 


### PR DESCRIPTION
Closes #430.

## Problem

`OpenDataLoaderPDF.processFile` threw an unspecific exception on invalid paths, crashing an entire batch loop. The CLI handled this gracefully; the Java API did not.

## Changes

- Added `validateInputFile(String)` that checks for null/blank input, syntactically invalid path, non-existent file, non-regular file, and missing `.pdf` extension — each throws `IllegalArgumentException` with a clear message.
- Preserved the existing `throws IOException` contract on `processFile`.
- **Logs only the file name** (not the full path) to avoid path-disclosure in log output — addresses the security concern flagged in CodeRabbit's review of #431.
- Updated Javadoc on `processFile` with both `@throws` tags and a batch-usage code example.
- Added Javadoc to the private `validateInputFile` helper to meet docstring coverage requirements.

## Improvements over #431

| Area | #431 | This PR |
|------|------|---------|
| `@throws IOException` in Javadoc | Removed (breaks contract) | Restored |
| `@throws IllegalArgumentException` in Javadoc | Missing | Present |
| Log path disclosure | Logs full `inputPdfName` | Logs only `path.getFileName()` |
| `validateInputFile` Javadoc | Present | Present |
| Batch-loop usage example | Missing | Included in Javadoc |

## Test manually

```java
// Should throw IllegalArgumentException, not NPE or IOException
OpenDataLoaderPDF.processFile(null, config);
OpenDataLoaderPDF.processFile("", config);
OpenDataLoaderPDF.processFile("/does/not/exist.pdf", config);
OpenDataLoaderPDF.processFile("/tmp/somefile.txt", config);

// Should proceed to DocumentProcessor
OpenDataLoaderPDF.processFile("/path/to/valid.pdf", config);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for provided PDF input names: rejects null/blank, syntactically invalid paths, root-only paths, non-existent or non-regular files, and names not ending with “.pdf” (case-insensitive).
  * API contract updated to surface and document invalid-input errors when validation fails.
  * Validation failures now emit warning-level diagnostic logs to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->