### PR TITLE
feat(helium): Hancom AI hybrid backend + PDF/UA-2 remediation improvements

### DIFF
--- a/docs/superpowers/plans/2026-04-18-hancom-ai-mock-server.md
+++ b/docs/superpowers/plans/2026-04-18-hancom-ai-mock-server.md
@@ -1,0 +1,1710 @@
+# Hancom AI Mock Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hancom AI 서버 부재 시 transformer 개발/디버그 사이클을 유지하기 위한 fixture-replay HTTP mock 서버 구현 + 클라이언트(`HancomAIClient.java`) REQUEST_ID 규약 패치.
+
+**Architecture:** Python(FastAPI) 로컬 서버가 200개 벤치 PDF의 SHA256을 인덱싱하고, PDF 입력은 SHA256 룩업, 이미지 입력은 클라이언트가 REQUEST_ID에 인코딩한 `(sha_short, page, obj, module)`로 룩업, pdf2img는 PyMuPDF로 동적 300DPI 렌더링 + base64 응답. 클라이언트는 `convert()` 진입 시 PDF SHA256을 캐시하고 모든 호출에 REQUEST_ID 규약 적용.
+
+**Tech Stack:**
+- Mock 서버: Python 3.10+, FastAPI, uvicorn, PyMuPDF, pytest, httpx (TestClient)
+- Client 패치: Java 8+, OkHttp, Jackson, Maven, JUnit 5
+- 데이터: `bundolee/kb-odl/raw/4-기술/2026-04-16_Q2-기술-ctx_hancom-ai-a11y_출력데이터-스키마/`
+- PDFs: `opendataloader-project/opendataloader-bench/pdfs/`
+
+**Spec:** `bundolee/kb-odl/raw/4-기술/2026-04-18_Q2-DEV-02-Code_hancom-ai-mock-server-design.md` (commit `dfe0671`)
+
+---
+
+## File Structure
+
+### Mock 서버 (신규)
+
+`opendataloader-project/opendataloader-pdfua/scripts/mock_server/`
+
+| 파일 | 책임 |
+|---|---|
+| `mock_server/__init__.py` | 빈 패키지 마커 |
+| `mock_server/__main__.py` | CLI 엔트리포인트 (`python -m mock_server ...`) |
+| `mock_server/index.py` | 부팅 시 `--pdf-dir` 스캔 → `{sha256: (basename, path)}` 인덱스 |
+| `mock_server/request_id.py` | REQUEST_ID 정규식 파싱 (`odl-{sha12}-p{n}-o{n}-{module}`) |
+| `mock_server/lookup.py` | 모듈명/입력타입에 따른 fixture 경로 결정 + JSON 로드. `FixtureMiss` 예외. |
+| `mock_server/pdf_render.py` | PyMuPDF로 PDF 페이지 → PNG 300DPI bytes |
+| `mock_server/server.py` | FastAPI app: `/ping`, `/hocr/sdk`, `/support/pdf2img` (각각 `/api/v1/` 변형 별칭) |
+| `mock_server/tests/__init__.py` | |
+| `mock_server/tests/conftest.py` | 테스트 fixture (샘플 PDF dir, 샘플 fixture dir) |
+| `mock_server/tests/test_index.py` | |
+| `mock_server/tests/test_request_id.py` | |
+| `mock_server/tests/test_lookup.py` | |
+| `mock_server/tests/test_pdf_render.py` | |
+| `mock_server/tests/test_server.py` | |
+| `mock_server/pyproject.toml` | 의존성 + pytest 설정 |
+| `mock_server/README.md` | 실행법 + 디버깅 + client 패치 메모 |
+
+### Client 패치 (수정)
+
+`opendataloader-project/opendataloader-pdf/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java`
+
+`opendataloader-project/opendataloader-pdf/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAIClientRequestIdTest.java` (신규)
+
+---
+
+## Phase 1 — Mock Server (10 tasks)
+
+### Task 1: 프로젝트 스캐폴딩
+
+**Files:**
+- Create: `opendataloader-project/opendataloader-pdfua/scripts/mock_server/pyproject.toml`
+- Create: `opendataloader-project/opendataloader-pdfua/scripts/mock_server/__init__.py`
+- Create: `opendataloader-project/opendataloader-pdfua/scripts/mock_server/tests/__init__.py`
+- Create: `opendataloader-project/opendataloader-pdfua/scripts/mock_server/README.md`
+
+- [ ] **Step 1: pyproject.toml 작성**
+
+```toml
+[project]
+name = "hancom-ai-mock-server"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110",
+    "uvicorn>=0.27",
+    "pymupdf>=1.24",
+    "python-multipart>=0.0.9",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.27",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+```
+
+- [ ] **Step 2: 빈 패키지 마커 + README 초안**
+
+`mock_server/__init__.py`:
+```python
+"""Hancom AI HOCR SDK fixture-replay mock server."""
+```
+
+`mock_server/tests/__init__.py`:
+```python
+```
+
+`mock_server/README.md`:
+```markdown
+# Hancom AI Mock Server
+
+Fixture-replay mock for `HancomAIClient`. See spec at
+`bundolee/kb-odl/raw/4-기술/2026-04-18_Q2-DEV-02-Code_hancom-ai-mock-server-design.md`.
+
+## Run
+
+```bash
+cd opendataloader-pdfua/scripts/mock_server
+pip install -e ".[dev]"
+python -m mock_server \
+  --pdf-dir /path/to/opendataloader-bench/pdfs \
+  --fixture-dir /path/to/kb-odl/raw/4-기술/2026-04-16_Q2-기술-ctx_hancom-ai-a11y_출력데이터-스키마 \
+  --port 18008
+```
+
+## Tests
+
+```bash
+pytest -v
+```
+```
+
+- [ ] **Step 3: 디렉토리 구조 확인**
+
+Run: `ls opendataloader-project/opendataloader-pdfua/scripts/mock_server/`
+Expected: `pyproject.toml  README.md  __init__.py  tests/`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd opendataloader-project/opendataloader-pdfua
+git add scripts/mock_server/
+git commit -m "feat(mock-server): scaffold project structure"
+```
+
+---
+
+### Task 2: REQUEST_ID 파서 (TDD)
+
+**Files:**
+- Test: `opendataloader-project/opendataloader-pdfua/scripts/mock_server/tests/test_request_id.py`
+- Create: `opendataloader-project/opendataloader-pdfua/scripts/mock_server/mock_server/request_id.py`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`tests/test_request_id.py`:
+```python
+import pytest
+from mock_server.request_id import parse_request_id, RequestIdParts
+
+
+def test_parse_caption():
+    parts = parse_request_id("odl-a3f1c9d2e7b8-p0-o5-caption")
+    assert parts == RequestIdParts(sha_short="a3f1c9d2e7b8", page=0, obj=5, module="caption")
+
+
+def test_parse_chart():
+    parts = parse_request_id("odl-deadbeef0000-p3-o12-chart")
+    assert parts == RequestIdParts(sha_short="deadbeef0000", page=3, obj=12, module="chart")
+
+
+def test_parse_tsr():
+    parts = parse_request_id("odl-aabbccddeeff-p0-o0-tsr")
+    assert parts.module == "tsr"
+
+
+def test_parse_invalid_returns_none():
+    assert parse_request_id("odl-DOCUMENT_LAYOUT_WITH_OCR") is None
+    assert parse_request_id("garbage") is None
+    assert parse_request_id("") is None
+    assert parse_request_id("odl-a3f1-p0-o0-unknown") is None  # bad module
+
+
+def test_parse_pdf_module_request_id_returns_none():
+    # PDF modules use REQUEST_ID for tracing only; mock matches via SHA256 of bytes.
+    # Parser returns None for these so caller falls back to PDF lookup path.
+    assert parse_request_id("odl-a3f1c9d2e7b8-dla-ocr") is None
+```
+
+- [ ] **Step 2: 테스트 실행 (실패 확인)**
+
+Run: `cd opendataloader-project/opendataloader-pdfua/scripts/mock_server && pytest tests/test_request_id.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mock_server.request_id'`
+
+- [ ] **Step 3: 최소 구현**
+
+`mock_server/request_id.py`:
+```python
+"""Parse client REQUEST_ID for image-input module lookup."""
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+_PATTERN = re.compile(
+    r"^odl-(?P<sha>[0-9a-f]{12})-p(?P<page>\d+)-o(?P<obj>\d+)-(?P<module>caption|chart|tsr)$"
+)
+
+
+@dataclass(frozen=True)
+class RequestIdParts:
+    sha_short: str
+    page: int
+    obj: int
+    module: str
+
+
+def parse_request_id(request_id: str) -> Optional[RequestIdParts]:
+    if not request_id:
+        return None
+    m = _PATTERN.match(request_id)
+    if not m:
+        return None
+    return RequestIdParts(
+        sha_short=m.group("sha"),
+        page=int(m.group("page")),
+        obj=int(m.group("obj")),
+        module=m.group("module"),
+    )
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pytest tests/test_request_id.py -v`
+Expected: 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/mock_server/mock_server/request_id.py scripts/mock_server/tests/test_request_id.py
+git commit -m "feat(mock-server): REQUEST_ID parser for image module lookup"
+```
+
+---
+
+### Task 3: SHA256 인덱스 빌더 (TDD)
+
+**Files:**
+- Test: `scripts/mock_server/tests/test_index.py`
+- Test: `scripts/mock_server/tests/conftest.py`
+- Create: `scripts/mock_server/mock_server/index.py`
+
+- [ ] **Step 1: conftest fixture 작성**
+
+`tests/conftest.py`:
+```python
+import hashlib
+import shutil
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture
+def sample_pdf_dir(tmp_path):
+    """Create a tiny PDF dir with 3 fake PDFs (just bytes, not parsed by index)."""
+    d = tmp_path / "pdfs"
+    d.mkdir()
+    for i in range(1, 4):
+        (d / f"pdf{i:03d}.pdf").write_bytes(f"FAKE_PDF_CONTENT_{i}".encode())
+    return d
+
+
+def sha256_hex(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+```
+
+- [ ] **Step 2: 실패하는 테스트 작성**
+
+`tests/test_index.py`:
+```python
+from mock_server.index import build_pdf_index, PdfIndexEntry
+from .conftest import sha256_hex
+
+
+def test_build_index_three_pdfs(sample_pdf_dir):
+    index = build_pdf_index(sample_pdf_dir)
+    assert len(index) == 3
+    expected_sha = sha256_hex(b"FAKE_PDF_CONTENT_1")
+    assert expected_sha in index
+    entry = index[expected_sha]
+    assert entry.basename == "pdf001"
+    assert entry.path == sample_pdf_dir / "pdf001.pdf"
+
+
+def test_build_index_empty_dir(tmp_path):
+    index = build_pdf_index(tmp_path)
+    assert index == {}
+
+
+def test_build_index_sha_short_lookup(sample_pdf_dir):
+    index = build_pdf_index(sample_pdf_dir)
+    full_sha = next(iter(index))
+    short = full_sha[:12]
+    entry = index.find_by_short(short)
+    assert entry is not None
+    assert entry.basename in {"pdf001", "pdf002", "pdf003"}
+```
+
+- [ ] **Step 3: 테스트 실행 (실패 확인)**
+
+Run: `pytest tests/test_index.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 4: 최소 구현**
+
+`mock_server/index.py`:
+```python
+"""Build SHA256 index of benchmark PDFs at server boot."""
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class PdfIndexEntry:
+    basename: str
+    path: Path
+
+
+class PdfIndex(dict):
+    """Dict {full_sha256: PdfIndexEntry} with helper for short-prefix lookup."""
+
+    def find_by_short(self, sha_short: str) -> Optional[PdfIndexEntry]:
+        for full_sha, entry in self.items():
+            if full_sha.startswith(sha_short):
+                return entry
+        return None
+
+
+def build_pdf_index(pdf_dir: Path) -> PdfIndex:
+    index = PdfIndex()
+    for path in sorted(Path(pdf_dir).glob("*.pdf")):
+        sha = hashlib.sha256(path.read_bytes()).hexdigest()
+        index[sha] = PdfIndexEntry(basename=path.stem, path=path)
+    return index
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `pytest tests/test_index.py -v`
+Expected: 3 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/mock_server/
+git commit -m "feat(mock-server): SHA256 PDF index with short-prefix lookup"
+```
+
+---
+
+### Task 4: Lookup 로직 (TDD)
+
+**Files:**
+- Test: `scripts/mock_server/tests/test_lookup.py`
+- Test: `scripts/mock_server/tests/conftest.py` (확장)
+- Create: `scripts/mock_server/mock_server/lookup.py`
+
+- [ ] **Step 1: conftest 확장 — 가짜 fixture dir**
+
+`tests/conftest.py` 끝에 추가:
+```python
+import json
+
+
+@pytest.fixture
+def sample_fixture_dir(tmp_path):
+    """Mimic the recorded data layout with one entry per module."""
+    root = tmp_path / "fixtures"
+    for sub in ["DLA_OCR", "DLA", "OCR", "TSR", "TSR_regionlist", "FIGURE"]:
+        (root / sub).mkdir(parents=True)
+    (root / "DLA_OCR" / "pdf001.json").write_text(json.dumps({"module": "DLA_OCR", "id": "pdf001"}))
+    (root / "DLA" / "pdf001.json").write_text(json.dumps({"module": "DLA"}))
+    (root / "OCR" / "pdf001.json").write_text(json.dumps({"module": "OCR"}))
+    (root / "TSR" / "pdf002_p0_o0.json").write_text(json.dumps({"module": "TSR", "table": True}))
+    (root / "TSR_regionlist" / "pdf003_p0_o0.json").write_text(json.dumps({"module": "TSR_regionlist"}))
+    (root / "FIGURE" / "pdf001_p0_o5_caption.json").write_text(json.dumps({"caption": "test"}))
+    (root / "FIGURE" / "pdf001_p0_o5_chart.json").write_text(json.dumps({"understanding": "TITLE | <0x0A> 1 | 2"}))
+    return root
+```
+
+- [ ] **Step 2: 실패 테스트 작성**
+
+`tests/test_lookup.py`:
+```python
+import pytest
+from mock_server.lookup import (
+    lookup_pdf_module, lookup_image_module, FixtureMiss,
+    MODULE_TO_DIR,
+)
+
+
+def test_pdf_module_lookup_dla_ocr(sample_fixture_dir):
+    data = lookup_pdf_module(sample_fixture_dir, "DOCUMENT_LAYOUT_WITH_OCR", "pdf001")
+    assert data == {"module": "DLA_OCR", "id": "pdf001"}
+
+
+def test_pdf_module_lookup_dla(sample_fixture_dir):
+    data = lookup_pdf_module(sample_fixture_dir, "DOCUMENT_LAYOUT_ANALYSIS", "pdf001")
+    assert data["module"] == "DLA"
+
+
+def test_pdf_module_lookup_unknown_module(sample_fixture_dir):
+    with pytest.raises(FixtureMiss) as exc:
+        lookup_pdf_module(sample_fixture_dir, "BOGUS_MODULE", "pdf001")
+    assert "BOGUS_MODULE" in str(exc.value)
+
+
+def test_pdf_module_lookup_missing_basename(sample_fixture_dir):
+    with pytest.raises(FixtureMiss):
+        lookup_pdf_module(sample_fixture_dir, "DOCUMENT_LAYOUT_WITH_OCR", "pdf999")
+
+
+def test_image_module_lookup_caption(sample_fixture_dir):
+    data = lookup_image_module(sample_fixture_dir, "caption", "pdf001", page=0, obj=5)
+    assert data == {"caption": "test"}
+
+
+def test_image_module_lookup_chart(sample_fixture_dir):
+    data = lookup_image_module(sample_fixture_dir, "chart", "pdf001", page=0, obj=5)
+    assert data["understanding"].startswith("TITLE")
+
+
+def test_image_module_lookup_tsr_primary(sample_fixture_dir):
+    data = lookup_image_module(sample_fixture_dir, "tsr", "pdf002", page=0, obj=0)
+    assert data["table"] is True
+
+
+def test_image_module_lookup_tsr_regionlist_fallback(sample_fixture_dir):
+    data = lookup_image_module(sample_fixture_dir, "tsr", "pdf003", page=0, obj=0)
+    assert data["module"] == "TSR_regionlist"
+
+
+def test_image_module_lookup_missing(sample_fixture_dir):
+    with pytest.raises(FixtureMiss):
+        lookup_image_module(sample_fixture_dir, "caption", "pdf001", page=99, obj=99)
+
+
+def test_module_to_dir_mapping():
+    assert MODULE_TO_DIR["DOCUMENT_LAYOUT_WITH_OCR"] == "DLA_OCR"
+    assert MODULE_TO_DIR["TABLE_STRUCTURE_RECOGNITION"] == "TSR"
+```
+
+- [ ] **Step 3: 실패 확인**
+
+Run: `pytest tests/test_lookup.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 4: 구현**
+
+`mock_server/lookup.py`:
+```python
+"""Map (module, key) → fixture JSON path and load. Raises FixtureMiss on miss."""
+import json
+from pathlib import Path
+from typing import Any
+
+
+class FixtureMiss(Exception):
+    """Raised when no fixture file matches the request."""
+
+
+MODULE_TO_DIR = {
+    "DOCUMENT_LAYOUT_WITH_OCR": "DLA_OCR",
+    "DOCUMENT_LAYOUT_ANALYSIS": "DLA",
+    "TEXT_RECOGNITION": "OCR",
+    "TABLE_STRUCTURE_RECOGNITION": "TSR",
+}
+
+
+def lookup_pdf_module(fixture_dir: Path, module_name: str, basename: str) -> Any:
+    sub = MODULE_TO_DIR.get(module_name)
+    if sub is None:
+        raise FixtureMiss(f"unknown PDF-input module: {module_name}")
+    path = Path(fixture_dir) / sub / f"{basename}.json"
+    if not path.exists():
+        raise FixtureMiss(f"no fixture at {sub}/{basename}.json")
+    return json.loads(path.read_text())
+
+
+def lookup_image_module(
+    fixture_dir: Path, module_short: str, basename: str, page: int, obj: int
+) -> Any:
+    if module_short in {"caption", "chart"}:
+        path = Path(fixture_dir) / "FIGURE" / f"{basename}_p{page}_o{obj}_{module_short}.json"
+        if not path.exists():
+            raise FixtureMiss(f"no FIGURE fixture: {path.name}")
+        return json.loads(path.read_text())
+    if module_short == "tsr":
+        primary = Path(fixture_dir) / "TSR" / f"{basename}_p{page}_o{obj}.json"
+        fallback = Path(fixture_dir) / "TSR_regionlist" / f"{basename}_p{page}_o{obj}.json"
+        for candidate in (primary, fallback):
+            if candidate.exists():
+                return json.loads(candidate.read_text())
+        raise FixtureMiss(f"no TSR fixture: {basename}_p{page}_o{obj}.json (TSR/ or TSR_regionlist/)")
+    raise FixtureMiss(f"unknown image module: {module_short}")
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `pytest tests/test_lookup.py -v`
+Expected: 10 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/mock_server/
+git commit -m "feat(mock-server): lookup with TSR_regionlist fallback"
+```
+
+---
+
+### Task 5: PDF Renderer (TDD)
+
+**Files:**
+- Test: `scripts/mock_server/tests/test_pdf_render.py`
+- Create: `scripts/mock_server/mock_server/pdf_render.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+`tests/test_pdf_render.py`:
+```python
+import io
+import pytest
+import fitz  # PyMuPDF
+from mock_server.pdf_render import render_page_png
+
+
+@pytest.fixture
+def real_pdf(tmp_path):
+    """Create a minimal 2-page PDF using PyMuPDF itself."""
+    doc = fitz.open()
+    doc.new_page(width=612, height=792)  # 1 page
+    doc.new_page(width=612, height=792)  # 2 pages
+    p = tmp_path / "minimal.pdf"
+    doc.save(p)
+    doc.close()
+    return p
+
+
+def test_render_first_page_returns_png_bytes(real_pdf):
+    png_bytes = render_page_png(real_pdf, page_index=0, dpi=300)
+    assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_render_dimensions_300dpi(real_pdf):
+    from PIL import Image
+    png_bytes = render_page_png(real_pdf, page_index=0, dpi=300)
+    img = Image.open(io.BytesIO(png_bytes))
+    # 612pt at 300dpi / 72pt-per-inch = 2550px (±1 for rounding)
+    assert abs(img.width - 2550) <= 2
+    assert abs(img.height - 3300) <= 2
+
+
+def test_render_out_of_range_raises(real_pdf):
+    with pytest.raises(IndexError):
+        render_page_png(real_pdf, page_index=99)
+```
+
+Note: Pillow is a transitive dep of PyMuPDF; if not, add to dev deps.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pytest tests/test_pdf_render.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: 구현**
+
+`mock_server/pdf_render.py`:
+```python
+"""Render a PDF page to PNG bytes using PyMuPDF."""
+from pathlib import Path
+import fitz
+
+
+def render_page_png(pdf_path: Path, page_index: int, dpi: int = 300) -> bytes:
+    doc = fitz.open(str(pdf_path))
+    try:
+        if page_index < 0 or page_index >= doc.page_count:
+            raise IndexError(f"page_index {page_index} out of range (0..{doc.page_count - 1})")
+        page = doc.load_page(page_index)
+        zoom = dpi / 72.0
+        matrix = fitz.Matrix(zoom, zoom)
+        pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+        return pixmap.tobytes("png")
+    finally:
+        doc.close()
+```
+
+- [ ] **Step 4: pyproject.toml dev deps에 Pillow 추가 (테스트용)**
+
+Edit `scripts/mock_server/pyproject.toml`, replace `[project.optional-dependencies]` block with:
+```toml
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.27",
+    "pillow>=10.0",
+]
+```
+
+Reinstall: `pip install -e ".[dev]"`
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `pytest tests/test_pdf_render.py -v`
+Expected: 3 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/mock_server/
+git commit -m "feat(mock-server): PyMuPDF page renderer at 300dpi"
+```
+
+---
+
+### Task 6: FastAPI Server — /ping + /hocr/sdk PDF 분기 (TDD)
+
+**Files:**
+- Test: `scripts/mock_server/tests/test_server.py`
+- Create: `scripts/mock_server/mock_server/server.py`
+
+- [ ] **Step 1: 실패 테스트 (ping + DLA_OCR happy path + unknown PDF)**
+
+`tests/test_server.py`:
+```python
+import hashlib
+import json
+import pytest
+from fastapi.testclient import TestClient
+from mock_server.server import create_app
+
+
+@pytest.fixture
+def client(sample_pdf_dir, sample_fixture_dir):
+    # Make sample_fixture_dir match sample_pdf_dir basenames (pdf001..pdf003)
+    # sample_fixture_dir already has pdf001/pdf002/pdf003 entries; OK.
+    app = create_app(pdf_dir=sample_pdf_dir, fixture_dir=sample_fixture_dir)
+    return TestClient(app)
+
+
+def test_ping(client):
+    r = client.get("/ping")
+    assert r.status_code == 200
+
+
+def test_ping_via_v1_alias(client):
+    r = client.get("/api/v1/ping")
+    assert r.status_code == 200
+
+
+def test_dla_ocr_happy_path(client, sample_pdf_dir):
+    pdf_bytes = (sample_pdf_dir / "pdf001.pdf").read_bytes()
+    r = client.post(
+        "/hocr/sdk",
+        data={
+            "REQUEST_ID": "odl-anything-dla-ocr",
+            "OPEN_API_NAME": "DOCUMENT_LAYOUT_WITH_OCR",
+            "DATA_FORMAT": "pdf",
+        },
+        files={"FILE": ("document.pdf", pdf_bytes, "application/pdf")},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["SUCCESS"] is True
+    assert body["MSG"] == "SUCCESS"
+    assert body["RESULT"] == {"module": "DLA_OCR", "id": "pdf001"}
+
+
+def test_dla_ocr_via_v1_alias(client, sample_pdf_dir):
+    pdf_bytes = (sample_pdf_dir / "pdf001.pdf").read_bytes()
+    r = client.post(
+        "/api/v1/hocr/sdk",
+        data={"REQUEST_ID": "x", "OPEN_API_NAME": "DOCUMENT_LAYOUT_WITH_OCR", "DATA_FORMAT": "pdf"},
+        files={"FILE": ("document.pdf", pdf_bytes, "application/pdf")},
+    )
+    assert r.status_code == 200
+    assert r.json()["SUCCESS"] is True
+
+
+def test_unknown_pdf_returns_fixture_miss(client):
+    r = client.post(
+        "/hocr/sdk",
+        data={"REQUEST_ID": "x", "OPEN_API_NAME": "DOCUMENT_LAYOUT_WITH_OCR", "DATA_FORMAT": "pdf"},
+        files={"FILE": ("u.pdf", b"UNKNOWN_PDF_BYTES", "application/pdf")},
+    )
+    assert r.status_code == 200  # mirror real server semantics
+    body = r.json()
+    assert body["SUCCESS"] is False
+    assert body["MSG"] == "FIXTURE_MISS"
+    assert "_mock_hint" in body
+    assert "sha256" in body["_mock_hint"]
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pytest tests/test_server.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: 구현**
+
+`mock_server/server.py`:
+```python
+"""FastAPI app for hancom-ai HOCR SDK mock."""
+import hashlib
+import logging
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, Form, UploadFile, File, APIRouter
+
+from .index import build_pdf_index, PdfIndex
+from .lookup import lookup_pdf_module, lookup_image_module, FixtureMiss
+from .request_id import parse_request_id
+from .pdf_render import render_page_png
+
+LOGGER = logging.getLogger("mock_server")
+
+
+def _envelope(request_id: str, success: bool, msg: str, result, hint: Optional[str] = None):
+    body = {"REQUEST_ID": request_id, "SUCCESS": success, "MSG": msg, "RESULT": result if isinstance(result, list) else [result]}
+    if hint is not None:
+        body["_mock_hint"] = hint
+    return body
+
+
+def create_app(pdf_dir: Path, fixture_dir: Path) -> FastAPI:
+    pdf_index: PdfIndex = build_pdf_index(Path(pdf_dir))
+    LOGGER.info("indexed %d PDFs", len(pdf_index))
+
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.get("/ping")
+    def ping():
+        return {"status": "ok"}
+
+    @router.post("/hocr/sdk")
+    async def hocr_sdk(
+        REQUEST_ID: str = Form(""),
+        OPEN_API_NAME: str = Form(...),
+        DATA_FORMAT: str = Form(...),
+        FILE: UploadFile = File(...),
+    ):
+        body = await FILE.read()
+        if DATA_FORMAT == "pdf":
+            sha = hashlib.sha256(body).hexdigest()
+            entry = pdf_index.get(sha)
+            if entry is None:
+                hint = f"sha256={sha[:12]}... not in {len(pdf_index)}-PDF index"
+                LOGGER.warning("FIXTURE_MISS pdf %s module=%s", sha[:12], OPEN_API_NAME)
+                return _envelope(REQUEST_ID, False, "FIXTURE_MISS", [], hint)
+            try:
+                data = lookup_pdf_module(Path(fixture_dir), OPEN_API_NAME, entry.basename)
+            except FixtureMiss as e:
+                LOGGER.warning("FIXTURE_MISS pdf-lookup %s: %s", entry.basename, e)
+                return _envelope(REQUEST_ID, False, "FIXTURE_MISS", [], str(e))
+            return _envelope(REQUEST_ID, True, "SUCCESS", data)
+        # image branch (Task 7)
+        return _envelope(REQUEST_ID, False, "FIXTURE_MISS", [], "image branch not implemented yet")
+
+    app.include_router(router)
+    app.include_router(router, prefix="/api/v1")
+    return app
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pytest tests/test_server.py -v`
+Expected: 5 passed (ping x2, DLA_OCR happy x2, unknown PDF)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/mock_server/
+git commit -m "feat(mock-server): /ping + /hocr/sdk PDF branch with /api/v1 alias"
+```
+
+---
+
+### Task 7: 이미지 분기 추가 (TDD)
+
+**Files:**
+- Modify: `scripts/mock_server/mock_server/server.py`
+- Modify: `scripts/mock_server/tests/test_server.py`
+
+- [ ] **Step 1: 추가 테스트 작성**
+
+Append to `tests/test_server.py`:
+```python
+def test_image_caption_happy_path(client, sample_pdf_dir):
+    # Compute sha_short for pdf001
+    pdf_bytes = (sample_pdf_dir / "pdf001.pdf").read_bytes()
+    sha_short = hashlib.sha256(pdf_bytes).hexdigest()[:12]
+    r = client.post(
+        "/hocr/sdk",
+        data={
+            "REQUEST_ID": f"odl-{sha_short}-p0-o5-caption",
+            "OPEN_API_NAME": "IMAGE_CAPTIONING",
+            "DATA_FORMAT": "image",
+        },
+        files={"FILE": ("crop.png", b"\x89PNGfake", "image/png")},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["SUCCESS"] is True
+    assert body["RESULT"][0] == {"caption": "test"}
+
+
+def test_image_unparsable_request_id(client):
+    r = client.post(
+        "/hocr/sdk",
+        data={
+            "REQUEST_ID": "odl-bad",
+            "OPEN_API_NAME": "IMAGE_CAPTIONING",
+            "DATA_FORMAT": "image",
+        },
+        files={"FILE": ("crop.png", b"\x89PNGfake", "image/png")},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["SUCCESS"] is False
+    assert "REQUEST_ID" in body["_mock_hint"]
+
+
+def test_image_unknown_pdf_short(client):
+    r = client.post(
+        "/hocr/sdk",
+        data={
+            "REQUEST_ID": "odl-ffffffffffff-p0-o0-caption",
+            "OPEN_API_NAME": "IMAGE_CAPTIONING",
+            "DATA_FORMAT": "image",
+        },
+        files={"FILE": ("crop.png", b"\x89PNGfake", "image/png")},
+    )
+    body = r.json()
+    assert body["SUCCESS"] is False
+    assert "ffffffffffff" in body["_mock_hint"]
+
+
+def test_image_tsr_regionlist_fallback(client, sample_pdf_dir):
+    pdf_bytes = (sample_pdf_dir / "pdf003.pdf").read_bytes()
+    sha_short = hashlib.sha256(pdf_bytes).hexdigest()[:12]
+    r = client.post(
+        "/hocr/sdk",
+        data={
+            "REQUEST_ID": f"odl-{sha_short}-p0-o0-tsr",
+            "OPEN_API_NAME": "TABLE_STRUCTURE_RECOGNITION",
+            "DATA_FORMAT": "image",
+        },
+        files={"FILE": ("crop.png", b"\x89PNGfake", "image/png")},
+    )
+    assert r.json()["RESULT"][0]["module"] == "TSR_regionlist"
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pytest tests/test_server.py -v -k image`
+Expected: 4 failed (image branch returns FIXTURE_MISS placeholder)
+
+- [ ] **Step 3: 이미지 분기 구현**
+
+In `mock_server/server.py`, replace the image branch placeholder line `# image branch (Task 7)` and the line below it with:
+
+```python
+        # image branch
+        parts = parse_request_id(REQUEST_ID)
+        if parts is None:
+            hint = f"REQUEST_ID does not match odl-<sha12>-p<n>-o<n>-<caption|chart|tsr>"
+            LOGGER.warning("FIXTURE_MISS bad REQUEST_ID: %s", REQUEST_ID)
+            return _envelope(REQUEST_ID, False, "FIXTURE_MISS", [], hint)
+        entry = pdf_index.find_by_short(parts.sha_short)
+        if entry is None:
+            hint = f"sha_short={parts.sha_short} not in {len(pdf_index)}-PDF index"
+            LOGGER.warning("FIXTURE_MISS unknown sha_short: %s", parts.sha_short)
+            return _envelope(REQUEST_ID, False, "FIXTURE_MISS", [], hint)
+        try:
+            data = lookup_image_module(
+                Path(fixture_dir), parts.module, entry.basename, parts.page, parts.obj
+            )
+        except FixtureMiss as e:
+            LOGGER.warning("FIXTURE_MISS image-lookup: %s", e)
+            return _envelope(REQUEST_ID, False, "FIXTURE_MISS", [], str(e))
+        return _envelope(REQUEST_ID, True, "SUCCESS", data)
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pytest tests/test_server.py -v`
+Expected: 9 passed (5 from Task 6 + 4 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/mock_server/
+git commit -m "feat(mock-server): image module branch with REQUEST_ID parsing"
+```
+
+---
+
+### Task 8: pdf2img 엔드포인트 (TDD)
+
+**Files:**
+- Modify: `scripts/mock_server/mock_server/server.py`
+- Modify: `scripts/mock_server/tests/test_server.py`
+- Modify: `scripts/mock_server/tests/conftest.py` (real PDF fixture)
+
+- [ ] **Step 1: conftest에 real PDF 추가 + 인덱스에 포함**
+
+Edit `tests/conftest.py`, replace `sample_pdf_dir` with:
+```python
+@pytest.fixture
+def sample_pdf_dir(tmp_path):
+    """Create a tiny PDF dir: 3 fake byte files + 1 real PDF for pdf2img tests."""
+    import fitz
+    d = tmp_path / "pdfs"
+    d.mkdir()
+    for i in range(1, 4):
+        (d / f"pdf{i:03d}.pdf").write_bytes(f"FAKE_PDF_CONTENT_{i}".encode())
+    # real 2-page PDF named pdf004.pdf
+    doc = fitz.open()
+    doc.new_page(width=612, height=792)
+    doc.new_page(width=612, height=792)
+    doc.save(d / "pdf004.pdf")
+    doc.close()
+    return d
+```
+
+- [ ] **Step 2: 실패 테스트 추가**
+
+Append to `tests/test_server.py`:
+```python
+import base64
+
+
+def test_pdf2img_returns_base64_png(client, sample_pdf_dir):
+    pdf_bytes = (sample_pdf_dir / "pdf004.pdf").read_bytes()
+    r = client.post(
+        "/support/pdf2img",
+        data={"REQUEST_ID": "odl-pdf2img-0", "PAGE_INDEX": "0"},
+        files={"FILE": ("document.pdf", pdf_bytes, "application/pdf")},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["SUCCESS"] is True
+    png_b64 = body["RESULT"][0]["RESULT"]["PAGE_PNG_DATA"]
+    assert png_b64
+    assert base64.b64decode(png_b64)[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_pdf2img_via_v1_alias(client, sample_pdf_dir):
+    pdf_bytes = (sample_pdf_dir / "pdf004.pdf").read_bytes()
+    r = client.post(
+        "/api/v1/support/pdf2img",
+        data={"REQUEST_ID": "x", "PAGE_INDEX": "1"},
+        files={"FILE": ("d.pdf", pdf_bytes, "application/pdf")},
+    )
+    assert r.json()["SUCCESS"] is True
+
+
+def test_pdf2img_unknown_pdf(client):
+    r = client.post(
+        "/support/pdf2img",
+        data={"REQUEST_ID": "x", "PAGE_INDEX": "0"},
+        files={"FILE": ("u.pdf", b"NOT_INDEXED", "application/pdf")},
+    )
+    body = r.json()
+    assert body["SUCCESS"] is False
+    assert body["MSG"] == "FIXTURE_MISS"
+
+
+def test_pdf2img_out_of_range(client, sample_pdf_dir):
+    pdf_bytes = (sample_pdf_dir / "pdf004.pdf").read_bytes()
+    r = client.post(
+        "/support/pdf2img",
+        data={"REQUEST_ID": "x", "PAGE_INDEX": "99"},
+        files={"FILE": ("d.pdf", pdf_bytes, "application/pdf")},
+    )
+    body = r.json()
+    assert body["SUCCESS"] is False
+    assert "page_index" in body["_mock_hint"]
+```
+
+- [ ] **Step 3: 실패 확인**
+
+Run: `pytest tests/test_server.py -v -k pdf2img`
+Expected: 4 failed (404 from FastAPI — endpoint not registered)
+
+- [ ] **Step 4: pdf2img 라우트 추가**
+
+In `mock_server/server.py`, inside `create_app` after the `/hocr/sdk` route, add:
+```python
+    @router.post("/support/pdf2img")
+    async def pdf2img(
+        REQUEST_ID: str = Form(""),
+        PAGE_INDEX: int = Form(...),
+        FILE: UploadFile = File(...),
+    ):
+        body = await FILE.read()
+        sha = hashlib.sha256(body).hexdigest()
+        entry = pdf_index.get(sha)
+        if entry is None:
+            hint = f"sha256={sha[:12]}... not in {len(pdf_index)}-PDF index"
+            return _envelope(REQUEST_ID, False, "FIXTURE_MISS", [], hint)
+        try:
+            png_bytes = render_page_png(entry.path, PAGE_INDEX, dpi=300)
+        except IndexError as e:
+            return _envelope(REQUEST_ID, False, "FIXTURE_MISS", [], str(e))
+        import base64
+        b64 = base64.b64encode(png_bytes).decode("ascii")
+        return _envelope(
+            REQUEST_ID, True, "SUCCESS",
+            {"RESULT": {"PAGE_PNG_DATA": b64}},
+        )
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `pytest tests/test_server.py -v`
+Expected: 13 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/mock_server/
+git commit -m "feat(mock-server): /support/pdf2img with PyMuPDF dynamic rendering"
+```
+
+---
+
+### Task 9: CLI 엔트리포인트
+
+**Files:**
+- Create: `scripts/mock_server/mock_server/__main__.py`
+
+- [ ] **Step 1: 구현**
+
+`mock_server/__main__.py`:
+```python
+"""CLI: python -m mock_server --pdf-dir ... --fixture-dir ... --port 18008"""
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import uvicorn
+
+from .server import create_app
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="mock_server")
+    parser.add_argument("--pdf-dir", required=True, type=Path)
+    parser.add_argument("--fixture-dir", required=True, type=Path)
+    parser.add_argument("--port", type=int, default=18008)
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    if not args.pdf_dir.is_dir():
+        print(f"--pdf-dir not found: {args.pdf_dir}", file=sys.stderr)
+        sys.exit(2)
+    if not args.fixture_dir.is_dir():
+        print(f"--fixture-dir not found: {args.fixture_dir}", file=sys.stderr)
+        sys.exit(2)
+
+    app = create_app(pdf_dir=args.pdf_dir, fixture_dir=args.fixture_dir)
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: smoke test — CLI 인자 검증**
+
+Run:
+```bash
+cd opendataloader-project/opendataloader-pdfua/scripts/mock_server
+python -m mock_server --pdf-dir /nonexistent --fixture-dir /nonexistent
+```
+Expected: exit code 2, stderr `--pdf-dir not found: /nonexistent`
+
+- [ ] **Step 3: 실제 데이터로 부팅 smoke test**
+
+Run (in a separate terminal or background, then kill):
+```bash
+python -m mock_server \
+  --pdf-dir /Users/benedict/Workspace/opendataloader-project/opendataloader-bench/pdfs \
+  --fixture-dir /Users/benedict/Workspace/bundolee/kb-odl/raw/4-기술/2026-04-16_Q2-기술-ctx_hancom-ai-a11y_출력데이터-스키마 \
+  --port 18008 &
+sleep 2
+curl -s http://127.0.0.1:18008/ping
+kill %1
+```
+Expected: log `indexed 200 PDFs`, curl returns `{"status":"ok"}`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/mock_server/
+git commit -m "feat(mock-server): CLI entrypoint with arg validation"
+```
+
+---
+
+### Task 10: README 마무리 + E2E 절차 기록
+
+**Files:**
+- Modify: `scripts/mock_server/README.md`
+
+- [ ] **Step 1: README 확장**
+
+Replace `mock_server/README.md` with:
+```markdown
+# Hancom AI Mock Server
+
+Fixture-replay mock for [HancomAIClient.java](../../../opendataloader-pdf/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java).
+
+Spec: `bundolee/kb-odl/raw/4-기술/2026-04-18_Q2-DEV-02-Code_hancom-ai-mock-server-design.md`
+
+## Setup
+
+```bash
+cd opendataloader-pdfua/scripts/mock_server
+pip install -e ".[dev]"
+```
+
+## Run
+
+```bash
+python -m mock_server \
+  --pdf-dir /Users/benedict/Workspace/opendataloader-project/opendataloader-bench/pdfs \
+  --fixture-dir /Users/benedict/Workspace/bundolee/kb-odl/raw/4-기술/2026-04-16_Q2-기술-ctx_hancom-ai-a11y_출력데이터-스키마 \
+  --port 18008
+```
+
+Expect log: `indexed 200 PDFs, listening on :18008`.
+
+## Endpoints
+
+| Method | Path (and `/api/v1/` alias) | Purpose |
+|---|---|---|
+| GET | `/ping` | Health check (HTTP 200) |
+| POST | `/hocr/sdk` | All 6 modules (DATA_FORMAT distinguishes pdf vs image) |
+| POST | `/support/pdf2img` | 300dpi PNG, base64 encoded |
+
+## REQUEST_ID Convention
+
+Image-input modules (TSR / IMAGE_CAPTIONING / CHART_IMAGE_UNDERSTANDING) require:
+
+```
+odl-{sha_short}-p{page}-o{obj}-{module_short}
+```
+
+- `sha_short` = first 12 hex chars of source PDF SHA256
+- `module_short` ∈ {`caption`, `chart`, `tsr`}
+
+PDF-input modules (DLA_OCR / DLA / OCR / TSR-pdf / pdf2img) match via SHA256 of FILE bytes; REQUEST_ID is informational.
+
+The Java client patch (Phase 2 of the plan) builds these IDs automatically.
+
+## End-to-End Smoke Test
+
+After both Phase 1 (server) and Phase 2 (client patch) are merged:
+
+```bash
+# Terminal 1
+python -m mock_server --pdf-dir ... --fixture-dir ... --port 18008
+
+# Terminal 2 — pdfua against the mock
+cd opendataloader-project/opendataloader-pdfua
+mvn package -q
+java -jar target/*.jar \
+  --input /path/to/opendataloader-bench/pdfs/01030000000001.pdf \
+  --output /tmp/out \
+  --hybrid hancom-ai \
+  --hybrid-url http://localhost:18008
+```
+
+Expected: tagged PDF appears in `/tmp/out`, server log shows DLA_OCR + pdf2img + TSR + IMAGE_CAPTIONING calls all returning SUCCESS.
+
+## Tests
+
+```bash
+pytest -v
+```
+
+Expected: ~22 tests pass.
+
+## FIXTURE_MISS Debugging
+
+When `SUCCESS:false`, response includes `_mock_hint`:
+
+- `sha256=... not in 200-PDF index` → input PDF is not in the recorded benchmark set; either add it or use a benchmark PDF.
+- `REQUEST_ID does not match odl-<sha12>-p<n>-o<n>-<...>` → client did not apply the REQUEST_ID convention; check Phase 2 patch.
+- `no FIXTURE_<...>` → the recorded set lacks this specific page/object; this can happen for new combinations.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/mock_server/README.md
+git commit -m "docs(mock-server): README with endpoints, REQUEST_ID convention, E2E smoke"
+```
+
+---
+
+## Phase 2 — Client Patch (4 tasks)
+
+### Task 11: Test for REQUEST_ID building (TDD)
+
+**Files:**
+- Create: `opendataloader-project/opendataloader-pdf/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAIClientRequestIdTest.java`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`HancomAIClientRequestIdTest.java`:
+```java
+package org.opendataloader.pdf.hybrid;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HancomAIClientRequestIdTest {
+
+    private MockWebServer server;
+    private HancomAIClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        client = new HancomAIClient(
+            server.url("").toString().replaceAll("/$", ""),
+            new OkHttpClient(),
+            new ObjectMapper()
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void callModule_request_id_includes_sha_short() throws Exception {
+        byte[] pdfBytes = "PDF_CONTENT_FOR_TEST".getBytes();
+        String shaShort = sha256Hex(pdfBytes).substring(0, 12);
+
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody("{\"SUCCESS\":true,\"RESULT\":[]}"));
+
+        // invokeCallModule is a package-private test hook added by the patch.
+        client.invokeCallModule(pdfBytes, "DOCUMENT_LAYOUT_WITH_OCR");
+
+        RecordedRequest req = server.takeRequest();
+        String body = req.getBody().readUtf8();
+        assertTrue(body.contains("odl-" + shaShort + "-dla-ocr"),
+            "REQUEST_ID should include sha_short and module short name; body=" + body);
+    }
+
+    @Test
+    void callImageCaptioning_request_id_includes_page_obj() throws Exception {
+        byte[] pdfBytes = "PDF_CONTENT_FOR_TEST".getBytes();
+        String shaShort = sha256Hex(pdfBytes).substring(0, 12);
+        client.setSourcePdfShaShort(shaShort); // test hook
+
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody("{\"SUCCESS\":true,\"RESULT\":[[{\"caption\":\"x\"}]]}"));
+
+        client.invokeCallImageCaptioning(new byte[]{1, 2, 3}, /*pageNum*/ 2, /*objectId*/ 7);
+
+        RecordedRequest req = server.takeRequest();
+        String body = req.getBody().readUtf8();
+        assertTrue(body.contains("odl-" + shaShort + "-p2-o7-caption"),
+            "image REQUEST_ID format mismatch; body=" + body);
+    }
+
+    private static String sha256Hex(byte[] b) throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        return HexFormat.of().formatHex(md.digest(b));
+    }
+}
+```
+
+- [ ] **Step 2: pom.xml에 mockwebserver 의존성 확인**
+
+Run: `grep -n "mockwebserver" opendataloader-project/opendataloader-pdf/java/opendataloader-pdf-core/pom.xml`
+Expected: dependency line exists. If not, add to `pom.xml` `<dependencies>`:
+```xml
+<dependency>
+  <groupId>com.squareup.okhttp3</groupId>
+  <artifactId>mockwebserver</artifactId>
+  <version>4.12.0</version>
+  <scope>test</scope>
+</dependency>
+```
+
+- [ ] **Step 3: 실패 확인**
+
+Run:
+```bash
+cd opendataloader-project/opendataloader-pdf/java
+mvn -pl opendataloader-pdf-core test -Dtest=HancomAIClientRequestIdTest
+```
+Expected: COMPILE FAIL — `invokeCallModule`, `invokeCallImageCaptioning`, `setSourcePdfShaShort` not defined.
+
+- [ ] **Step 4: Commit (test only, expecting fail)**
+
+```bash
+cd opendataloader-project/opendataloader-pdf
+git add java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAIClientRequestIdTest.java java/opendataloader-pdf-core/pom.xml
+git commit -m "test(hybrid): failing test for HancomAIClient REQUEST_ID convention"
+```
+
+---
+
+### Task 12: HancomAIClient 패치 — REQUEST_ID 빌드
+
+**Files:**
+- Modify: `opendataloader-project/opendataloader-pdf/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java`
+
+- [ ] **Step 1: SHA256 헬퍼 + 인스턴스 필드 + 모듈 단축명 맵 추가**
+
+In `HancomAIClient.java` after the existing instance field declarations (after `private final HybridConfig config;`), add:
+```java
+    private String sourcePdfShaShort = "unknown";
+
+    private static final java.util.Map<String, String> MODULE_SHORT;
+    static {
+        java.util.Map<String, String> m = new java.util.HashMap<>();
+        m.put("DOCUMENT_LAYOUT_WITH_OCR", "dla-ocr");
+        m.put("DOCUMENT_LAYOUT_ANALYSIS", "dla");
+        m.put("TEXT_RECOGNITION", "ocr");
+        m.put("TABLE_STRUCTURE_RECOGNITION", "tsr");
+        m.put("IMAGE_CAPTIONING", "caption");
+        m.put("CHART_IMAGE_UNDERSTANDING", "chart");
+        MODULE_SHORT = java.util.Collections.unmodifiableMap(m);
+    }
+
+    private static String sha256ShortHex(byte[] data) {
+        try {
+            java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(data);
+            StringBuilder sb = new StringBuilder(12);
+            for (int i = 0; i < 6; i++) sb.append(String.format("%02x", hash[i]));
+            return sb.toString();
+        } catch (java.security.NoSuchAlgorithmException e) {
+            return "nohash000000";
+        }
+    }
+
+    // Test hook
+    void setSourcePdfShaShort(String s) { this.sourcePdfShaShort = s; }
+```
+
+- [ ] **Step 2: `convert(HybridRequest)` 진입에서 SHA 계산**
+
+In `convert(...)` method, immediately after `byte[] pdfBytes = request.getPdfBytes();`, add:
+```java
+        this.sourcePdfShaShort = sha256ShortHex(pdfBytes);
+```
+
+- [ ] **Step 3: `callModule` REQUEST_ID 변경**
+
+In `callModule(byte[] pdfBytes, String moduleName)` method, replace the line:
+```java
+            .addFormDataPart("REQUEST_ID", "odl-" + moduleName)
+```
+with:
+```java
+            .addFormDataPart("REQUEST_ID",
+                "odl-" + sourcePdfShaShort + "-" + MODULE_SHORT.getOrDefault(moduleName, moduleName))
+```
+
+- [ ] **Step 4: `callModuleImage` 시그니처 + REQUEST_ID 변경**
+
+Replace the entire `callModuleImage` method with:
+```java
+    private JsonNode callModuleImage(byte[] pngBytes, String moduleName, int pageNum, int objectId) throws IOException {
+        String moduleShort = MODULE_SHORT.getOrDefault(moduleName, moduleName);
+        String requestId = "odl-" + sourcePdfShaShort + "-p" + pageNum + "-o" + objectId + "-" + moduleShort;
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("REQUEST_ID", requestId)
+            .addFormDataPart("OPEN_API_NAME", moduleName)
+            .addFormDataPart("DATA_FORMAT", "image")
+            .addFormDataPart("FILE", "crop.png",
+                RequestBody.create(pngBytes, MEDIA_TYPE_PNG))
+            .build();
+
+        Request httpRequest = new Request.Builder()
+            .url(baseUrl + SDK_ENDPOINT)
+            .post(body)
+            .build();
+
+        LOGGER.log(Level.FINE, "Calling Hancom AI module (image): {0} [{1}]",
+            new Object[]{moduleName, requestId});
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            if (!response.isSuccessful()) {
+                ResponseBody respBody = response.body();
+                String errorMsg = respBody != null ? respBody.string() : "";
+                LOGGER.log(Level.WARNING, "Hancom AI module {0} (image) returned HTTP {1}: {2}",
+                    new Object[]{moduleName, response.code(), errorMsg});
+                return objectMapper.createArrayNode();
+            }
+
+            ResponseBody respBody = response.body();
+            if (respBody == null) {
+                return objectMapper.createArrayNode();
+            }
+
+            JsonNode root = objectMapper.readTree(respBody.string());
+            boolean success = root.has("SUCCESS") && root.get("SUCCESS").asBoolean();
+            if (!success) {
+                LOGGER.log(Level.WARNING, "Hancom AI module {0} (image) returned SUCCESS=false: {1}",
+                    new Object[]{moduleName, root.has("MSG") ? root.get("MSG").asText() : ""});
+                return objectMapper.createArrayNode();
+            }
+
+            JsonNode result = root.get("RESULT");
+            return result != null ? result : objectMapper.createArrayNode();
+        }
+    }
+```
+
+Update the single existing call site of `callModuleImage` (line ~410 in original, inside `recognizeTableStructures`) — find:
+```java
+                    JsonNode tsrResult = callModuleImage(cropPng, "TABLE_STRUCTURE_RECOGNITION");
+```
+and replace with:
+```java
+                    int objId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
+                    JsonNode tsrResult = callModuleImage(cropPng, "TABLE_STRUCTURE_RECOGNITION", pageNum, objId);
+```
+
+- [ ] **Step 5: `callImageCaptioning` 시그니처 + REQUEST_ID 변경**
+
+Replace the `callImageCaptioning` method signature and body with:
+```java
+    private String callImageCaptioning(byte[] pngBytes, int pageNum, int objectId) throws IOException {
+        String requestId = "odl-" + sourcePdfShaShort + "-p" + pageNum + "-o" + objectId + "-caption";
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("REQUEST_ID", requestId)
+            .addFormDataPart("OPEN_API_NAME", "IMAGE_CAPTIONING")
+            .addFormDataPart("DATA_FORMAT", "image")
+            .addFormDataPart("FILE", "figure.png",
+                RequestBody.create(pngBytes, MEDIA_TYPE_PNG))
+            .build();
+
+        Request httpRequest = new Request.Builder()
+            .url(baseUrl + SDK_ENDPOINT)
+            .post(body)
+            .build();
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            if (!response.isSuccessful()) return null;
+
+            ResponseBody respBody = response.body();
+            if (respBody == null) return null;
+
+            JsonNode root = objectMapper.readTree(respBody.string());
+            if (!root.has("SUCCESS") || !root.get("SUCCESS").asBoolean()) return null;
+
+            JsonNode result = root.get("RESULT");
+            if (result == null || !result.isArray() || result.size() == 0) return null;
+
+            JsonNode page = result.get(0);
+            if (page.isArray() && page.size() > 0) page = page.get(0);
+
+            return page.has("caption") ? page.get("caption").asText("") : null;
+        }
+    }
+```
+
+Update the single existing call site (inside `captionFigures`, line ~294 in original) — find:
+```java
+                    String caption = callImageCaptioning(croppedPng);
+```
+and replace with:
+```java
+                    int objIdForCaption = fig.has("object_id") ? fig.get("object_id").asInt() : -1;
+                    String caption = callImageCaptioning(croppedPng, pageNum, objIdForCaption);
+```
+
+- [ ] **Step 6: `fetchPageImage` REQUEST_ID 강화 (mock 매칭 무관, 디버그 일관성)**
+
+In `fetchPageImage(...)`, replace:
+```java
+            .addFormDataPart("REQUEST_ID", "odl-pdf2img-" + pageIndex)
+```
+with:
+```java
+            .addFormDataPart("REQUEST_ID",
+                "odl-" + sourcePdfShaShort + "-pdf2img-p" + pageIndex)
+```
+
+- [ ] **Step 7: 테스트 hook 메서드 추가 (package-private)**
+
+At the very bottom of the class (before the closing `}`), add:
+```java
+    // --- Test hooks (package-private) ---
+
+    void invokeCallModule(byte[] pdfBytes, String moduleName) throws IOException {
+        this.sourcePdfShaShort = sha256ShortHex(pdfBytes);
+        callModule(pdfBytes, moduleName);
+    }
+
+    void invokeCallImageCaptioning(byte[] pngBytes, int pageNum, int objectId) throws IOException {
+        callImageCaptioning(pngBytes, pageNum, objectId);
+    }
+```
+
+- [ ] **Step 8: 컴파일 + 새 테스트 통과 확인**
+
+Run:
+```bash
+cd opendataloader-project/opendataloader-pdf/java
+mvn -pl opendataloader-pdf-core test -Dtest=HancomAIClientRequestIdTest
+```
+Expected: 2 passed.
+
+- [ ] **Step 9: 기존 테스트도 회귀 없는지 확인**
+
+Run:
+```bash
+mvn -pl opendataloader-pdf-core test
+```
+Expected: BUILD SUCCESS, all tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd opendataloader-project/opendataloader-pdf
+git add java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+git commit -m "feat(hybrid): HancomAIClient REQUEST_ID convention with sha-short, page, obj
+
+For mock-server fixture lookup. Real Hancom AI server treats REQUEST_ID
+as opaque client-defined string; no behavior change there.
+
+Spec: bundolee/kb-odl/.../2026-04-18_Q2-DEV-02-Code_hancom-ai-mock-server-design.md"
+```
+
+---
+
+### Task 13: 통합 smoke — pdfua → mock 전체 호출 체인
+
+**Files:** (코드 변경 없음, 검증만)
+
+- [ ] **Step 1: pdf-core 로컬 install**
+
+Run:
+```bash
+cd opendataloader-project/opendataloader-pdf/java
+mvn -pl opendataloader-pdf-core install -DskipTests
+```
+Expected: BUILD SUCCESS, artifact installed to `~/.m2`.
+
+- [ ] **Step 2: pdfua 빌드**
+
+Run:
+```bash
+cd opendataloader-project/opendataloader-pdfua
+mvn package -DskipTests
+```
+Expected: BUILD SUCCESS, jar at `target/`.
+
+- [ ] **Step 3: mock 서버 백그라운드 기동**
+
+Run:
+```bash
+cd opendataloader-project/opendataloader-pdfua/scripts/mock_server
+python -m mock_server \
+  --pdf-dir /Users/benedict/Workspace/opendataloader-project/opendataloader-bench/pdfs \
+  --fixture-dir /Users/benedict/Workspace/bundolee/kb-odl/raw/4-기술/2026-04-16_Q2-기술-ctx_hancom-ai-a11y_출력데이터-스키마 \
+  --port 18008 > /tmp/mock-server.log 2>&1 &
+sleep 2
+curl -sf http://127.0.0.1:18008/ping
+```
+Expected: `{"status":"ok"}`, log contains `indexed 200 PDFs`.
+
+- [ ] **Step 4: pdfua 실행**
+
+Run:
+```bash
+mkdir -p /tmp/mock-out
+cd opendataloader-project/opendataloader-pdfua
+java -jar target/*.jar \
+  --input /Users/benedict/Workspace/opendataloader-project/opendataloader-bench/pdfs/01030000000001.pdf \
+  --output /tmp/mock-out \
+  --hybrid hancom-ai \
+  --hybrid-url http://localhost:18008
+```
+Expected: exit 0, output PDF in `/tmp/mock-out/`, server log shows DLA_OCR + pdf2img + (TSR or IMAGE_CAPTIONING based on document) all SUCCESS.
+
+- [ ] **Step 5: FIXTURE_MISS 의도적 트리거 — 외부 PDF**
+
+Run:
+```bash
+echo "%PDF-1.4 fake" > /tmp/notindexed.pdf
+java -jar opendataloader-project/opendataloader-pdfua/target/*.jar \
+  --input /tmp/notindexed.pdf \
+  --output /tmp/mock-out2 \
+  --hybrid hancom-ai \
+  --hybrid-url http://localhost:18008
+```
+Expected: server log contains `FIXTURE_MISS pdf` warning with sha prefix; pdfua may either fail loud or fall back gracefully — record actual behavior in commit message.
+
+- [ ] **Step 6: 서버 종료 + 로그 보존**
+
+Run:
+```bash
+kill %1 || pkill -f "python -m mock_server"
+cp /tmp/mock-server.log opendataloader-project/opendataloader-pdfua/scripts/mock_server/e2e-smoke.log
+```
+
+- [ ] **Step 7: 결과 검토 + commit**
+
+Run:
+```bash
+ls -la /tmp/mock-out/
+head -50 opendataloader-project/opendataloader-pdfua/scripts/mock_server/e2e-smoke.log
+```
+
+```bash
+cd opendataloader-project/opendataloader-pdfua
+git add scripts/mock_server/e2e-smoke.log
+git commit -m "chore(mock-server): record e2e smoke log against benchmark PDF #01030000000001"
+```
+
+---
+
+### Task 14: 회의록에 완료 보고 추가
+
+**Files:**
+- Modify: `bundolee/kb-odl/raw/운영/회의록/2026-04-16_hancom-ai-a11y_2차회의-매핑표-리뷰.md` (다음 액션 표 업데이트) 또는 별도 진행 보고
+
+- [ ] **Step 1: 회의록 다음 액션 표 갱신**
+
+In the meeting notes' "다음 액션" table (around line 63), find rows referencing the blocked development and append a status note. If unsure where, add a new row below the existing table:
+
+```markdown
+| 8 | hancom-ai mock 서버 + client REQUEST_ID 패치 완료 | 기술 | 2026-04-18 — transformer 재설계 막힘 해소 |
+```
+
+- [ ] **Step 2: Commit (in kb-odl)**
+
+```bash
+cd /Users/benedict/Workspace/bundolee/kb-odl
+git add "raw/운영/회의록/2026-04-16_hancom-ai-a11y_2차회의-매핑표-리뷰.md"
+git commit -m "회의록 갱신: hancom-ai mock 서버 구축 완료, transformer 재설계 unblock"
+```
+
+---
+
+## Self-Review Checklist (작성자 자체 검증)
+
+**Spec coverage:**
+- ✅ 6개 모듈 (DLA_OCR/DLA/OCR/TSR/IMAGE_CAPTIONING/CHART) — Task 4 lookup, Task 6/7 server
+- ✅ pdf2img 동적 변환 — Task 5 renderer, Task 8 endpoint
+- ✅ /ping 엔드포인트 — Task 6
+- ✅ /api/v1 alias — Task 6
+- ✅ DATA_FORMAT 분기 — Task 6/7
+- ✅ TSR_regionlist 폴백 — Task 4
+- ✅ Unknown PDF FIXTURE_MISS — Task 6
+- ✅ Client 패치 (REQUEST_ID 규약 6개 모듈 단축명, sha_short, page, obj) — Task 11/12
+- ✅ E2E smoke — Task 13
+
+**Placeholder scan:** TBD/TODO/"구현 나중에" 없음. 모든 코드 step에 완전한 코드 블록 첨부.
+
+**Type consistency:** `RequestIdParts(sha_short, page, obj, module)` 일관, `MODULE_TO_DIR`(server-side mapping) vs `MODULE_SHORT`(client-side mapping) 분리 명확. `lookup_image_module(..., module_short, basename, page, obj)` 시그니처 일관.
+
+**Java 컴파일 위험요소:**
+- `HexFormat`은 Java 17+. 만약 빌드 타깃이 Java 8/11이면 테스트에서 직접 hex 변환 헬퍼로 대체 필요. Task 11 Step 1 컴파일 실패 시 즉시 발견.
+- mockwebserver 의존성 추가 필요 (Task 11 Step 2에서 검증).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `opendataloader-project/opendataloader-pdf/docs/superpowers/plans/2026-04-18-hancom-ai-mock-server.md`.
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task with two-stage review between tasks. Best for this plan since it spans two repos (Python + Java) and has a clear TDD rhythm.
+
+2. **Inline Execution** — execute tasks in this session with checkpoints. Faster turnaround but heavier on the main context.
+
+Which approach?

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/AutoTagger.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/AutoTagger.java
@@ -82,7 +82,7 @@ public final class AutoTagger {
         long taggingNs = System.nanoTime() - t0;
 
         return new TaggingResult(document, extraction.getExtractionNs(), taggingNs,
-            extraction.getHybridTimings());
+            extraction.getHybridTimings(), extraction.getElementMetadata());
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -42,6 +42,8 @@ public class Config {
     public static final String HYBRID_DOCLING_FAST = "docling-fast";
     /** Hybrid mode: hancom backend (Hancom Document AI). */
     public static final String HYBRID_HANCOM = "hancom";
+    /** Hybrid mode: hancom-ai backend (Hancom AI HOCR SDK — individual modules). */
+    public static final String HYBRID_HANCOM_AI = "hancom-ai";
     /** Hybrid mode: azure backend (Azure Document Intelligence). */
     public static final String HYBRID_AZURE = "azure";
     /** Hybrid mode: google backend (Google Document AI). */
@@ -119,6 +121,7 @@ public class Config {
         hybridOptions.add(HYBRID_DOCLING);
         hybridOptions.add(HYBRID_DOCLING_FAST);  // deprecated alias
         hybridOptions.add(HYBRID_HANCOM);
+        hybridOptions.add(HYBRID_HANCOM_AI);
         // azure, google added when implemented
         hybridModeOptions.add(HYBRID_MODE_AUTO);
         hybridModeOptions.add(HYBRID_MODE_FULL);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/TaggingResult.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/TaggingResult.java
@@ -1,9 +1,12 @@
 package org.opendataloader.pdf.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.opendataloader.pdf.hybrid.ElementMetadata;
 import org.verapdf.pd.PDDocument;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Result of {@link AutoTagger#tag}. Contains the tagged PDF document in-memory
@@ -19,8 +22,10 @@ public class TaggingResult implements AutoCloseable {
     private final long extractionNs;
     private final long taggingNs;
     private final JsonNode hybridTimings;
+    private final Map<Long, ElementMetadata> elementMetadata;
 
-    public TaggingResult(PDDocument document, long extractionNs, long taggingNs, JsonNode hybridTimings) {
+    public TaggingResult(PDDocument document, long extractionNs, long taggingNs,
+                          JsonNode hybridTimings, Map<Long, ElementMetadata> elementMetadata) {
         if (document == null) {
             throw new IllegalArgumentException("document must not be null");
         }
@@ -28,6 +33,11 @@ public class TaggingResult implements AutoCloseable {
         this.extractionNs = extractionNs;
         this.taggingNs = taggingNs;
         this.hybridTimings = hybridTimings;
+        this.elementMetadata = elementMetadata != null ? elementMetadata : Collections.emptyMap();
+    }
+
+    public TaggingResult(PDDocument document, long extractionNs, long taggingNs, JsonNode hybridTimings) {
+        this(document, extractionNs, taggingNs, hybridTimings, Collections.emptyMap());
     }
 
     /** The tagged PDF document. Do not close this directly — close the TaggingResult instead. */
@@ -48,6 +58,11 @@ public class TaggingResult implements AutoCloseable {
     /** Per-step hybrid server timings, or null if hybrid mode was not used. */
     public JsonNode getHybridTimings() {
         return hybridTimings;
+    }
+
+    /** Element metadata from hybrid backend, or empty map if not available. */
+    public Map<Long, ElementMetadata> getElementMetadata() {
+        return elementMetadata;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/entities/EnrichedImageChunk.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/entities/EnrichedImageChunk.java
@@ -67,6 +67,10 @@ public class EnrichedImageChunk extends ImageChunk {
                 .replace(">", "")
                 .replace("&", "")
                 .replace("\u0000", "")
+                // PDF/UA-2 clause 8.4.3.3 forbids Private Use Area code points in /Alt.
+                // Strip BMP PUA (U+E000–U+F8FF) and supplementary PUA (encoded as surrogate pairs
+                // U+DB80–U+DBFF paired with U+DC00–U+DFFF).
+                .replaceAll("[\\uE000-\\uF8FF]|[\\uDB80-\\uDBFF][\\uDC00-\\uDFFF]", "")
                 .replaceAll("\\s{2,}", " ")
                 .trim();
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/entities/SemanticFootnote.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/entities/SemanticFootnote.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.entities;
+
+import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
+
+/**
+ * Represents a footnote/endnote element.
+ * Maps to PDF 2.0 FENote structure element in AutoTaggingProcessor.
+ */
+public class SemanticFootnote extends SemanticParagraph {
+    public SemanticFootnote() {
+        super();
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DiskPageImageCache.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DiskPageImageCache.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Disk-backed page image cache. Stores page images as PNG files in a
+ * temporary directory. evict() is a no-op (keeps files for potential re-read).
+ * close() deletes the temp directory and all files.
+ */
+public class DiskPageImageCache implements PageImageCache {
+
+    private static final Logger LOGGER = Logger.getLogger(DiskPageImageCache.class.getCanonicalName());
+
+    private final Path tempDir;
+
+    public DiskPageImageCache() throws IOException {
+        this.tempDir = Files.createTempDirectory("odl-pages-");
+    }
+
+    // Visible for testing
+    DiskPageImageCache(Path tempDir) {
+        this.tempDir = tempDir;
+    }
+
+    @Override
+    public BufferedImage getOrFetch(int pageIndex, PageImageFetcher fetcher) throws IOException {
+        Path file = tempDir.resolve("page-" + pageIndex + ".png");
+        if (Files.exists(file)) {
+            return ImageIO.read(file.toFile());
+        }
+        BufferedImage image = fetcher.fetch(pageIndex);
+        ImageIO.write(image, "png", file.toFile());
+        return image;
+    }
+
+    @Override
+    public void evict(int pageIndex) {
+        // no-op: keep on disk for potential re-read
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!Files.exists(tempDir)) {
+            return;
+        }
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(tempDir)) {
+            for (Path entry : stream) {
+                try {
+                    Files.deleteIfExists(entry);
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Failed to delete temp file: {0}", entry);
+                }
+            }
+        }
+        Files.deleteIfExists(tempDir);
+    }
+
+    /**
+     * Returns the temp directory path (for testing).
+     */
+    Path getTempDir() {
+        return tempDir;
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DiskPageImageCache.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DiskPageImageCache.java
@@ -48,10 +48,21 @@ public class DiskPageImageCache implements PageImageCache {
     public BufferedImage getOrFetch(int pageIndex, PageImageFetcher fetcher) throws IOException {
         Path file = tempDir.resolve("page-" + pageIndex + ".png");
         if (Files.exists(file)) {
-            return ImageIO.read(file.toFile());
+            BufferedImage cached = ImageIO.read(file.toFile());
+            if (cached != null) {
+                return cached;
+            }
+            // Cached file is unreadable (corrupt or no ImageReader) — re-fetch.
+            LOGGER.log(Level.WARNING, "Cached page image is unreadable, re-fetching: {0}", file);
+            Files.deleteIfExists(file);
         }
         BufferedImage image = fetcher.fetch(pageIndex);
-        ImageIO.write(image, "png", file.toFile());
+        if (image == null) {
+            throw new IOException("Page image fetcher returned null for page " + pageIndex);
+        }
+        if (!ImageIO.write(image, "png", file.toFile())) {
+            throw new IOException("No ImageIO writer accepted PNG output for page " + pageIndex);
+        }
         return image;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/ElementMetadata.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/ElementMetadata.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Per-element metadata produced by hybrid backends.
+ * Keyed by IObject.recognizedStructureId in a sidecar Map.
+ * All fields are optional — backends populate what they can.
+ */
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class ElementMetadata {
+
+    /** DLA confidence (0.0~1.0). */
+    private double confidence = 1.0;
+
+    /** Original Hancom AI label (0~17), -1 if not applicable. */
+    private int sourceLabel = -1;
+
+    /** Heading inference method: "bbox-height" or "fixed". */
+    private String headingInferenceMethod;
+
+    /** Bounding box height in pixels, used for heading inference. */
+    private Double bboxHeightPx;
+
+    /** Word-cell matching method: "bbox-intersection" or "tsr-text-fallback". */
+    private String wordMatchMethod;
+
+    /** Number of words matched in the cell. */
+    private int matchedWordCount;
+
+    /** TSR metadata for tables. */
+    private TsrMetadata tsr;
+
+    /** Caption metadata for images. */
+    private CaptionMetadata caption;
+
+    /** Regionlist resolution metadata for label 7. */
+    private RegionlistResolution regionlistResolution;
+
+    public double getConfidence() {
+        return confidence;
+    }
+
+    public ElementMetadata setConfidence(double confidence) {
+        this.confidence = confidence;
+        return this;
+    }
+
+    public int getSourceLabel() {
+        return sourceLabel;
+    }
+
+    public ElementMetadata setSourceLabel(int sourceLabel) {
+        this.sourceLabel = sourceLabel;
+        return this;
+    }
+
+    public String getHeadingInferenceMethod() {
+        return headingInferenceMethod;
+    }
+
+    public ElementMetadata setHeadingInferenceMethod(String headingInferenceMethod) {
+        this.headingInferenceMethod = headingInferenceMethod;
+        return this;
+    }
+
+    public Double getBboxHeightPx() {
+        return bboxHeightPx;
+    }
+
+    public ElementMetadata setBboxHeightPx(Double bboxHeightPx) {
+        this.bboxHeightPx = bboxHeightPx;
+        return this;
+    }
+
+    public String getWordMatchMethod() {
+        return wordMatchMethod;
+    }
+
+    public ElementMetadata setWordMatchMethod(String wordMatchMethod) {
+        this.wordMatchMethod = wordMatchMethod;
+        return this;
+    }
+
+    public int getMatchedWordCount() {
+        return matchedWordCount;
+    }
+
+    public ElementMetadata setMatchedWordCount(int matchedWordCount) {
+        this.matchedWordCount = matchedWordCount;
+        return this;
+    }
+
+    public TsrMetadata getTsr() {
+        return tsr;
+    }
+
+    public ElementMetadata setTsr(TsrMetadata tsr) {
+        this.tsr = tsr;
+        return this;
+    }
+
+    public CaptionMetadata getCaption() {
+        return caption;
+    }
+
+    public ElementMetadata setCaption(CaptionMetadata caption) {
+        this.caption = caption;
+        return this;
+    }
+
+    public RegionlistResolution getRegionlistResolution() {
+        return regionlistResolution;
+    }
+
+    public ElementMetadata setRegionlistResolution(RegionlistResolution regionlistResolution) {
+        this.regionlistResolution = regionlistResolution;
+        return this;
+    }
+
+    /**
+     * TSR (Table Structure Recognition) metadata for table elements.
+     */
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public static class TsrMetadata {
+
+        private int numCells;
+        private String html;
+        private long runTimeMs;
+
+        public int getNumCells() {
+            return numCells;
+        }
+
+        public TsrMetadata setNumCells(int numCells) {
+            this.numCells = numCells;
+            return this;
+        }
+
+        public String getHtml() {
+            return html;
+        }
+
+        public TsrMetadata setHtml(String html) {
+            this.html = html;
+            return this;
+        }
+
+        public long getRunTimeMs() {
+            return runTimeMs;
+        }
+
+        public TsrMetadata setRunTimeMs(long runTimeMs) {
+            this.runTimeMs = runTimeMs;
+            return this;
+        }
+    }
+
+    /**
+     * Caption metadata for image elements.
+     */
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public static class CaptionMetadata {
+
+        private String text;
+        private String language;
+        private long runTimeMs;
+
+        public String getText() {
+            return text;
+        }
+
+        public CaptionMetadata setText(String text) {
+            this.text = text;
+            return this;
+        }
+
+        public String getLanguage() {
+            return language;
+        }
+
+        public CaptionMetadata setLanguage(String language) {
+            this.language = language;
+            return this;
+        }
+
+        public long getRunTimeMs() {
+            return runTimeMs;
+        }
+
+        public CaptionMetadata setRunTimeMs(long runTimeMs) {
+            this.runTimeMs = runTimeMs;
+            return this;
+        }
+    }
+
+    /**
+     * Resolution metadata for regionlist elements (label 7).
+     */
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public static class RegionlistResolution {
+
+        /** Strategy used: "table-first" or "list-only". */
+        private String strategy;
+
+        /** Whether TSR was attempted. */
+        private boolean tsrAttempted;
+
+        /** TSR result: "success", "no-cells", "failed", or null. */
+        private String tsrResult;
+
+        public String getStrategy() {
+            return strategy;
+        }
+
+        public RegionlistResolution setStrategy(String strategy) {
+            this.strategy = strategy;
+            return this;
+        }
+
+        public boolean isTsrAttempted() {
+            return tsrAttempted;
+        }
+
+        public RegionlistResolution setTsrAttempted(boolean tsrAttempted) {
+            this.tsrAttempted = tsrAttempted;
+            return this;
+        }
+
+        public String getTsrResult() {
+            return tsrResult;
+        }
+
+        public RegionlistResolution setTsrResult(String tsrResult) {
+            this.tsrResult = tsrResult;
+            return this;
+        }
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/ElementMetadata.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/ElementMetadata.java
@@ -52,6 +52,12 @@ public class ElementMetadata {
     /** Regionlist resolution metadata for label 7. */
     private RegionlistResolution regionlistResolution;
 
+    /** Text source decision: "stream", "ocr", or "ocr-fallback". */
+    private String textSource;
+
+    /** Stream vs OCR text similarity score (auto mode only). */
+    private Double streamOcrSimilarity;
+
     public double getConfidence() {
         return confidence;
     }
@@ -130,6 +136,24 @@ public class ElementMetadata {
 
     public ElementMetadata setRegionlistResolution(RegionlistResolution regionlistResolution) {
         this.regionlistResolution = regionlistResolution;
+        return this;
+    }
+
+    public String getTextSource() {
+        return textSource;
+    }
+
+    public ElementMetadata setTextSource(String textSource) {
+        this.textSource = textSource;
+        return this;
+    }
+
+    public Double getStreamOcrSimilarity() {
+        return streamOcrSimilarity;
+    }
+
+    public ElementMetadata setStreamOcrSimilarity(Double streamOcrSimilarity) {
+        this.streamOcrSimilarity = streamOcrSimilarity;
         return this;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -77,8 +77,10 @@ public class HancomAIClient implements HybridClient {
     private final String baseUrl;
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
+    private final HybridConfig config;
 
     public HancomAIClient(HybridConfig config) {
+        this.config = config;
         this.baseUrl = config.getEffectiveUrl("hancom-ai");
         this.objectMapper = new ObjectMapper();
         this.httpClient = new OkHttpClient.Builder()
@@ -90,6 +92,7 @@ public class HancomAIClient implements HybridClient {
 
     // Visible for testing
     HancomAIClient(String baseUrl, OkHttpClient httpClient, ObjectMapper objectMapper) {
+        this.config = new HybridConfig();
         this.baseUrl = baseUrl;
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
@@ -124,40 +127,52 @@ public class HancomAIClient implements HybridClient {
         byte[] pdfBytes = request.getPdfBytes();
         LOGGER.log(Level.INFO, "Hancom AI: processing PDF ({0} bytes)", pdfBytes.length);
 
-        ObjectNode merged = objectMapper.createObjectNode();
-        ObjectNode timingsNode = objectMapper.createObjectNode();
+        try (PageImageCache pageImageCache = createPageImageCache()) {
+            ObjectNode merged = objectMapper.createObjectNode();
+            ObjectNode timingsNode = objectMapper.createObjectNode();
 
-        // Step 1: DLA + OCR
-        JsonNode dlaOcrResult = callModule(pdfBytes, "DOCUMENT_LAYOUT_WITH_OCR");
-        merged.set("DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
-        addTimings(timingsNode, "DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
+            // Step 1: DLA + OCR
+            JsonNode dlaOcrResult = callModule(pdfBytes, "DOCUMENT_LAYOUT_WITH_OCR");
+            merged.set("DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
+            addTimings(timingsNode, "DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
 
-        // Step 2: Table Structure
-        JsonNode tableResult = callModule(pdfBytes, "TABLE_STRUCTURE_RECOGNITION");
-        merged.set("TABLE_STRUCTURE_RECOGNITION", tableResult);
-        addTimings(timingsNode, "TABLE_STRUCTURE_RECOGNITION", tableResult);
+            // Step 2: Table Structure
+            JsonNode tableResult = callModule(pdfBytes, "TABLE_STRUCTURE_RECOGNITION");
+            merged.set("TABLE_STRUCTURE_RECOGNITION", tableResult);
+            addTimings(timingsNode, "TABLE_STRUCTURE_RECOGNITION", tableResult);
 
-        // Step 3: Figure captioning — pdf2img → crop figures → caption each
-        long captionStartMs = System.currentTimeMillis();
-        ArrayNode figureCaptions = captionFigures(pdfBytes, dlaOcrResult);
-        long captionMs = System.currentTimeMillis() - captionStartMs;
-        merged.set("FIGURE_CAPTIONS", figureCaptions);
+            // Step 3: Figure captioning — pdf2img → crop figures → caption each
+            long captionStartMs = System.currentTimeMillis();
+            ArrayNode figureCaptions = captionFigures(pdfBytes, dlaOcrResult, pageImageCache);
+            long captionMs = System.currentTimeMillis() - captionStartMs;
+            merged.set("FIGURE_CAPTIONS", figureCaptions);
 
-        ObjectNode captionTiming = objectMapper.createObjectNode();
-        captionTiming.put("total_ms", captionMs);
-        captionTiming.put("count", figureCaptions.size());
-        if (figureCaptions.size() > 0) {
-            captionTiming.put("avg_ms", captionMs / figureCaptions.size());
+            ObjectNode captionTiming = objectMapper.createObjectNode();
+            captionTiming.put("total_ms", captionMs);
+            captionTiming.put("count", figureCaptions.size());
+            if (figureCaptions.size() > 0) {
+                captionTiming.put("avg_ms", captionMs / figureCaptions.size());
+            }
+            timingsNode.set("IMAGE_CAPTIONING", captionTiming);
+
+            merged.set("timings", timingsNode);
+
+            LOGGER.log(Level.INFO, "Hancom AI: completed — {0} figure captions generated",
+                figureCaptions.size());
+
+            return new HybridResponse(null, null, merged, Collections.emptyMap(),
+                Collections.emptyList(), timingsNode);
         }
-        timingsNode.set("IMAGE_CAPTIONING", captionTiming);
+    }
 
-        merged.set("timings", timingsNode);
-
-        LOGGER.log(Level.INFO, "Hancom AI: completed — {0} figure captions generated",
-            figureCaptions.size());
-
-        return new HybridResponse(null, null, merged, Collections.emptyMap(),
-            Collections.emptyList(), timingsNode);
+    /**
+     * Creates a PageImageCache based on config.
+     */
+    private PageImageCache createPageImageCache() throws IOException {
+        if ("disk".equalsIgnoreCase(config.getImageCache())) {
+            return new DiskPageImageCache();
+        }
+        return new MemoryPageImageCache();
     }
 
     @Override
@@ -180,7 +195,8 @@ public class HancomAIClient implements HybridClient {
      *
      * @return ArrayNode of {page_number, object_id, bbox, caption}
      */
-    private ArrayNode captionFigures(byte[] pdfBytes, JsonNode dlaResult) {
+    private ArrayNode captionFigures(byte[] pdfBytes, JsonNode dlaResult,
+                                     PageImageCache pageImageCache) {
         ArrayNode captions = objectMapper.createArrayNode();
 
         // Extract pages from DLA result
@@ -213,24 +229,19 @@ public class HancomAIClient implements HybridClient {
             new Object[]{figuresByPage.values().stream().mapToInt(List::size).sum(),
                           figuresByPage.size()});
 
-        // Get page images and crop figures
-        Map<Integer, BufferedImage> pageImages = new HashMap<>();
-
         for (Map.Entry<Integer, List<JsonNode>> entry : figuresByPage.entrySet()) {
             int pageNum = entry.getKey();
             List<JsonNode> figures = entry.getValue();
 
-            // Get page image (cached)
-            BufferedImage pageImage = pageImages.get(pageNum);
-            if (pageImage == null) {
-                try {
-                    pageImage = fetchPageImage(pdfBytes, pageNum);
-                    pageImages.put(pageNum, pageImage);
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Failed to get page {0} image: {1}",
-                        new Object[]{pageNum, e.getMessage()});
-                    continue;
-                }
+            // Get page image via cache
+            BufferedImage pageImage;
+            try {
+                pageImage = pageImageCache.getOrFetch(pageNum,
+                    idx -> fetchPageImage(pdfBytes, idx));
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to get page {0} image: {1}",
+                    new Object[]{pageNum, e.getMessage()});
+                continue;
             }
 
             // Caption each figure
@@ -273,6 +284,9 @@ public class HancomAIClient implements HybridClient {
                         new Object[]{pageNum, e.getMessage()});
                 }
             }
+
+            // Done with this page — allow cache to reclaim memory
+            pageImageCache.evict(pageNum);
         }
 
         return captions;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -1,0 +1,465 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * HTTP client for Hancom AI HOCR SDK API.
+ *
+ * <p>Pipeline:
+ * <ol>
+ *   <li>pdf2img — convert each page to PNG image</li>
+ *   <li>DOCUMENT_LAYOUT_WITH_OCR — layout analysis + OCR on full PDF</li>
+ *   <li>TABLE_STRUCTURE_RECOGNITION — table cell structure on full PDF</li>
+ *   <li>IMAGE_CAPTIONING — crop each Figure region from page image, caption individually</li>
+ * </ol>
+ *
+ * @see HancomAISchemaTransformer
+ */
+public class HancomAIClient implements HybridClient {
+
+    private static final Logger LOGGER = Logger.getLogger(HancomAIClient.class.getCanonicalName());
+
+    public static final String DEFAULT_URL = "http://localhost:18008";
+
+    private static final String SDK_ENDPOINT = "/hocr/sdk";
+    private static final String PDF2IMG_ENDPOINT = "/support/pdf2img";
+    private static final String PING_ENDPOINT = "/ping";
+    private static final int HEALTH_CHECK_TIMEOUT_MS = 3000;
+    private static final String DEFAULT_FILENAME = "document.pdf";
+    private static final MediaType MEDIA_TYPE_PDF = MediaType.parse("application/pdf");
+    private static final MediaType MEDIA_TYPE_PNG = MediaType.parse("image/png");
+
+    // DLA labels for Figure regions
+    private static final int LABEL_FIGURE = 9;
+    private static final int LABEL_FIGURE_CAPTION = 10;
+
+    private final String baseUrl;
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public HancomAIClient(HybridConfig config) {
+        this.baseUrl = config.getEffectiveUrl("hancom-ai");
+        this.objectMapper = new ObjectMapper();
+        this.httpClient = new OkHttpClient.Builder()
+            .connectTimeout(config.getTimeoutMs(), TimeUnit.MILLISECONDS)
+            .readTimeout(config.getTimeoutMs(), TimeUnit.MILLISECONDS)
+            .writeTimeout(config.getTimeoutMs(), TimeUnit.MILLISECONDS)
+            .build();
+    }
+
+    // Visible for testing
+    HancomAIClient(String baseUrl, OkHttpClient httpClient, ObjectMapper objectMapper) {
+        this.baseUrl = baseUrl;
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void checkAvailability() throws IOException {
+        OkHttpClient healthClient = httpClient.newBuilder()
+            .connectTimeout(HEALTH_CHECK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .readTimeout(HEALTH_CHECK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .build();
+
+        Request request = new Request.Builder()
+            .url(baseUrl + PING_ENDPOINT)
+            .get()
+            .build();
+
+        try (Response response = healthClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("Hancom AI server at " + baseUrl +
+                    " returned HTTP " + response.code());
+            }
+        } catch (IOException e) {
+            throw new IOException(
+                "Hancom AI server is not available at " + baseUrl + "\n"
+                + "Check that the server is running and accessible.", e);
+        }
+    }
+
+    @Override
+    public HybridResponse convert(HybridRequest request) throws IOException {
+        byte[] pdfBytes = request.getPdfBytes();
+        LOGGER.log(Level.INFO, "Hancom AI: processing PDF ({0} bytes)", pdfBytes.length);
+
+        ObjectNode merged = objectMapper.createObjectNode();
+        ObjectNode timingsNode = objectMapper.createObjectNode();
+
+        // Step 1: DLA + OCR
+        JsonNode dlaOcrResult = callModule(pdfBytes, "DOCUMENT_LAYOUT_WITH_OCR");
+        merged.set("DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
+        addTimings(timingsNode, "DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
+
+        // Step 2: Table Structure
+        JsonNode tableResult = callModule(pdfBytes, "TABLE_STRUCTURE_RECOGNITION");
+        merged.set("TABLE_STRUCTURE_RECOGNITION", tableResult);
+        addTimings(timingsNode, "TABLE_STRUCTURE_RECOGNITION", tableResult);
+
+        // Step 3: Figure captioning — pdf2img → crop figures → caption each
+        long captionStartMs = System.currentTimeMillis();
+        ArrayNode figureCaptions = captionFigures(pdfBytes, dlaOcrResult);
+        long captionMs = System.currentTimeMillis() - captionStartMs;
+        merged.set("FIGURE_CAPTIONS", figureCaptions);
+
+        ObjectNode captionTiming = objectMapper.createObjectNode();
+        captionTiming.put("total_ms", captionMs);
+        captionTiming.put("count", figureCaptions.size());
+        if (figureCaptions.size() > 0) {
+            captionTiming.put("avg_ms", captionMs / figureCaptions.size());
+        }
+        timingsNode.set("IMAGE_CAPTIONING", captionTiming);
+
+        merged.set("timings", timingsNode);
+
+        LOGGER.log(Level.INFO, "Hancom AI: completed — {0} figure captions generated",
+            figureCaptions.size());
+
+        return new HybridResponse(null, null, merged, Collections.emptyMap(),
+            Collections.emptyList(), timingsNode);
+    }
+
+    @Override
+    public CompletableFuture<HybridResponse> convertAsync(HybridRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return convert(request);
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to convert via Hancom AI", e);
+            }
+        });
+    }
+
+    /**
+     * Captions each Figure found by DLA:
+     * 1. Get page images via pdf2img
+     * 2. Find Figure objects (label 9, 10) from DLA results
+     * 3. Crop each Figure from page image
+     * 4. Send cropped image to IMAGE_CAPTIONING
+     *
+     * @return ArrayNode of {page_number, object_id, bbox, caption}
+     */
+    private ArrayNode captionFigures(byte[] pdfBytes, JsonNode dlaResult) {
+        ArrayNode captions = objectMapper.createArrayNode();
+
+        // Extract pages from DLA result
+        List<JsonNode> dlaPages = extractPages(dlaResult);
+        if (dlaPages.isEmpty()) return captions;
+
+        // Collect Figure objects per page
+        Map<Integer, List<JsonNode>> figuresByPage = new HashMap<>();
+        for (JsonNode page : dlaPages) {
+            int pageNum = page.has("page_number") ? page.get("page_number").asInt() : -1;
+            if (pageNum < 0) continue;
+
+            JsonNode objects = page.get("objects");
+            if (objects == null || !objects.isArray()) continue;
+
+            for (JsonNode obj : objects) {
+                int label = obj.has("label") ? obj.get("label").asInt() : -1;
+                if (label == LABEL_FIGURE || label == LABEL_FIGURE_CAPTION) {
+                    figuresByPage.computeIfAbsent(pageNum, k -> new ArrayList<>()).add(obj);
+                }
+            }
+        }
+
+        if (figuresByPage.isEmpty()) {
+            LOGGER.log(Level.INFO, "Hancom AI: no Figure objects found, skipping captioning");
+            return captions;
+        }
+
+        LOGGER.log(Level.INFO, "Hancom AI: captioning {0} figures across {1} pages",
+            new Object[]{figuresByPage.values().stream().mapToInt(List::size).sum(),
+                          figuresByPage.size()});
+
+        // Get page images and crop figures
+        Map<Integer, BufferedImage> pageImages = new HashMap<>();
+
+        for (Map.Entry<Integer, List<JsonNode>> entry : figuresByPage.entrySet()) {
+            int pageNum = entry.getKey();
+            List<JsonNode> figures = entry.getValue();
+
+            // Get page image (cached)
+            BufferedImage pageImage = pageImages.get(pageNum);
+            if (pageImage == null) {
+                try {
+                    pageImage = fetchPageImage(pdfBytes, pageNum);
+                    pageImages.put(pageNum, pageImage);
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Failed to get page {0} image: {1}",
+                        new Object[]{pageNum, e.getMessage()});
+                    continue;
+                }
+            }
+
+            // Caption each figure
+            for (JsonNode fig : figures) {
+                JsonNode bboxNode = fig.get("bbox");
+                if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) continue;
+
+                int left = bboxNode.get(0).asInt();
+                int top = bboxNode.get(1).asInt();
+                int right = bboxNode.get(2).asInt();
+                int bottom = bboxNode.get(3).asInt();
+
+                // Clamp to image bounds
+                left = Math.max(0, left);
+                top = Math.max(0, top);
+                right = Math.min(pageImage.getWidth(), right);
+                bottom = Math.min(pageImage.getHeight(), bottom);
+
+                if (right <= left || bottom <= top) continue;
+
+                try {
+                    BufferedImage cropped = pageImage.getSubimage(left, top, right - left, bottom - top);
+                    byte[] croppedPng = imageToPng(cropped);
+                    String caption = callImageCaptioning(croppedPng);
+
+                    ObjectNode capNode = objectMapper.createObjectNode();
+                    capNode.put("page_number", pageNum);
+                    capNode.put("object_id", fig.has("object_id") ? fig.get("object_id").asInt() : -1);
+                    ArrayNode bboxArr = objectMapper.createArrayNode();
+                    bboxArr.add(left).add(top).add(right).add(bottom);
+                    capNode.set("bbox", bboxArr);
+                    capNode.put("caption", caption != null ? caption : "");
+                    captions.add(capNode);
+
+                    LOGGER.log(Level.FINE, "Captioned figure page={0} bbox=[{1},{2},{3},{4}]: {5}",
+                        new Object[]{pageNum, left, top, right, bottom,
+                            caption != null ? caption.substring(0, Math.min(50, caption.length())) : ""});
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Failed to caption figure on page {0}: {1}",
+                        new Object[]{pageNum, e.getMessage()});
+                }
+            }
+        }
+
+        return captions;
+    }
+
+    /**
+     * Fetches a page image from the pdf2img endpoint.
+     */
+    private BufferedImage fetchPageImage(byte[] pdfBytes, int pageIndex) throws IOException {
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("REQUEST_ID", "odl-pdf2img-" + pageIndex)
+            .addFormDataPart("PAGE_INDEX", String.valueOf(pageIndex))
+            .addFormDataPart("FILE", DEFAULT_FILENAME,
+                RequestBody.create(pdfBytes, MEDIA_TYPE_PDF))
+            .build();
+
+        Request httpRequest = new Request.Builder()
+            .url(baseUrl + PDF2IMG_ENDPOINT)
+            .post(body)
+            .build();
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("pdf2img returned HTTP " + response.code());
+            }
+
+            ResponseBody respBody = response.body();
+            if (respBody == null) {
+                throw new IOException("pdf2img returned empty body");
+            }
+
+            JsonNode root = objectMapper.readTree(respBody.string());
+            // Navigate: RESULT[0].RESULT.PAGE_PNG_DATA
+            JsonNode resultArr = root.get("RESULT");
+            if (resultArr == null || !resultArr.isArray() || resultArr.size() == 0) {
+                throw new IOException("pdf2img RESULT is empty");
+            }
+
+            JsonNode pageResult = resultArr.get(0);
+            JsonNode innerResult = pageResult.get("RESULT");
+            if (innerResult == null) {
+                throw new IOException("pdf2img inner RESULT is null");
+            }
+
+            String pngBase64 = innerResult.has("PAGE_PNG_DATA")
+                ? innerResult.get("PAGE_PNG_DATA").asText() : null;
+            if (pngBase64 == null || pngBase64.isEmpty()) {
+                throw new IOException("pdf2img PAGE_PNG_DATA is empty");
+            }
+
+            byte[] pngBytes = Base64.getDecoder().decode(pngBase64);
+            return ImageIO.read(new ByteArrayInputStream(pngBytes));
+        }
+    }
+
+    /**
+     * Sends a cropped image to IMAGE_CAPTIONING and returns the caption text.
+     */
+    private String callImageCaptioning(byte[] pngBytes) throws IOException {
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("REQUEST_ID", "odl-caption")
+            .addFormDataPart("OPEN_API_NAME", "IMAGE_CAPTIONING")
+            .addFormDataPart("DATA_FORMAT", "image")
+            .addFormDataPart("FILE", "figure.png",
+                RequestBody.create(pngBytes, MEDIA_TYPE_PNG))
+            .build();
+
+        Request httpRequest = new Request.Builder()
+            .url(baseUrl + SDK_ENDPOINT)
+            .post(body)
+            .build();
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            if (!response.isSuccessful()) return null;
+
+            ResponseBody respBody = response.body();
+            if (respBody == null) return null;
+
+            JsonNode root = objectMapper.readTree(respBody.string());
+            if (!root.has("SUCCESS") || !root.get("SUCCESS").asBoolean()) return null;
+
+            JsonNode result = root.get("RESULT");
+            if (result == null || !result.isArray() || result.size() == 0) return null;
+
+            JsonNode page = result.get(0);
+            if (page.isArray() && page.size() > 0) page = page.get(0);
+
+            return page.has("caption") ? page.get("caption").asText("") : null;
+        }
+    }
+
+    /**
+     * Calls a single HOCR SDK module with PDF input.
+     */
+    private JsonNode callModule(byte[] pdfBytes, String moduleName) throws IOException {
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("REQUEST_ID", "odl-" + moduleName)
+            .addFormDataPart("OPEN_API_NAME", moduleName)
+            .addFormDataPart("DATA_FORMAT", "pdf")
+            .addFormDataPart("FILE", DEFAULT_FILENAME,
+                RequestBody.create(pdfBytes, MEDIA_TYPE_PDF))
+            .build();
+
+        Request httpRequest = new Request.Builder()
+            .url(baseUrl + SDK_ENDPOINT)
+            .post(body)
+            .build();
+
+        LOGGER.log(Level.INFO, "Calling Hancom AI module: {0}", moduleName);
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            if (!response.isSuccessful()) {
+                ResponseBody respBody = response.body();
+                String errorMsg = respBody != null ? respBody.string() : "";
+                LOGGER.log(Level.WARNING, "Hancom AI module {0} returned HTTP {1}: {2}",
+                    new Object[]{moduleName, response.code(), errorMsg});
+                return objectMapper.createArrayNode();
+            }
+
+            ResponseBody respBody = response.body();
+            if (respBody == null) {
+                return objectMapper.createArrayNode();
+            }
+
+            JsonNode root = objectMapper.readTree(respBody.string());
+            boolean success = root.has("SUCCESS") && root.get("SUCCESS").asBoolean();
+            if (!success) {
+                LOGGER.log(Level.WARNING, "Hancom AI module {0} returned SUCCESS=false: {1}",
+                    new Object[]{moduleName, root.has("MSG") ? root.get("MSG").asText() : ""});
+                return objectMapper.createArrayNode();
+            }
+
+            JsonNode result = root.get("RESULT");
+            return result != null ? result : objectMapper.createArrayNode();
+        }
+    }
+
+    // --- Helpers ---
+
+    private List<JsonNode> extractPages(JsonNode moduleResult) {
+        List<JsonNode> pages = new ArrayList<>();
+        if (moduleResult == null || !moduleResult.isArray()) return pages;
+        JsonNode inner = moduleResult.size() > 0 && moduleResult.get(0).isArray()
+            ? moduleResult.get(0) : moduleResult;
+        for (JsonNode page : inner) {
+            if (page.isObject()) pages.add(page);
+        }
+        return pages;
+    }
+
+    private byte[] imageToPng(BufferedImage image) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", baos);
+        return baos.toByteArray();
+    }
+
+    private void addTimings(ObjectNode timingsNode, String moduleName, JsonNode result) {
+        long totalMs = 0;
+        int pageCount = 0;
+        if (result.isArray() && result.size() > 0) {
+            JsonNode pages = result.get(0).isArray() ? result.get(0) : result;
+            for (JsonNode page : pages) {
+                if (page.has("run_time")) {
+                    totalMs += page.get("run_time").asLong();
+                    pageCount++;
+                }
+            }
+        }
+        ObjectNode timing = objectMapper.createObjectNode();
+        timing.put("total_ms", totalMs);
+        timing.put("count", pageCount);
+        if (pageCount > 0) timing.put("avg_ms", totalMs / pageCount);
+        timingsNode.set(moduleName, timing);
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void shutdown() {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
+        if (httpClient.cache() != null) {
+            try { httpClient.cache().close(); } catch (Exception ignored) { }
+        }
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -374,10 +374,14 @@ public class HancomAIClient implements HybridClient {
                                                 PageImageCache pageImageCache) {
         ArrayNode results = objectMapper.createArrayNode();
 
-        // If regionlist strategy is list-only, skip TSR entirely
-        if (config.isRegionlistListOnly()) {
-            LOGGER.log(Level.INFO, "Hancom AI: regionlist strategy is list-only, skipping TSR");
-            return results;
+        // In list-only mode, LABEL_REGIONLIST is always rendered as a list and
+        // does not need TSR. LABEL_TABLE still needs TSR — without it the
+        // transformer's LABEL_TABLE branch returns null and real tables drop out
+        // of the structured output entirely.
+        boolean skipRegionlistTsr = config.isRegionlistListOnly();
+        if (skipRegionlistTsr) {
+            LOGGER.log(Level.INFO, "Hancom AI: regionlist strategy is list-only, "
+                + "skipping TSR for Regionlist (label 7); Table (label 9) TSR still runs");
         }
 
         List<JsonNode> dlaPages = extractPages(dlaResult);
@@ -394,7 +398,8 @@ public class HancomAIClient implements HybridClient {
             boolean needsPageImage = false;
             for (JsonNode obj : objects) {
                 int label = obj.has("label") ? obj.get("label").asInt() : -1;
-                if (label == LABEL_REGIONLIST || label == LABEL_TABLE) {
+                if (label == LABEL_TABLE
+                        || (label == LABEL_REGIONLIST && !skipRegionlistTsr)) {
                     needsPageImage = true;
                     break;
                 }
@@ -418,6 +423,7 @@ public class HancomAIClient implements HybridClient {
             for (JsonNode obj : objects) {
                 int label = obj.has("label") ? obj.get("label").asInt() : -1;
                 if (label != LABEL_REGIONLIST && label != LABEL_TABLE) continue;
+                if (label == LABEL_REGIONLIST && skipRegionlistTsr) continue;
 
                 JsonNode bboxNode = obj.get("bbox");
                 if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) continue;
@@ -475,9 +481,11 @@ public class HancomAIClient implements HybridClient {
                         new Object[]{pageNum, e.getMessage()});
                 }
             }
-
-            // Evict page image after processing all objects on this page
-            pageImageCache.evict(pageNum);
+            // Do NOT evict the page image here — captionFigures() runs next and
+            // reuses the same cache. Evicting per-page during TSR would force
+            // pdf2img to re-render pages that contain both tables and figures.
+            // The try-with-resources in convert() closes the cache at the end
+            // of the request.
         }
 
         LOGGER.log(Level.INFO, "Hancom AI: TSR processed {0} table crops", results.size());

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -481,11 +481,23 @@ public class HancomAIClient implements HybridClient {
                         new Object[]{pageNum, e.getMessage()});
                 }
             }
-            // Do NOT evict the page image here — captionFigures() runs next and
-            // reuses the same cache. Evicting per-page during TSR would force
-            // pdf2img to re-render pages that contain both tables and figures.
-            // The try-with-resources in convert() closes the cache at the end
-            // of the request.
+            // Evict the page image here only if captionFigures() will not revisit
+            // this page. captionFigures() iterates pages that contain at least one
+            // LABEL_FIGURE object; for table-only pages (no figures) the cached
+            // full-resolution image would otherwise sit in memory until the
+            // try-with-resources in convert() closes the cache — ~25MB per page
+            // for the memory cache, which is costly on large table-heavy PDFs.
+            boolean hasFigure = false;
+            for (JsonNode obj : objects) {
+                int objLabel = obj.has("label") ? obj.get("label").asInt() : -1;
+                if (objLabel == LABEL_FIGURE) {
+                    hasFigure = true;
+                    break;
+                }
+            }
+            if (!hasFigure) {
+                pageImageCache.evict(pageNum);
+            }
         }
 
         LOGGER.log(Level.INFO, "Hancom AI: TSR processed {0} table crops", results.size());

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -89,6 +89,35 @@ public class HancomAIClient implements HybridClient {
     private final ObjectMapper objectMapper;
     private final HybridConfig config;
 
+    private String sourcePdfShaShort = "unknown";
+
+    private static final java.util.Map<String, String> MODULE_SHORT;
+    static {
+        java.util.Map<String, String> m = new java.util.HashMap<>();
+        m.put("DOCUMENT_LAYOUT_WITH_OCR", "dla-ocr");
+        m.put("DOCUMENT_LAYOUT_ANALYSIS", "dla");
+        m.put("TEXT_RECOGNITION", "ocr");
+        m.put("TABLE_STRUCTURE_RECOGNITION", "tsr");
+        m.put("IMAGE_CAPTIONING", "caption");
+        m.put("CHART_IMAGE_UNDERSTANDING", "chart");
+        MODULE_SHORT = java.util.Collections.unmodifiableMap(m);
+    }
+
+    private static String sha256ShortHex(byte[] data) {
+        try {
+            java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(data);
+            StringBuilder sb = new StringBuilder(12);
+            for (int i = 0; i < 6; i++) sb.append(String.format("%02x", hash[i]));
+            return sb.toString();
+        } catch (java.security.NoSuchAlgorithmException e) {
+            return "nohash000000";
+        }
+    }
+
+    // Test hook
+    void setSourcePdfShaShort(String s) { this.sourcePdfShaShort = s; }
+
     public HancomAIClient(HybridConfig config) {
         this.config = config;
         this.baseUrl = config.getEffectiveUrl("hancom-ai");
@@ -135,6 +164,7 @@ public class HancomAIClient implements HybridClient {
     @Override
     public HybridResponse convert(HybridRequest request) throws IOException {
         byte[] pdfBytes = request.getPdfBytes();
+        this.sourcePdfShaShort = sha256ShortHex(pdfBytes);
         LOGGER.log(Level.INFO, "Hancom AI: processing PDF ({0} bytes)", pdfBytes.length);
 
         try (PageImageCache pageImageCache = createPageImageCache()) {
@@ -291,7 +321,8 @@ public class HancomAIClient implements HybridClient {
                         saveCropFile(config.getCropOutputDir(), pageNum, objId, "figure", croppedPng);
                     }
 
-                    String caption = callImageCaptioning(croppedPng);
+                    int objIdForCaption = fig.has("object_id") ? fig.get("object_id").asInt() : -1;
+                    String caption = callImageCaptioning(croppedPng, pageNum, objIdForCaption);
 
                     ObjectNode capNode = objectMapper.createObjectNode();
                     capNode.put("page_number", pageNum);
@@ -407,7 +438,8 @@ public class HancomAIClient implements HybridClient {
                     }
 
                     // Call TSR with crop image
-                    JsonNode tsrResult = callModuleImage(cropPng, "TABLE_STRUCTURE_RECOGNITION");
+                    int objId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
+                    JsonNode tsrResult = callModuleImage(cropPng, "TABLE_STRUCTURE_RECOGNITION", pageNum, objId);
 
                     // Build result entry
                     ObjectNode entry = objectMapper.createObjectNode();
@@ -448,10 +480,12 @@ public class HancomAIClient implements HybridClient {
      * Calls a single HOCR SDK module with image (PNG) input.
      * Similar to {@link #callModule} but sends image data instead of PDF.
      */
-    private JsonNode callModuleImage(byte[] pngBytes, String moduleName) throws IOException {
+    private JsonNode callModuleImage(byte[] pngBytes, String moduleName, int pageNum, int objectId) throws IOException {
+        String moduleShort = MODULE_SHORT.getOrDefault(moduleName, moduleName);
+        String requestId = "odl-" + sourcePdfShaShort + "-p" + pageNum + "-o" + objectId + "-" + moduleShort;
         MultipartBody body = new MultipartBody.Builder()
             .setType(MultipartBody.FORM)
-            .addFormDataPart("REQUEST_ID", "odl-" + moduleName)
+            .addFormDataPart("REQUEST_ID", requestId)
             .addFormDataPart("OPEN_API_NAME", moduleName)
             .addFormDataPart("DATA_FORMAT", "image")
             .addFormDataPart("FILE", "crop.png",
@@ -463,7 +497,8 @@ public class HancomAIClient implements HybridClient {
             .post(body)
             .build();
 
-        LOGGER.log(Level.FINE, "Calling Hancom AI module (image): {0}", moduleName);
+        LOGGER.log(Level.FINE, "Calling Hancom AI module (image): {0} [{1}]",
+            new Object[]{moduleName, requestId});
 
         try (Response response = httpClient.newCall(httpRequest).execute()) {
             if (!response.isSuccessful()) {
@@ -513,7 +548,8 @@ public class HancomAIClient implements HybridClient {
     private BufferedImage fetchPageImage(byte[] pdfBytes, int pageIndex) throws IOException {
         MultipartBody body = new MultipartBody.Builder()
             .setType(MultipartBody.FORM)
-            .addFormDataPart("REQUEST_ID", "odl-pdf2img-" + pageIndex)
+            .addFormDataPart("REQUEST_ID",
+                "odl-" + sourcePdfShaShort + "-pdf2img-p" + pageIndex)
             .addFormDataPart("PAGE_INDEX", String.valueOf(pageIndex))
             .addFormDataPart("FILE", DEFAULT_FILENAME,
                 RequestBody.create(pdfBytes, MEDIA_TYPE_PDF))
@@ -561,10 +597,11 @@ public class HancomAIClient implements HybridClient {
     /**
      * Sends a cropped image to IMAGE_CAPTIONING and returns the caption text.
      */
-    private String callImageCaptioning(byte[] pngBytes) throws IOException {
+    private String callImageCaptioning(byte[] pngBytes, int pageNum, int objectId) throws IOException {
+        String requestId = "odl-" + sourcePdfShaShort + "-p" + pageNum + "-o" + objectId + "-caption";
         MultipartBody body = new MultipartBody.Builder()
             .setType(MultipartBody.FORM)
-            .addFormDataPart("REQUEST_ID", "odl-caption")
+            .addFormDataPart("REQUEST_ID", requestId)
             .addFormDataPart("OPEN_API_NAME", "IMAGE_CAPTIONING")
             .addFormDataPart("DATA_FORMAT", "image")
             .addFormDataPart("FILE", "figure.png",
@@ -601,7 +638,8 @@ public class HancomAIClient implements HybridClient {
     private JsonNode callModule(byte[] pdfBytes, String moduleName) throws IOException {
         MultipartBody body = new MultipartBody.Builder()
             .setType(MultipartBody.FORM)
-            .addFormDataPart("REQUEST_ID", "odl-" + moduleName)
+            .addFormDataPart("REQUEST_ID",
+                "odl-" + sourcePdfShaShort + "-" + MODULE_SHORT.getOrDefault(moduleName, moduleName))
             .addFormDataPart("OPEN_API_NAME", moduleName)
             .addFormDataPart("DATA_FORMAT", "pdf")
             .addFormDataPart("FILE", DEFAULT_FILENAME,
@@ -690,5 +728,16 @@ public class HancomAIClient implements HybridClient {
         if (httpClient.cache() != null) {
             try { httpClient.cache().close(); } catch (Exception ignored) { }
         }
+    }
+
+    // --- Test hooks (package-private) ---
+
+    void invokeCallModule(byte[] pdfBytes, String moduleName) throws IOException {
+        this.sourcePdfShaShort = sha256ShortHex(pdfBytes);
+        callModule(pdfBytes, moduleName);
+    }
+
+    void invokeCallImageCaptioning(byte[] pngBytes, int pageNum, int objectId) throws IOException {
+        callImageCaptioning(pngBytes, pageNum, objectId);
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -31,7 +31,9 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -50,7 +52,7 @@ import java.util.logging.Logger;
  * <ol>
  *   <li>pdf2img — convert each page to PNG image</li>
  *   <li>DOCUMENT_LAYOUT_WITH_OCR — layout analysis + OCR on full PDF</li>
- *   <li>TABLE_STRUCTURE_RECOGNITION — table cell structure on full PDF</li>
+ *   <li>TABLE_STRUCTURE_RECOGNITION — crop each Table/Regionlist from page image, send to TSR individually</li>
  *   <li>IMAGE_CAPTIONING — crop each Figure region from page image, caption individually</li>
  * </ol>
  *
@@ -70,9 +72,15 @@ public class HancomAIClient implements HybridClient {
     private static final MediaType MEDIA_TYPE_PDF = MediaType.parse("application/pdf");
     private static final MediaType MEDIA_TYPE_PNG = MediaType.parse("image/png");
 
+    // DLA label 7 = Table / Regionlist (may be actual table or a list region)
+    private static final int LABEL_TABLE = 7;
+
     // DLA labels for Figure regions
     private static final int LABEL_FIGURE = 9;
     private static final int LABEL_FIGURE_CAPTION = 10;
+
+    /** Padding (pixels) added around table crops before sending to TSR. */
+    private static final int TSR_CROP_PADDING = 20;
 
     private final String baseUrl;
     private final OkHttpClient httpClient;
@@ -136,10 +144,19 @@ public class HancomAIClient implements HybridClient {
             merged.set("DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
             addTimings(timingsNode, "DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
 
-            // Step 2: Table Structure
-            JsonNode tableResult = callModule(pdfBytes, "TABLE_STRUCTURE_RECOGNITION");
-            merged.set("TABLE_STRUCTURE_RECOGNITION", tableResult);
-            addTimings(timingsNode, "TABLE_STRUCTURE_RECOGNITION", tableResult);
+            // Step 2: Table Structure — crop each Table region from page image, send to TSR individually
+            long tsrStartMs = System.currentTimeMillis();
+            ArrayNode tsrResults = recognizeTableStructures(pdfBytes, dlaOcrResult, pageImageCache);
+            long tsrMs = System.currentTimeMillis() - tsrStartMs;
+            merged.set("TABLE_STRUCTURE_RECOGNITION", tsrResults);
+
+            ObjectNode tsrTiming = objectMapper.createObjectNode();
+            tsrTiming.put("total_ms", tsrMs);
+            tsrTiming.put("count", tsrResults.size());
+            if (tsrResults.size() > 0) {
+                tsrTiming.put("avg_ms", tsrMs / tsrResults.size());
+            }
+            timingsNode.set("TABLE_STRUCTURE_RECOGNITION", tsrTiming);
 
             // Step 3: Figure captioning — pdf2img → crop figures → caption each
             long captionStartMs = System.currentTimeMillis();
@@ -157,8 +174,8 @@ public class HancomAIClient implements HybridClient {
 
             merged.set("timings", timingsNode);
 
-            LOGGER.log(Level.INFO, "Hancom AI: completed — {0} figure captions generated",
-                figureCaptions.size());
+            LOGGER.log(Level.INFO, "Hancom AI: completed — {0} table crops, {1} figure captions",
+                new Object[]{tsrResults.size(), figureCaptions.size()});
 
             return new HybridResponse(null, null, merged, Collections.emptyMap(),
                 Collections.emptyList(), timingsNode);
@@ -265,6 +282,13 @@ public class HancomAIClient implements HybridClient {
                 try {
                     BufferedImage cropped = pageImage.getSubimage(left, top, right - left, bottom - top);
                     byte[] croppedPng = imageToPng(cropped);
+
+                    // Save crop if configured
+                    if (config.isSaveCrops() && config.getCropOutputDir() != null) {
+                        int objId = fig.has("object_id") ? fig.get("object_id").asInt() : -1;
+                        saveCropFile(config.getCropOutputDir(), pageNum, objId, "figure", croppedPng);
+                    }
+
                     String caption = callImageCaptioning(croppedPng);
 
                     ObjectNode capNode = objectMapper.createObjectNode();
@@ -290,6 +314,195 @@ public class HancomAIClient implements HybridClient {
         }
 
         return captions;
+    }
+
+    /**
+     * For each Table region (label 7) found by DLA, crop the region from the
+     * page image and send the crop to TABLE_STRUCTURE_RECOGNITION individually.
+     *
+     * <p>When regionlist strategy is "list-only", label 7 is always treated as a
+     * list and TSR is skipped entirely.
+     *
+     * @param pdfBytes the original PDF bytes (needed for pdf2img)
+     * @param dlaResult the DLA+OCR result containing detected objects
+     * @param pageImageCache shared cache for page images
+     * @return ArrayNode of per-table results:
+     *         [{page_number, object_id, label, dla_bbox, tsr: {cells, num_cells, html, ...}}]
+     */
+    private ArrayNode recognizeTableStructures(byte[] pdfBytes, JsonNode dlaResult,
+                                                PageImageCache pageImageCache) {
+        ArrayNode results = objectMapper.createArrayNode();
+
+        // If regionlist strategy is list-only, skip TSR entirely
+        if (config.isRegionlistListOnly()) {
+            LOGGER.log(Level.INFO, "Hancom AI: regionlist strategy is list-only, skipping TSR");
+            return results;
+        }
+
+        List<JsonNode> dlaPages = extractPages(dlaResult);
+        if (dlaPages.isEmpty()) return results;
+
+        for (JsonNode page : dlaPages) {
+            int pageNum = page.has("page_number") ? page.get("page_number").asInt() : -1;
+            if (pageNum < 0) continue;
+
+            JsonNode objects = page.get("objects");
+            if (objects == null || !objects.isArray()) continue;
+
+            // Check if any table objects exist on this page
+            boolean needsPageImage = false;
+            for (JsonNode obj : objects) {
+                int label = obj.has("label") ? obj.get("label").asInt() : -1;
+                if (label == LABEL_TABLE) {
+                    needsPageImage = true;
+                    break;
+                }
+            }
+            if (!needsPageImage) continue;
+
+            // Get page image
+            BufferedImage pageImage;
+            try {
+                pageImage = pageImageCache.getOrFetch(pageNum,
+                    idx -> fetchPageImage(pdfBytes, idx));
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to get page {0} image for TSR: {1}",
+                    new Object[]{pageNum, e.getMessage()});
+                continue;
+            }
+
+            int imgWidth = pageImage.getWidth();
+            int imgHeight = pageImage.getHeight();
+
+            for (JsonNode obj : objects) {
+                int label = obj.has("label") ? obj.get("label").asInt() : -1;
+                if (label != LABEL_TABLE) continue;
+
+                JsonNode bboxNode = obj.get("bbox");
+                if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) continue;
+
+                int left = bboxNode.get(0).asInt();
+                int top = bboxNode.get(1).asInt();
+                int right = bboxNode.get(2).asInt();
+                int bottom = bboxNode.get(3).asInt();
+
+                // Add padding around crop
+                left = Math.max(0, left - TSR_CROP_PADDING);
+                top = Math.max(0, top - TSR_CROP_PADDING);
+                right = Math.min(imgWidth, right + TSR_CROP_PADDING);
+                bottom = Math.min(imgHeight, bottom + TSR_CROP_PADDING);
+
+                if (right <= left || bottom <= top) continue;
+
+                try {
+                    BufferedImage crop = pageImage.getSubimage(left, top, right - left, bottom - top);
+                    byte[] cropPng = imageToPng(crop);
+
+                    // Save crop if configured
+                    if (config.isSaveCrops() && config.getCropOutputDir() != null) {
+                        int objectId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
+                        saveCropFile(config.getCropOutputDir(), pageNum, objectId, "table", cropPng);
+                    }
+
+                    // Call TSR with crop image
+                    JsonNode tsrResult = callModuleImage(cropPng, "TABLE_STRUCTURE_RECOGNITION");
+
+                    // Build result entry
+                    ObjectNode entry = objectMapper.createObjectNode();
+                    entry.put("page_number", pageNum);
+                    entry.put("object_id",
+                        obj.has("object_id") ? obj.get("object_id").asInt() : -1);
+                    entry.put("label", label);
+
+                    // Store the DLA bbox (padded, page-level pixels) for coordinate offset later
+                    ArrayNode dlaBbox = objectMapper.createArrayNode();
+                    dlaBbox.add(left).add(top).add(right).add(bottom);
+                    entry.set("dla_bbox", dlaBbox);
+
+                    // Extract TSR page result
+                    List<JsonNode> tsrPages = extractPages(tsrResult);
+                    if (!tsrPages.isEmpty()) {
+                        entry.set("tsr", tsrPages.get(0));
+                    } else {
+                        entry.set("tsr", objectMapper.createObjectNode());
+                    }
+
+                    results.add(entry);
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "TSR failed for page {0} object: {1}",
+                        new Object[]{pageNum, e.getMessage()});
+                }
+            }
+
+            // Evict page image after processing all objects on this page
+            pageImageCache.evict(pageNum);
+        }
+
+        LOGGER.log(Level.INFO, "Hancom AI: TSR processed {0} table crops", results.size());
+        return results;
+    }
+
+    /**
+     * Calls a single HOCR SDK module with image (PNG) input.
+     * Similar to {@link #callModule} but sends image data instead of PDF.
+     */
+    private JsonNode callModuleImage(byte[] pngBytes, String moduleName) throws IOException {
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("REQUEST_ID", "odl-" + moduleName)
+            .addFormDataPart("OPEN_API_NAME", moduleName)
+            .addFormDataPart("DATA_FORMAT", "image")
+            .addFormDataPart("FILE", "crop.png",
+                RequestBody.create(pngBytes, MEDIA_TYPE_PNG))
+            .build();
+
+        Request httpRequest = new Request.Builder()
+            .url(baseUrl + SDK_ENDPOINT)
+            .post(body)
+            .build();
+
+        LOGGER.log(Level.FINE, "Calling Hancom AI module (image): {0}", moduleName);
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            if (!response.isSuccessful()) {
+                ResponseBody respBody = response.body();
+                String errorMsg = respBody != null ? respBody.string() : "";
+                LOGGER.log(Level.WARNING, "Hancom AI module {0} (image) returned HTTP {1}: {2}",
+                    new Object[]{moduleName, response.code(), errorMsg});
+                return objectMapper.createArrayNode();
+            }
+
+            ResponseBody respBody = response.body();
+            if (respBody == null) {
+                return objectMapper.createArrayNode();
+            }
+
+            JsonNode root = objectMapper.readTree(respBody.string());
+            boolean success = root.has("SUCCESS") && root.get("SUCCESS").asBoolean();
+            if (!success) {
+                LOGGER.log(Level.WARNING, "Hancom AI module {0} (image) returned SUCCESS=false: {1}",
+                    new Object[]{moduleName, root.has("MSG") ? root.get("MSG").asText() : ""});
+                return objectMapper.createArrayNode();
+            }
+
+            JsonNode result = root.get("RESULT");
+            return result != null ? result : objectMapper.createArrayNode();
+        }
+    }
+
+    /**
+     * Saves a cropped image to disk for debugging.
+     */
+    private void saveCropFile(String outputDir, int pageNum, int objectId,
+                              String labelName, byte[] pngBytes) {
+        try {
+            File dir = new File(outputDir, "crops");
+            dir.mkdirs();
+            String filename = String.format("page-%d_%s-o%d.png", pageNum, labelName, objectId);
+            Files.write(new File(dir, filename).toPath(), pngBytes);
+        } catch (IOException e) {
+            LOGGER.log(Level.FINE, "Failed to save crop file", e);
+        }
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -72,12 +72,14 @@ public class HancomAIClient implements HybridClient {
     private static final MediaType MEDIA_TYPE_PDF = MediaType.parse("application/pdf");
     private static final MediaType MEDIA_TYPE_PNG = MediaType.parse("image/png");
 
-    // DLA label 7 = Table / Regionlist (may be actual table or a list region)
-    private static final int LABEL_TABLE = 7;
+    // DLA label 7 = Regionlist (may be actual table or a list region)
+    private static final int LABEL_REGIONLIST = 7;
 
-    // DLA labels for Figure regions
-    private static final int LABEL_FIGURE = 9;
-    private static final int LABEL_FIGURE_CAPTION = 10;
+    // DLA label 9 = Table
+    private static final int LABEL_TABLE = 9;
+
+    // DLA label 10 = Figure
+    private static final int LABEL_FIGURE = 10;
 
     /** Padding (pixels) added around table crops before sending to TSR. */
     private static final int TSR_CROP_PADDING = 20;
@@ -206,7 +208,7 @@ public class HancomAIClient implements HybridClient {
     /**
      * Captions each Figure found by DLA:
      * 1. Get page images via pdf2img
-     * 2. Find Figure objects (label 9, 10) from DLA results
+     * 2. Find Figure objects (label 10) from DLA results
      * 3. Crop each Figure from page image
      * 4. Send cropped image to IMAGE_CAPTIONING
      *
@@ -231,7 +233,7 @@ public class HancomAIClient implements HybridClient {
 
             for (JsonNode obj : objects) {
                 int label = obj.has("label") ? obj.get("label").asInt() : -1;
-                if (label == LABEL_FIGURE || label == LABEL_FIGURE_CAPTION) {
+                if (label == LABEL_FIGURE) {
                     figuresByPage.computeIfAbsent(pageNum, k -> new ArrayList<>()).add(obj);
                 }
             }
@@ -349,11 +351,11 @@ public class HancomAIClient implements HybridClient {
             JsonNode objects = page.get("objects");
             if (objects == null || !objects.isArray()) continue;
 
-            // Check if any table objects exist on this page
+            // Check if any table/regionlist objects exist on this page
             boolean needsPageImage = false;
             for (JsonNode obj : objects) {
                 int label = obj.has("label") ? obj.get("label").asInt() : -1;
-                if (label == LABEL_TABLE) {
+                if (label == LABEL_REGIONLIST || label == LABEL_TABLE) {
                     needsPageImage = true;
                     break;
                 }
@@ -376,7 +378,7 @@ public class HancomAIClient implements HybridClient {
 
             for (JsonNode obj : objects) {
                 int label = obj.has("label") ? obj.get("label").asInt() : -1;
-                if (label != LABEL_TABLE) continue;
+                if (label != LABEL_REGIONLIST && label != LABEL_TABLE) continue;
 
                 JsonNode bboxNode = obj.get("bbox");
                 if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) continue;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -171,8 +171,16 @@ public class HancomAIClient implements HybridClient {
             ObjectNode merged = objectMapper.createObjectNode();
             ObjectNode timingsNode = objectMapper.createObjectNode();
 
-            // Step 1: DLA + OCR
+            // Step 1: DLA + OCR. This is required — downstream steps have nothing
+            // to process without it, so treat an empty response as a failure so the
+            // caller can fall back to the Java pipeline instead of silently emitting
+            // an empty document.
             JsonNode dlaOcrResult = callModule(pdfBytes, "DOCUMENT_LAYOUT_WITH_OCR");
+            if (dlaOcrResult == null || !dlaOcrResult.isArray() || dlaOcrResult.size() == 0) {
+                throw new IOException(
+                    "Hancom AI DOCUMENT_LAYOUT_WITH_OCR returned empty result — "
+                    + "backend unavailable or rejected the document");
+            }
             merged.set("DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
             addTimings(timingsNode, "DOCUMENT_LAYOUT_WITH_OCR", dlaOcrResult);
 
@@ -590,7 +598,11 @@ public class HancomAIClient implements HybridClient {
             }
 
             byte[] pngBytes = Base64.getDecoder().decode(pngBase64);
-            return ImageIO.read(new ByteArrayInputStream(pngBytes));
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(pngBytes));
+            if (image == null) {
+                throw new IOException("pdf2img PAGE_PNG_DATA is not a readable image");
+            }
+            return image;
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -605,7 +605,15 @@ public class HancomAIClient implements HybridClient {
                 throw new IOException("pdf2img PAGE_PNG_DATA is empty");
             }
 
-            byte[] pngBytes = Base64.getDecoder().decode(pngBase64);
+            byte[] pngBytes;
+            try {
+                pngBytes = Base64.getDecoder().decode(pngBase64);
+            } catch (IllegalArgumentException e) {
+                // fetchPageImage is declared to throw IOException and callers catch
+                // only IOException. Escaping IAE would abort the whole conversion
+                // instead of skipping the failed page.
+                throw new IOException("pdf2img PAGE_PNG_DATA is not valid Base64", e);
+            }
             BufferedImage image = ImageIO.read(new ByteArrayInputStream(pngBytes));
             if (image == null) {
                 throw new IOException("pdf2img PAGE_PNG_DATA is not a readable image");

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -137,6 +138,9 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         // Map table structures by page number
         Map<Integer, JsonNode> tableByPage = extractTablePages(tables);
 
+        // Collect all heading heights (label 1 and 4) across all pages for level inference
+        Map<Double, Integer> headingHeightToLevel = buildHeadingHeightToLevelMap(dlaPages);
+
         // Process DLA+OCR objects
         for (int i = 0; i < dlaPages.size(); i++) {
             JsonNode page = dlaPages.get(i);
@@ -151,7 +155,8 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             if (objects == null || !objects.isArray()) continue;
 
             for (JsonNode obj : objects) {
-                IObject iobj = transformObject(obj, pageNumber, pageHeight, figureCaptionMap);
+                IObject iobj = transformObject(obj, pageNumber, pageHeight, figureCaptionMap,
+                    headingHeightToLevel);
 
                 if (iobj != null) {
                     result.get(pageNumber).add(iobj);
@@ -199,7 +204,8 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
      * Transforms a single DLA object to an IObject based on its label.
      */
     private IObject transformObject(JsonNode obj, int pageIndex, double pageHeight,
-                                     Map<String, String> figureCaptionMap) {
+                                     Map<String, String> figureCaptionMap,
+                                     Map<Double, Integer> headingHeightToLevel) {
         int label = obj.has("label") ? obj.get("label").asInt() : -1;
 
         // Skip furniture
@@ -219,9 +225,11 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             case LABEL_TITLE:
                 return createHeading(text, bbox, 1);
             case LABEL_HEADING:
-                return createHeading(text, bbox, 2);
-            case LABEL_SUBHEADING:
-                return createHeading(text, bbox, 3);
+            case LABEL_SUBHEADING: {
+                double pixelHeight = bboxNode.get(3).asDouble() - bboxNode.get(1).asDouble();
+                int level = headingHeightToLevel.getOrDefault(pixelHeight, 2);
+                return createHeading(text, bbox, level);
+            }
 
             case LABEL_PARAGRAPH:
             case LABEL_LIST_ITEM:
@@ -332,6 +340,52 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         }
 
         return table;
+    }
+
+    // --- Helper: heading level inference ---
+
+    /**
+     * Collects all label 1 (heading) and label 4 (subheading) bbox heights across all pages,
+     * then assigns heading levels H2~H6 based on descending height order.
+     *
+     * <p>Taller bbox = bigger font = higher level (H2).
+     * Shorter bbox = smaller font = lower level (H3, H4, ...).
+     * Same height = same level. Capped at H6.
+     * Single unique height defaults to H2.
+     *
+     * @return map from pixel height to heading level (2~6)
+     */
+    private Map<Double, Integer> buildHeadingHeightToLevelMap(List<JsonNode> dlaPages) {
+        // Collect unique heights using TreeSet (natural descending order via reverseOrder)
+        TreeSet<Double> uniqueHeights = new TreeSet<>(Collections.reverseOrder());
+
+        for (JsonNode page : dlaPages) {
+            JsonNode objects = page.get("objects");
+            if (objects == null || !objects.isArray()) continue;
+
+            for (JsonNode obj : objects) {
+                int label = obj.has("label") ? obj.get("label").asInt() : -1;
+                if (label != LABEL_HEADING && label != LABEL_SUBHEADING) continue;
+
+                JsonNode bboxNode = obj.get("bbox");
+                if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) continue;
+
+                double pixelHeight = bboxNode.get(3).asDouble() - bboxNode.get(1).asDouble();
+                if (pixelHeight > 0) {
+                    uniqueHeights.add(pixelHeight);
+                }
+            }
+        }
+
+        // Assign levels: tallest → H2, next → H3, ... capped at H6
+        Map<Double, Integer> heightToLevel = new HashMap<>();
+        int level = 2;
+        for (Double height : uniqueHeights) {
+            heightToLevel.put(height, Math.min(level, 6));
+            level++;
+        }
+
+        return heightToLevel;
     }
 
     // --- Helper: extract pages from RESULT ---

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -24,6 +24,7 @@ import org.opendataloader.pdf.entities.SemanticPicture;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.SemanticCaption;
 import org.verapdf.wcag.algorithms.entities.SemanticHeading;
+import org.verapdf.wcag.algorithms.entities.SemanticNode;
 import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
@@ -329,6 +330,12 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             default:
                 iobj = text.isEmpty() ? null : createParagraph(text, bbox);
                 break;
+        }
+
+        // Map confidence to correctSemanticScore (only for SemanticNode subtypes)
+        if (iobj instanceof SemanticNode) {
+            double confidence = obj.has("confidence") ? obj.get("confidence").asDouble(1.0) : 1.0;
+            ((SemanticNode) iobj).setCorrectSemanticScore(confidence);
         }
 
         return iobj;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -18,6 +18,7 @@ package org.opendataloader.pdf.hybrid;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
+import org.opendataloader.pdf.entities.SemanticFootnote;
 import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.verapdf.wcag.algorithms.entities.IObject;
@@ -68,7 +69,7 @@ import java.util.regex.Pattern;
  *  10  → Figure with caption (SemanticPicture)
  *  11  → FigureName (SemanticCaption linked to nearest Figure)
  *  12  → Formula (SemanticFormula)
- *  13  → Footnote (SemanticParagraph)
+ *  13  → Footnote (SemanticFootnote → FENote)
  *  14  → Page header (filtered)
  *  15  → Page footer (filtered)
  *  17  → Page number (filtered)
@@ -279,9 +280,11 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             case LABEL_CAPTION:
                 return text.isEmpty() ? null : createCaption(text, bbox);
 
+            case LABEL_FOOTNOTE:
+                return text.isEmpty() ? null : createFootnote(text, bbox);
+
             case LABEL_PARAGRAPH:
             case LABEL_AUTHOR:
-            case LABEL_FOOTNOTE:
                 return text.isEmpty() ? null : createParagraph(text, bbox);
 
             case LABEL_TABLE:
@@ -696,6 +699,17 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         caption.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
         caption.setCorrectSemanticScore(1.0);
         return caption;
+    }
+
+    private SemanticFootnote createFootnote(String text, BoundingBox bbox) {
+        TextChunk textChunk = new TextChunk(bbox, text, 12.0, 12.0);
+        textChunk.adjustSymbolEndsToBoundingBox(null);
+        TextLine textLine = new TextLine(textChunk);
+        SemanticFootnote footnote = new SemanticFootnote();
+        footnote.add(textLine);
+        footnote.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+        footnote.setCorrectSemanticScore(1.0);
+        return footnote;
     }
 
     private ListItem createListItem(String text, BoundingBox bbox) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
+import org.opendataloader.pdf.entities.SemanticFormula;
+import org.opendataloader.pdf.entities.SemanticPicture;
+import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.SemanticHeading;
+import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
+import org.verapdf.wcag.algorithms.entities.content.TextChunk;
+import org.verapdf.wcag.algorithms.entities.content.TextLine;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Transforms Hancom AI HOCR SDK API responses into IObject hierarchy.
+ *
+ * <p>The merged JSON from {@link HancomAIClient} contains results from three modules:
+ * <ul>
+ *   <li>{@code DOCUMENT_LAYOUT_WITH_OCR} — objects with label + bbox + ocrtext</li>
+ *   <li>{@code TABLE_STRUCTURE_RECOGNITION} — table cells with html + bbox</li>
+ *   <li>{@code IMAGE_CAPTIONING} — per-page captions</li>
+ * </ul>
+ *
+ * <h2>Label Mapping (DLA integer labels → IObject types)</h2>
+ * <pre>
+ *   0  → Title (SemanticHeading level 1)
+ *   1  → Heading (SemanticHeading level 2)
+ *   2  → Paragraph (SemanticParagraph)
+ *   3  → List item (SemanticParagraph)
+ *   4  → Subheading (SemanticHeading level 3)
+ *   6  → Author/Meta (SemanticParagraph)
+ *   7  → Table region (handled via TABLE_STRUCTURE_RECOGNITION)
+ *   9  → Figure (SemanticPicture)
+ *  10  → Figure with caption (SemanticPicture)
+ *  11  → Caption (SemanticParagraph)
+ *  12  → Formula (SemanticFormula)
+ *  13  → Footnote (SemanticParagraph)
+ *  14  → Page header (filtered)
+ *  15  → Page footer (filtered)
+ *  17  → Page number (filtered)
+ * </pre>
+ *
+ * <h2>Coordinate System</h2>
+ * <p>Hancom AI uses TOPLEFT origin with [left, top, right, bottom] pixel coordinates.
+ * OpenDataLoader uses BOTTOMLEFT origin in PDF points. Conversion requires page height
+ * and DPI scaling (API renders at 300 DPI → 1 pixel = 72/300 points).
+ */
+public class HancomAISchemaTransformer implements HybridSchemaTransformer {
+
+    private static final Logger LOGGER = Logger.getLogger(HancomAISchemaTransformer.class.getCanonicalName());
+
+    private static final String BACKEND_TYPE = "hancom-ai";
+
+    // DLA label constants
+    private static final int LABEL_TITLE = 0;
+    private static final int LABEL_HEADING = 1;
+    private static final int LABEL_PARAGRAPH = 2;
+    private static final int LABEL_LIST_ITEM = 3;
+    private static final int LABEL_SUBHEADING = 4;
+    private static final int LABEL_AUTHOR = 6;
+    private static final int LABEL_TABLE = 7;
+    private static final int LABEL_FIGURE = 9;
+    private static final int LABEL_FIGURE_CAPTION = 10;
+    private static final int LABEL_CAPTION = 11;
+    private static final int LABEL_FORMULA = 12;
+    private static final int LABEL_FOOTNOTE = 13;
+    private static final int LABEL_PAGE_HEADER = 14;
+    private static final int LABEL_PAGE_FOOTER = 15;
+    private static final int LABEL_PAGE_NUMBER = 17;
+
+    // DPI conversion: API renders at 300 DPI, PDF uses 72 DPI
+    private static final double PIXEL_TO_POINT = 72.0 / 300.0;
+
+    private int pictureIndex;
+
+    @Override
+    public String getBackendType() {
+        return BACKEND_TYPE;
+    }
+
+    @Override
+    public List<List<IObject>> transform(HybridResponse response, Map<Integer, Double> pageHeights) {
+        JsonNode json = response.getJson();
+        if (json == null) {
+            LOGGER.log(Level.WARNING, "HybridResponse JSON is null");
+            return Collections.emptyList();
+        }
+
+        pictureIndex = 0;
+
+        // Get DLA+OCR results (primary source for layout + text)
+        JsonNode dlaOcr = json.get("DOCUMENT_LAYOUT_WITH_OCR");
+        JsonNode tables = json.get("TABLE_STRUCTURE_RECOGNITION");
+        JsonNode figureCaptions = json.get("FIGURE_CAPTIONS");
+
+        // Determine page count from DLA results
+        List<JsonNode> dlaPages = extractPages(dlaOcr);
+        int numPages = Math.max(dlaPages.size(), pageHeights != null ?
+            pageHeights.keySet().stream().mapToInt(Integer::intValue).max().orElse(0) : 0);
+
+        // Initialize result
+        List<List<IObject>> result = new ArrayList<>(numPages);
+        for (int i = 0; i < numPages; i++) {
+            result.add(new ArrayList<>());
+        }
+
+        // Build per-figure caption lookup: "pageNum:objectId" → caption
+        Map<String, String> figureCaptionMap = buildFigureCaptionMap(figureCaptions);
+
+        // Map table structures by page number
+        Map<Integer, JsonNode> tableByPage = extractTablePages(tables);
+
+        // Process DLA+OCR objects
+        for (int i = 0; i < dlaPages.size(); i++) {
+            JsonNode page = dlaPages.get(i);
+            int pageNumber = page.has("page_number") ? page.get("page_number").asInt() : i;
+            if (pageNumber >= result.size()) {
+                while (result.size() <= pageNumber) result.add(new ArrayList<>());
+            }
+
+            double pageHeight = getPageHeight(pageNumber, pageHeights, page);
+
+            JsonNode objects = page.get("objects");
+            if (objects == null || !objects.isArray()) continue;
+
+            for (JsonNode obj : objects) {
+                IObject iobj = transformObject(obj, pageNumber, pageHeight, figureCaptionMap);
+
+                if (iobj != null) {
+                    result.get(pageNumber).add(iobj);
+                }
+            }
+
+            // Add table from TABLE_STRUCTURE_RECOGNITION if available
+            JsonNode tablePage = tableByPage.get(pageNumber);
+            if (tablePage != null && tablePage.has("num_cells") && tablePage.get("num_cells").asInt() > 0) {
+                IObject table = transformTablePage(tablePage, pageNumber, pageHeight);
+                if (table != null) {
+                    result.get(pageNumber).add(table);
+                }
+            }
+        }
+
+        // Sort each page by reading order (top to bottom)
+        for (List<IObject> pageContents : result) {
+            pageContents.sort((a, b) -> {
+                double aTop = a.getBoundingBox() != null ? -a.getBoundingBox().getTopY() : 0;
+                double bTop = b.getBoundingBox() != null ? -b.getBoundingBox().getTopY() : 0;
+                int cmp = Double.compare(aTop, bTop);
+                if (cmp != 0) return cmp;
+                double aLeft = a.getBoundingBox() != null ? a.getBoundingBox().getLeftX() : 0;
+                double bLeft = b.getBoundingBox() != null ? b.getBoundingBox().getLeftX() : 0;
+                return Double.compare(aLeft, bLeft);
+            });
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<IObject> transformPage(int pageNumber, JsonNode pageContent, double pageHeight) {
+        Map<Integer, Double> heights = new HashMap<>();
+        heights.put(pageNumber, pageHeight);
+        HybridResponse wrapper = new HybridResponse("", pageContent, Collections.emptyMap());
+        List<List<IObject>> all = transform(wrapper, heights);
+        int idx = pageNumber - 1;
+        if (idx >= 0 && idx < all.size()) return all.get(idx);
+        return all.isEmpty() ? Collections.emptyList() : all.get(0);
+    }
+
+    /**
+     * Transforms a single DLA object to an IObject based on its label.
+     */
+    private IObject transformObject(JsonNode obj, int pageIndex, double pageHeight,
+                                     Map<String, String> figureCaptionMap) {
+        int label = obj.has("label") ? obj.get("label").asInt() : -1;
+
+        // Skip furniture
+        if (label == LABEL_PAGE_HEADER || label == LABEL_PAGE_FOOTER || label == LABEL_PAGE_NUMBER) {
+            return null;
+        }
+
+        JsonNode bboxNode = obj.get("bbox");
+        if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) {
+            return null;
+        }
+
+        BoundingBox bbox = extractBoundingBox(bboxNode, pageIndex, pageHeight);
+        String text = obj.has("ocrtext") ? obj.get("ocrtext").asText("") : "";
+
+        switch (label) {
+            case LABEL_TITLE:
+                return createHeading(text, bbox, 1);
+            case LABEL_HEADING:
+                return createHeading(text, bbox, 2);
+            case LABEL_SUBHEADING:
+                return createHeading(text, bbox, 3);
+
+            case LABEL_PARAGRAPH:
+            case LABEL_LIST_ITEM:
+            case LABEL_AUTHOR:
+            case LABEL_FOOTNOTE:
+            case LABEL_CAPTION:
+                return text.isEmpty() ? null : createParagraph(text, bbox);
+
+            case LABEL_TABLE:
+                // Table region detected by DLA — treat as paragraph with table-like text
+                return text.isEmpty() ? null : createParagraph(text, bbox);
+
+            case LABEL_FIGURE:
+            case LABEL_FIGURE_CAPTION: {
+                // Look up per-figure caption from IMAGE_CAPTIONING
+                int objectId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
+                String key = pageIndex + ":" + objectId;
+                String caption = figureCaptionMap.get(key);
+                return createPicture(bbox, caption);
+            }
+
+            case LABEL_FORMULA:
+                return createFormula(text, bbox);
+
+            default:
+                return text.isEmpty() ? null : createParagraph(text, bbox);
+        }
+    }
+
+    /**
+     * Transforms a TABLE_STRUCTURE_RECOGNITION page result to a TableBorder.
+     */
+    private IObject transformTablePage(JsonNode tablePage, int pageIndex, double pageHeight) {
+        JsonNode cellsNode = tablePage.get("cells");
+        if (cellsNode == null || !cellsNode.isArray() || cellsNode.size() == 0) {
+            return null;
+        }
+
+        JsonNode tableBboxNode = tablePage.get("table_bbox");
+        BoundingBox tableBbox;
+        if (tableBboxNode != null && tableBboxNode.isArray() && tableBboxNode.size() >= 4) {
+            tableBbox = extractBoundingBox(tableBboxNode, pageIndex, pageHeight);
+        } else {
+            return null;
+        }
+
+        // Determine dimensions
+        int numRows = 0;
+        int numCols = 0;
+        for (JsonNode cell : cellsNode) {
+            int row = cell.has("row") ? cell.get("row").asInt() : 0;
+            int col = cell.has("col") ? cell.get("col").asInt() : 0;
+            int rowspan = cell.has("rowspan") ? cell.get("rowspan").asInt() : 1;
+            int colspan = cell.has("colspan") ? cell.get("colspan").asInt() : 1;
+            numRows = Math.max(numRows, row + rowspan);
+            numCols = Math.max(numCols, col + colspan);
+        }
+
+        if (numRows == 0 || numCols == 0) return null;
+
+        TableBorder table = new TableBorder(numRows, numCols);
+        table.setBoundingBox(tableBbox);
+        table.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+
+        double rowHeight = (tableBbox.getTopY() - tableBbox.getBottomY()) / numRows;
+        double colWidth = (tableBbox.getRightX() - tableBbox.getLeftX()) / numCols;
+
+        // Initialize rows
+        for (int r = 0; r < numRows; r++) {
+            double rowTop = tableBbox.getTopY() - (r * rowHeight);
+            double rowBottom = rowTop - rowHeight;
+            TableBorderRow borderRow = new TableBorderRow(r, numCols, 0L);
+            borderRow.setBoundingBox(new BoundingBox(pageIndex,
+                tableBbox.getLeftX(), rowBottom, tableBbox.getRightX(), rowTop));
+            table.getRows()[r] = borderRow;
+
+            for (int c = 0; c < numCols; c++) {
+                TableBorderCell emptyCell = new TableBorderCell(r, c, 1, 1, 0L);
+                emptyCell.setBoundingBox(new BoundingBox(pageIndex,
+                    tableBbox.getLeftX() + c * colWidth, rowBottom,
+                    tableBbox.getLeftX() + (c + 1) * colWidth, rowTop));
+                table.getRows()[r].getCells()[c] = emptyCell;
+            }
+        }
+
+        // Fill cells from API
+        for (JsonNode cellNode : cellsNode) {
+            int row = cellNode.has("row") ? cellNode.get("row").asInt() : 0;
+            int col = cellNode.has("col") ? cellNode.get("col").asInt() : 0;
+            int rowspan = cellNode.has("rowspan") ? cellNode.get("rowspan").asInt() : 1;
+            int colspan = cellNode.has("colspan") ? cellNode.get("colspan").asInt() : 1;
+            String cellText = cellNode.has("text") ? cellNode.get("text").asText("") : "";
+
+            if (row < numRows && col < numCols) {
+                TableBorderCell cell = new TableBorderCell(row, col, rowspan, colspan, 0L);
+                double cellLeft = tableBbox.getLeftX() + col * colWidth;
+                double cellRight = cellLeft + colspan * colWidth;
+                double cellTop = tableBbox.getTopY() - row * rowHeight;
+                double cellBottom = cellTop - rowspan * rowHeight;
+                cell.setBoundingBox(new BoundingBox(pageIndex, cellLeft, cellBottom, cellRight, cellTop));
+
+                if (!cellText.isEmpty()) {
+                    cell.addContentObject(createParagraph(cellText, cell.getBoundingBox()));
+                }
+
+                table.getRows()[row].getCells()[col] = cell;
+            }
+        }
+
+        return table;
+    }
+
+    // --- Helper: extract pages from RESULT ---
+
+    private List<JsonNode> extractPages(JsonNode moduleResult) {
+        List<JsonNode> pages = new ArrayList<>();
+        if (moduleResult == null || !moduleResult.isArray()) return pages;
+
+        // RESULT is [[page0, page1, ...]] (nested array)
+        JsonNode inner = moduleResult.size() > 0 && moduleResult.get(0).isArray()
+            ? moduleResult.get(0) : moduleResult;
+
+        for (JsonNode page : inner) {
+            if (page.isObject()) {
+                pages.add(page);
+            }
+        }
+        return pages;
+    }
+
+    /**
+     * Builds a lookup map from FIGURE_CAPTIONS: "pageNumber:objectId" → caption text.
+     */
+    private Map<String, String> buildFigureCaptionMap(JsonNode figureCaptions) {
+        Map<String, String> map = new HashMap<>();
+        if (figureCaptions == null || !figureCaptions.isArray()) return map;
+
+        for (JsonNode cap : figureCaptions) {
+            int pageNum = cap.has("page_number") ? cap.get("page_number").asInt() : -1;
+            int objectId = cap.has("object_id") ? cap.get("object_id").asInt() : -1;
+            String caption = cap.has("caption") ? cap.get("caption").asText("") : "";
+            if (pageNum >= 0 && objectId >= 0 && !caption.isEmpty()) {
+                map.put(pageNum + ":" + objectId, caption);
+            }
+        }
+        return map;
+    }
+
+    private Map<Integer, JsonNode> extractTablePages(JsonNode tableResult) {
+        Map<Integer, JsonNode> map = new HashMap<>();
+        if (tableResult == null) return map;
+
+        for (JsonNode page : extractPages(tableResult)) {
+            int pageNum = page.has("page_number") ? page.get("page_number").asInt() : -1;
+            if (pageNum >= 0) {
+                map.put(pageNum, page);
+            }
+        }
+        return map;
+    }
+
+    // --- Helper: page height ---
+
+    private double getPageHeight(int pageNumber, Map<Integer, Double> pageHeights, JsonNode page) {
+        // pageHeights uses 1-indexed keys
+        Double h = pageHeights != null ? pageHeights.get(pageNumber + 1) : null;
+        if (h != null) return h;
+
+        // Derive from image dimensions (API renders at 300 DPI)
+        if (page.has("image_height")) {
+            return page.get("image_height").asDouble() * PIXEL_TO_POINT;
+        }
+        return 842.0; // A4 default
+    }
+
+    // --- Helper: coordinate conversion ---
+
+    /**
+     * Converts from Hancom AI pixel coordinates [left, top, right, bottom] (TOPLEFT origin, 300 DPI)
+     * to OpenDataLoader PDF points (BOTTOMLEFT origin, 72 DPI).
+     */
+    private BoundingBox extractBoundingBox(JsonNode bboxNode, int pageIndex, double pageHeight) {
+        double pixLeft = bboxNode.get(0).asDouble();
+        double pixTop = bboxNode.get(1).asDouble();
+        double pixRight = bboxNode.get(2).asDouble();
+        double pixBottom = bboxNode.get(3).asDouble();
+
+        // Pixel → PDF points
+        double left = pixLeft * PIXEL_TO_POINT;
+        double right = pixRight * PIXEL_TO_POINT;
+
+        // TOPLEFT → BOTTOMLEFT
+        double topY = pageHeight - (pixTop * PIXEL_TO_POINT);
+        double bottomY = pageHeight - (pixBottom * PIXEL_TO_POINT);
+
+        return new BoundingBox(pageIndex, left, bottomY, right, topY);
+    }
+
+    // --- Helper: IObject creation ---
+
+    private SemanticParagraph createParagraph(String text, BoundingBox bbox) {
+        TextChunk textChunk = new TextChunk(bbox, text, 12.0, 12.0);
+        textChunk.adjustSymbolEndsToBoundingBox(null);
+        TextLine textLine = new TextLine(textChunk);
+
+        SemanticParagraph paragraph = new SemanticParagraph();
+        paragraph.add(textLine);
+        paragraph.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+        paragraph.setCorrectSemanticScore(1.0);
+        return paragraph;
+    }
+
+    private SemanticHeading createHeading(String text, BoundingBox bbox, int level) {
+        TextChunk textChunk = new TextChunk(bbox, text, 12.0, 12.0);
+        textChunk.adjustSymbolEndsToBoundingBox(null);
+        TextLine textLine = new TextLine(textChunk);
+
+        SemanticHeading heading = new SemanticHeading();
+        heading.add(textLine);
+        heading.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+        heading.setHeadingLevel(level);
+        heading.setCorrectSemanticScore(1.0);
+        return heading;
+    }
+
+    private SemanticPicture createPicture(BoundingBox bbox, String caption) {
+        SemanticPicture picture = new SemanticPicture(bbox, ++pictureIndex, caption);
+        picture.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+        return picture;
+    }
+
+    private SemanticFormula createFormula(String text, BoundingBox bbox) {
+        SemanticFormula formula = new SemanticFormula(bbox, text);
+        formula.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+        return formula;
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -103,9 +103,25 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     // DPI conversion: API renders at 300 DPI, PDF uses 72 DPI
     private static final double PIXEL_TO_POINT = 72.0 / 300.0;
 
+    // Minimum intersection-over-word-area ratio for bbox matching
+    private static final double WORD_CELL_OVERLAP_THRESHOLD = 0.5;
+
     // Bullet/number prefix pattern for list items
     private static final Pattern BULLET_PREFIX_PATTERN = Pattern.compile(
         "^(\u2022|\u2013|\u2014|-|\\d+[.)::]|[a-zA-Z][.):])(\\s+)");
+
+    /**
+     * Holds text and bounding box for a DLA+OCR word-level object.
+     */
+    private static class WordInfo {
+        final String text;
+        final BoundingBox bbox;
+
+        WordInfo(String text, BoundingBox bbox) {
+            this.text = text;
+            this.bbox = bbox;
+        }
+    }
 
     private int pictureIndex;
 
@@ -149,6 +165,9 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         // Collect all heading heights (label 1 and 4) across all pages for level inference
         Map<Double, Integer> headingHeightToLevel = buildHeadingHeightToLevelMap(dlaPages);
 
+        // Collect per-page word info for cell-word bbox matching
+        Map<Integer, List<WordInfo>> wordsByPage = collectWordsByPage(dlaPages, pageHeights);
+
         // Process DLA+OCR objects
         for (int i = 0; i < dlaPages.size(); i++) {
             JsonNode page = dlaPages.get(i);
@@ -174,7 +193,8 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             // Add table from TABLE_STRUCTURE_RECOGNITION if available
             JsonNode tablePage = tableByPage.get(pageNumber);
             if (tablePage != null && tablePage.has("num_cells") && tablePage.get("num_cells").asInt() > 0) {
-                IObject table = transformTablePage(tablePage, pageNumber, pageHeight);
+                List<WordInfo> pageWords = wordsByPage.getOrDefault(pageNumber, Collections.emptyList());
+                IObject table = transformTablePage(tablePage, pageNumber, pageHeight, pageWords);
                 if (table != null) {
                     result.get(pageNumber).add(table);
                 }
@@ -276,8 +296,12 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
     /**
      * Transforms a TABLE_STRUCTURE_RECOGNITION page result to a TableBorder.
+     * Uses bbox intersection matching between TSR cells and DLA+OCR words to determine cell content.
+     *
+     * @param pageWords DLA+OCR word-level objects from the page for bbox matching
      */
-    private IObject transformTablePage(JsonNode tablePage, int pageIndex, double pageHeight) {
+    private IObject transformTablePage(JsonNode tablePage, int pageIndex, double pageHeight,
+                                        List<WordInfo> pageWords) {
         JsonNode cellsNode = tablePage.get("cells");
         if (cellsNode == null || !cellsNode.isArray() || cellsNode.size() == 0) {
             return null;
@@ -330,24 +354,41 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             }
         }
 
-        // Fill cells from API
+        // Fill cells from API with bbox-matched word content
         for (JsonNode cellNode : cellsNode) {
             int row = cellNode.has("row") ? cellNode.get("row").asInt() : 0;
             int col = cellNode.has("col") ? cellNode.get("col").asInt() : 0;
             int rowspan = cellNode.has("rowspan") ? cellNode.get("rowspan").asInt() : 1;
             int colspan = cellNode.has("colspan") ? cellNode.get("colspan").asInt() : 1;
-            String cellText = cellNode.has("text") ? cellNode.get("text").asText("") : "";
 
             if (row < numRows && col < numCols) {
                 TableBorderCell cell = new TableBorderCell(row, col, rowspan, colspan, 0L);
-                double cellLeft = tableBbox.getLeftX() + col * colWidth;
-                double cellRight = cellLeft + colspan * colWidth;
-                double cellTop = tableBbox.getTopY() - row * rowHeight;
-                double cellBottom = cellTop - rowspan * rowHeight;
-                cell.setBoundingBox(new BoundingBox(pageIndex, cellLeft, cellBottom, cellRight, cellTop));
 
-                if (!cellText.isEmpty()) {
-                    cell.addContentObject(createParagraph(cellText, cell.getBoundingBox()));
+                // Compute cell bbox: use TSR cell bbox if available, otherwise fall back to grid
+                BoundingBox cellBbox;
+                JsonNode cellBboxNode = cellNode.get("bbox");
+                if (cellBboxNode != null && cellBboxNode.isArray() && cellBboxNode.size() >= 4) {
+                    cellBbox = extractBoundingBox(cellBboxNode, pageIndex, pageHeight);
+                } else {
+                    double cellLeft = tableBbox.getLeftX() + col * colWidth;
+                    double cellRight = cellLeft + colspan * colWidth;
+                    double cellTop = tableBbox.getTopY() - row * rowHeight;
+                    double cellBottom = cellTop - rowspan * rowHeight;
+                    cellBbox = new BoundingBox(pageIndex, cellLeft, cellBottom, cellRight, cellTop);
+                }
+                cell.setBoundingBox(cellBbox);
+
+                // Match words to this cell via bbox intersection
+                String matchedText = matchWordsToCell(cellBbox, pageWords);
+
+                // Fallback to TSR text field if no words matched
+                if (matchedText.isEmpty()) {
+                    String tsrText = cellNode.has("text") ? cellNode.get("text").asText("") : "";
+                    if (!tsrText.isEmpty()) {
+                        cell.addContentObject(createParagraph(tsrText, cellBbox));
+                    }
+                } else {
+                    cell.addContentObject(createParagraph(matchedText, cellBbox));
                 }
 
                 table.getRows()[row].getCells()[col] = cell;
@@ -355,6 +396,113 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         }
 
         return table;
+    }
+
+    // --- Helper: cell-word bbox matching ---
+
+    /**
+     * Collects per-page word info (text + bbox in PDF points) from all DLA+OCR objects.
+     * Excludes furniture labels (14, 15, 17) and objects without text.
+     */
+    private Map<Integer, List<WordInfo>> collectWordsByPage(List<JsonNode> dlaPages,
+                                                             Map<Integer, Double> pageHeights) {
+        Map<Integer, List<WordInfo>> wordsByPage = new HashMap<>();
+
+        for (int i = 0; i < dlaPages.size(); i++) {
+            JsonNode page = dlaPages.get(i);
+            int pageNumber = page.has("page_number") ? page.get("page_number").asInt() : i;
+            double pageHeight = getPageHeight(pageNumber, pageHeights, page);
+
+            JsonNode objects = page.get("objects");
+            if (objects == null || !objects.isArray()) continue;
+
+            List<WordInfo> words = new ArrayList<>();
+            for (JsonNode obj : objects) {
+                int label = obj.has("label") ? obj.get("label").asInt() : -1;
+                // Skip furniture labels
+                if (label == LABEL_PAGE_HEADER || label == LABEL_PAGE_FOOTER || label == LABEL_PAGE_NUMBER) {
+                    continue;
+                }
+
+                String text = obj.has("ocrtext") ? obj.get("ocrtext").asText("") : "";
+                if (text.isEmpty()) continue;
+
+                JsonNode bboxNode = obj.get("bbox");
+                if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) continue;
+
+                BoundingBox bbox = extractBoundingBox(bboxNode, pageNumber, pageHeight);
+                words.add(new WordInfo(text, bbox));
+            }
+
+            if (!words.isEmpty()) {
+                wordsByPage.put(pageNumber, words);
+            }
+        }
+
+        return wordsByPage;
+    }
+
+    /**
+     * Matches DLA+OCR words to a cell by bbox intersection.
+     * A word belongs to a cell if intersection_area / word_area > 0.5.
+     * Matched words are sorted by reading order (top-to-bottom, left-to-right) and joined with space.
+     *
+     * @return joined text of matched words, or empty string if no matches
+     */
+    private String matchWordsToCell(BoundingBox cellBbox, List<WordInfo> pageWords) {
+        if (pageWords == null || pageWords.isEmpty()) {
+            return "";
+        }
+
+        List<WordInfo> matched = new ArrayList<>();
+        for (WordInfo word : pageWords) {
+            double wordArea = bboxArea(word.bbox);
+            if (wordArea <= 0) continue;
+
+            double intersection = bboxIntersectionArea(cellBbox, word.bbox);
+            if (intersection / wordArea > WORD_CELL_OVERLAP_THRESHOLD) {
+                matched.add(word);
+            }
+        }
+
+        if (matched.isEmpty()) {
+            return "";
+        }
+
+        // Sort by reading order: top-to-bottom (descending topY), then left-to-right
+        matched.sort((a, b) -> {
+            int cmp = Double.compare(b.bbox.getTopY(), a.bbox.getTopY()); // higher topY = higher on page
+            if (cmp != 0) return cmp;
+            return Double.compare(a.bbox.getLeftX(), b.bbox.getLeftX());
+        });
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < matched.size(); i++) {
+            if (i > 0) sb.append(' ');
+            sb.append(matched.get(i).text);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Computes the intersection area of two bounding boxes (both in PDF points, bottom-left origin).
+     */
+    private double bboxIntersectionArea(BoundingBox a, BoundingBox b) {
+        double left = Math.max(a.getLeftX(), b.getLeftX());
+        double right = Math.min(a.getRightX(), b.getRightX());
+        double bottom = Math.max(a.getBottomY(), b.getBottomY());
+        double top = Math.min(a.getTopY(), b.getTopY());
+        if (left >= right || bottom >= top) return 0.0;
+        return (right - left) * (top - bottom);
+    }
+
+    /**
+     * Computes the area of a bounding box.
+     */
+    private double bboxArea(BoundingBox b) {
+        double w = b.getRightX() - b.getLeftX();
+        double h = b.getTopY() - b.getBottomY();
+        return (w > 0 && h > 0) ? w * h : 0.0;
     }
 
     // --- Helper: heading level inference ---

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -131,6 +131,12 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
     private int pictureIndex;
     private String regionlistStrategy = HybridConfig.REGIONLIST_TABLE_FIRST;
+    private Map<Long, ElementMetadata> elementMetadataMap = new LinkedHashMap<>();
+
+    @Override
+    public Map<Long, ElementMetadata> getElementMetadata() {
+        return Collections.unmodifiableMap(elementMetadataMap);
+    }
 
     /**
      * Sets the regionlist strategy for label 7 handling.
@@ -164,6 +170,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         }
 
         pictureIndex = 0;
+        elementMetadataMap.clear();
 
         // Get DLA+OCR results (primary source for layout + text)
         JsonNode dlaOcr = json.get("DOCUMENT_LAYOUT_WITH_OCR");
@@ -403,6 +410,44 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             ((SemanticNode) iobj).setCorrectSemanticScore(confidence);
         }
 
+        // Produce ElementMetadata for this IObject
+        if (iobj != null && iobj.getRecognizedStructureId() != null) {
+            double confidence = obj.has("confidence") ? obj.get("confidence").asDouble(1.0) : 1.0;
+            ElementMetadata meta = new ElementMetadata()
+                .setConfidence(confidence)
+                .setSourceLabel(label);
+
+            if (label == LABEL_HEADING || label == LABEL_SUBHEADING) {
+                double pixelHeight = bboxNode.get(3).asDouble() - bboxNode.get(1).asDouble();
+                meta.setHeadingInferenceMethod("bbox-height")
+                    .setBboxHeightPx(pixelHeight);
+            } else if (label == LABEL_TITLE) {
+                meta.setHeadingInferenceMethod("fixed");
+            } else if (label == LABEL_FIGURE) {
+                int objectId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
+                String key = pageIndex + ":" + objectId;
+                String captionText = figureCaptionMap.get(key);
+                if (captionText != null) {
+                    ElementMetadata.CaptionMetadata capMeta = new ElementMetadata.CaptionMetadata();
+                    capMeta.setText(captionText);
+                    capMeta.setLanguage(detectLanguage(captionText));
+                    meta.setCaption(capMeta);
+                }
+            } else if (label == LABEL_REGIONLIST) {
+                ElementMetadata.RegionlistResolution rlRes = new ElementMetadata.RegionlistResolution();
+                rlRes.setStrategy(regionlistStrategy);
+                if (HybridConfig.REGIONLIST_LIST_ONLY.equals(regionlistStrategy)) {
+                    rlRes.setTsrAttempted(false);
+                } else {
+                    rlRes.setTsrAttempted(true);
+                    rlRes.setTsrResult(hasOverlappingTsr(bbox, tsrTableBboxes) ? "success" : "no-cells");
+                }
+                meta.setRegionlistResolution(rlRes);
+            }
+
+            elementMetadataMap.put(iobj.getRecognizedStructureId(), meta);
+        }
+
         return iobj;
     }
 
@@ -576,6 +621,18 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 table.getRows()[startRow].getCells()[startCol] = cell;
             }
         }
+
+        // Produce ElementMetadata for the table
+        ElementMetadata tableMeta = new ElementMetadata()
+            .setSourceLabel(tableEntry.has("label") ? tableEntry.get("label").asInt() : LABEL_TABLE);
+        if (tsr != null) {
+            ElementMetadata.TsrMetadata tsrMeta = new ElementMetadata.TsrMetadata();
+            tsrMeta.setNumCells(tsr.has("num_cells") ? tsr.get("num_cells").asInt() : 0);
+            tsrMeta.setHtml(tsr.has("html") ? tsr.get("html").asText("") : "");
+            tsrMeta.setRunTimeMs(tsr.has("run_time") ? tsr.get("run_time").asLong() : 0);
+            tableMeta.setTsr(tsrMeta);
+        }
+        elementMetadataMap.put(table.getRecognizedStructureId(), tableMeta);
 
         return table;
     }
@@ -1063,6 +1120,24 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         }
 
         return list;
+    }
+
+    /**
+     * Simple language detection heuristic: if the text contains any CJK character, returns "ko";
+     * otherwise returns "en".
+     */
+    static String detectLanguage(String text) {
+        if (text == null) return "en";
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL
+                || Character.UnicodeScript.of(c) == Character.UnicodeScript.HAN
+                || Character.UnicodeScript.of(c) == Character.UnicodeScript.HIRAGANA
+                || Character.UnicodeScript.of(c) == Character.UnicodeScript.KATAKANA) {
+                return "ko";
+            }
+        }
+        return "en";
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -129,6 +129,25 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     }
 
     private int pictureIndex;
+    private String regionlistStrategy = HybridConfig.REGIONLIST_TABLE_FIRST;
+
+    /**
+     * Sets the regionlist strategy for label 7 handling.
+     *
+     * @param regionlistStrategy the strategy ("table-first" or "list-only")
+     */
+    public void setRegionlistStrategy(String regionlistStrategy) {
+        this.regionlistStrategy = regionlistStrategy;
+    }
+
+    /**
+     * Gets the regionlist strategy.
+     *
+     * @return the current regionlist strategy
+     */
+    public String getRegionlistStrategy() {
+        return regionlistStrategy;
+    }
 
     @Override
     public String getBackendType() {
@@ -307,10 +326,15 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 break;
 
             case LABEL_TABLE:
-                // Table region detected by DLA — if TSR covers it, skip (table handled separately)
-                if (hasOverlappingTsr(bbox, tsrTableBboxes)) return null;
-                // No TSR data — treat as list (parse text by newlines into ListItems)
-                iobj = text.isEmpty() ? null : createListFromText(text, bbox);
+                if (HybridConfig.REGIONLIST_LIST_ONLY.equals(regionlistStrategy)) {
+                    // list-only: always treat as list, skip TSR check
+                    iobj = text.isEmpty() ? null : createListFromText(text, bbox);
+                } else {
+                    // table-first (default): if TSR covers it, skip (table handled separately)
+                    if (hasOverlappingTsr(bbox, tsrTableBboxes)) return null;
+                    // No TSR data — treat as list (parse text by newlines into ListItems)
+                    iobj = text.isEmpty() ? null : createListFromText(text, bbox);
+                }
                 break;
 
             case LABEL_FIGURE:

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -641,7 +641,13 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
     /**
      * Collects per-page word info (text + bbox in PDF points) from all DLA+OCR objects.
-     * Excludes furniture labels (14, 15, 17) and objects without text.
+     * Uses individual word-level entries from the {@code words[]} array when available,
+     * falling back to object-level ocrtext + bbox otherwise.
+     * Excludes furniture labels (14, 15, 17).
+     *
+     * <p>Word-level collection is critical for table cell-word bbox matching:
+     * object-level bbox covers the entire table, but individual word bboxes
+     * can be matched to specific cells.
      */
     private Map<Integer, List<WordInfo>> collectWordsByPage(List<JsonNode> dlaPages,
                                                              Map<Integer, Double> pageHeights) {
@@ -663,14 +669,34 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                     continue;
                 }
 
-                String text = obj.has("ocrtext") ? obj.get("ocrtext").asText("") : "";
-                if (text.isEmpty()) continue;
+                // Prefer individual words from words[] array (each has its own bbox)
+                JsonNode wordsArr = obj.get("words");
+                if (wordsArr != null && wordsArr.isArray() && wordsArr.size() > 0) {
+                    for (JsonNode word : wordsArr) {
+                        String wordText = word.has("text") ? word.get("text").asText("") : "";
+                        if (wordText.isEmpty()) continue;
 
-                JsonNode bboxNode = obj.get("bbox");
-                if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) continue;
+                        JsonNode wordBbox = word.get("bbox");
+                        if (wordBbox == null || !wordBbox.isArray() || wordBbox.size() < 4) continue;
 
-                BoundingBox bbox = extractBoundingBox(bboxNode, pageNumber, pageHeight);
-                words.add(new WordInfo(text, bbox));
+                        // Word bbox is 8-point polygon [x1,y1,x2,y2,x3,y3,x4,y4] or 4-point [l,t,r,b]
+                        // Convert to [left, top, right, bottom] in 300DPI pixels
+                        double[] ltrb = wordBboxToLTRB(wordBbox);
+                        JsonNode syntheticBbox = createBboxNode(ltrb);
+                        BoundingBox bbox = extractBoundingBox(syntheticBbox, pageNumber, pageHeight);
+                        words.add(new WordInfo(wordText, bbox));
+                    }
+                } else {
+                    // Fallback: use object-level ocrtext + bbox
+                    String text = obj.has("ocrtext") ? obj.get("ocrtext").asText("") : "";
+                    if (text.isEmpty()) continue;
+
+                    JsonNode bboxNode = obj.get("bbox");
+                    if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) continue;
+
+                    BoundingBox bbox = extractBoundingBox(bboxNode, pageNumber, pageHeight);
+                    words.add(new WordInfo(text, bbox));
+                }
             }
 
             if (!words.isEmpty()) {
@@ -679,6 +705,40 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         }
 
         return wordsByPage;
+    }
+
+    /**
+     * Converts word bbox from 8-point polygon [x1,y1,x2,y2,x3,y3,x4,y4] or
+     * 4-point [left,top,right,bottom] to [left, top, right, bottom].
+     */
+    private static double[] wordBboxToLTRB(JsonNode wordBbox) {
+        if (wordBbox.size() >= 8) {
+            // 8-point polygon: find min/max of x and y coordinates
+            double minX = Double.MAX_VALUE, minY = Double.MAX_VALUE;
+            double maxX = Double.MIN_VALUE, maxY = Double.MIN_VALUE;
+            for (int j = 0; j < wordBbox.size(); j += 2) {
+                double x = wordBbox.get(j).asDouble();
+                double y = wordBbox.get(j + 1).asDouble();
+                minX = Math.min(minX, x);
+                minY = Math.min(minY, y);
+                maxX = Math.max(maxX, x);
+                maxY = Math.max(maxY, y);
+            }
+            return new double[]{minX, minY, maxX, maxY};
+        } else {
+            // 4-point: [left, top, right, bottom]
+            return new double[]{
+                wordBbox.get(0).asDouble(), wordBbox.get(1).asDouble(),
+                wordBbox.get(2).asDouble(), wordBbox.get(3).asDouble()
+            };
+        }
+    }
+
+    private JsonNode createBboxNode(double[] ltrb) {
+        com.fasterxml.jackson.databind.node.ArrayNode arr =
+            new com.fasterxml.jackson.databind.ObjectMapper().createArrayNode();
+        for (double v : ltrb) arr.add(v);
+        return arr;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -399,7 +399,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 break;
 
             case LABEL_TABLE:
-                // Table regions are handled separately by transformTablePage() via TSR
+                // Table regions are handled separately by transformTableEntry() via TSR
                 return null;
 
             case LABEL_FIGURE: {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -16,6 +16,9 @@
 package org.opendataloader.pdf.hybrid;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
 import org.opendataloader.pdf.entities.SemanticFootnote;
@@ -324,11 +327,28 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
     @Override
     public List<IObject> transformPage(int pageNumber, JsonNode pageContent, double pageHeight) {
+        int idx = pageNumber - 1;
         Map<Integer, Double> heights = new HashMap<>();
         heights.put(pageNumber, pageHeight);
-        HybridResponse wrapper = new HybridResponse("", pageContent, Collections.emptyMap());
+
+        // transform() consumes the merged Hancom shape keyed by DOCUMENT_LAYOUT_WITH_OCR.
+        // When the caller passes a raw single-page DLA node (no wrapper), rewrap it so
+        // extractPages() can find it; otherwise transform() sees no pages and returns empty.
+        JsonNode wrapped = pageContent;
+        if (pageContent != null && pageContent.get("DOCUMENT_LAYOUT_WITH_OCR") == null) {
+            ObjectNode page = pageContent.isObject()
+                ? ((ObjectNode) pageContent).deepCopy()
+                : JsonNodeFactory.instance.objectNode();
+            page.put("page_number", idx);
+            ArrayNode pages = JsonNodeFactory.instance.arrayNode();
+            pages.add(page);
+            ObjectNode root = JsonNodeFactory.instance.objectNode();
+            root.set("DOCUMENT_LAYOUT_WITH_OCR", pages);
+            wrapped = root;
+        }
+
+        HybridResponse wrapper = new HybridResponse("", wrapped, Collections.emptyMap());
         List<List<IObject>> all = transform(wrapper, heights);
-        int idx = pageNumber - 1;
         if (idx >= 0 && idx < all.size()) return all.get(idx);
         return all.isEmpty() ? Collections.emptyList() : all.get(0);
     }
@@ -1208,6 +1228,21 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     private PDFList buildPDFList(List<ListItem> items) {
         PDFList list = new PDFList();
         list.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+
+        // Carry forward item-level metadata to the new PDFList ID. DocumentProcessor
+        // .remapMetadataToContents() keys on top-level content IDs, and grouping
+        // replaces top-level ListItems with this PDFList — without this copy, the
+        // list's source label / confidence / regionlist-resolution provenance is
+        // dropped from the final JSON.
+        if (!items.isEmpty()) {
+            Long firstItemId = items.get(0).getRecognizedStructureId();
+            ElementMetadata firstItemMeta = firstItemId != null
+                ? elementMetadataMap.get(firstItemId)
+                : null;
+            if (firstItemMeta != null) {
+                elementMetadataMap.put(list.getRecognizedStructureId(), firstItemMeta);
+            }
+        }
 
         double minLeft = Double.MAX_VALUE;
         double minBottom = Double.MAX_VALUE;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -38,6 +38,7 @@ import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
@@ -183,8 +184,45 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         // Build per-figure caption lookup: "pageNum:objectId" → caption
         Map<String, String> figureCaptionMap = buildFigureCaptionMap(figureCaptions);
 
-        // Map table structures by page number
-        Map<Integer, JsonNode> tableByPage = extractTablePages(tables);
+        // Build map: page_number -> list of TSR table entries
+        // New format: TSR is an ArrayNode of per-table entries with dla_bbox + tsr sub-object
+        Map<Integer, List<JsonNode>> tablesByPage = new LinkedHashMap<>();
+        JsonNode tsrArray = json.get("TABLE_STRUCTURE_RECOGNITION");
+        if (tsrArray != null && tsrArray.isArray()) {
+            // Check if this is new format (array of table entries with "tsr" sub-object)
+            // or old format (nested array of pages with "cells" directly)
+            boolean isNewFormat = false;
+            if (tsrArray.size() > 0) {
+                JsonNode first = tsrArray.get(0);
+                isNewFormat = first.isObject() && (first.has("tsr") || first.has("dla_bbox"));
+            }
+
+            if (isNewFormat) {
+                for (JsonNode entry : tsrArray) {
+                    int pageNum = entry.has("page_number") ? entry.get("page_number").asInt() : -1;
+                    if (pageNum >= 0) {
+                        tablesByPage.computeIfAbsent(pageNum, k -> new ArrayList<>()).add(entry);
+                    }
+                }
+            } else {
+                // Legacy format: extract pages and wrap each in a synthetic entry
+                Map<Integer, JsonNode> legacyTableByPage = extractTablePages(tsrArray);
+                for (Map.Entry<Integer, JsonNode> e : legacyTableByPage.entrySet()) {
+                    JsonNode legacyPage = e.getValue();
+                    // Wrap legacy page as a table entry with tsr = the page itself
+                    // and dla_bbox derived from table_bbox (page-level coords in legacy format)
+                    com.fasterxml.jackson.databind.node.ObjectNode syntheticEntry =
+                        new com.fasterxml.jackson.databind.ObjectMapper().createObjectNode();
+                    syntheticEntry.put("page_number", e.getKey());
+                    JsonNode legacyTableBbox = legacyPage.get("table_bbox");
+                    if (legacyTableBbox != null) {
+                        syntheticEntry.set("dla_bbox", legacyTableBbox);
+                    }
+                    syntheticEntry.set("tsr", legacyPage);
+                    tablesByPage.computeIfAbsent(e.getKey(), k -> new ArrayList<>()).add(syntheticEntry);
+                }
+            }
+        }
 
         // Collect all heading heights (label 1 and 4) across all pages for level inference
         Map<Double, Integer> headingHeightToLevel = buildHeadingHeightToLevelMap(dlaPages);
@@ -203,12 +241,13 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             double pageHeight = getPageHeight(pageNumber, pageHeights, page);
 
             // Collect TSR table bboxes for this page (used by label 7 overlap check)
+            // Use dla_bbox (page-level coords) for overlap check, not tsr.table_bbox (crop-relative)
             List<BoundingBox> tsrTableBboxes = new ArrayList<>();
-            JsonNode tsrPage = tableByPage.get(pageNumber);
-            if (tsrPage != null) {
-                JsonNode tBbox = tsrPage.get("table_bbox");
-                if (tBbox != null && tBbox.isArray() && tBbox.size() >= 4) {
-                    tsrTableBboxes.add(extractBoundingBox(tBbox, pageNumber, pageHeight));
+            List<JsonNode> pageTables = tablesByPage.getOrDefault(pageNumber, Collections.emptyList());
+            for (JsonNode tableEntry : pageTables) {
+                JsonNode dlaBbox = tableEntry.get("dla_bbox");
+                if (dlaBbox != null && dlaBbox.isArray() && dlaBbox.size() >= 4) {
+                    tsrTableBboxes.add(extractBoundingBox(dlaBbox, pageNumber, pageHeight));
                 }
             }
 
@@ -224,11 +263,10 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 }
             }
 
-            // Add table from TABLE_STRUCTURE_RECOGNITION if available
-            JsonNode tablePage = tableByPage.get(pageNumber);
-            if (tablePage != null && tablePage.has("num_cells") && tablePage.get("num_cells").asInt() > 0) {
-                List<WordInfo> pageWords = wordsByPage.getOrDefault(pageNumber, Collections.emptyList());
-                IObject table = transformTablePage(tablePage, pageNumber, pageHeight, pageWords);
+            // Add tables from TABLE_STRUCTURE_RECOGNITION if available
+            List<WordInfo> pageWords = wordsByPage.getOrDefault(pageNumber, Collections.emptyList());
+            for (JsonNode tableEntry : pageTables) {
+                IObject table = transformTableEntry(tableEntry, pageNumber, pageHeight, pageWords);
                 if (table != null) {
                     result.get(pageNumber).add(table);
                 }
@@ -369,36 +407,72 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     }
 
     /**
-     * Transforms a TABLE_STRUCTURE_RECOGNITION page result to a TableBorder.
-     * Uses bbox intersection matching between TSR cells and DLA+OCR words to determine cell content.
+     * Transforms a single TSR table entry to a TableBorder.
+     * Accepts the new per-table entry format with {@code dla_bbox} (crop origin in page pixels)
+     * and {@code tsr} sub-object containing cells with array-format rowspan/colspan.
      *
+     * <p>Cell bboxes are relative to the crop image. They are converted to page-level coordinates
+     * by adding the crop origin ({@code dla_bbox} left/top).
+     *
+     * @param tableEntry a TSR table entry with {@code dla_bbox} and {@code tsr} fields
      * @param pageWords DLA+OCR word-level objects from the page for bbox matching
      */
-    private IObject transformTablePage(JsonNode tablePage, int pageIndex, double pageHeight,
-                                        List<WordInfo> pageWords) {
-        JsonNode cellsNode = tablePage.get("cells");
+    private IObject transformTableEntry(JsonNode tableEntry, int pageIndex, double pageHeight,
+                                         List<WordInfo> pageWords) {
+        JsonNode tsr = tableEntry.get("tsr");
+        if (tsr == null || tsr.isEmpty()) return null;
+
+        JsonNode cellsNode = tsr.get("cells");
         if (cellsNode == null || !cellsNode.isArray() || cellsNode.size() == 0) {
             return null;
         }
 
-        JsonNode tableBboxNode = tablePage.get("table_bbox");
-        BoundingBox tableBbox;
-        if (tableBboxNode != null && tableBboxNode.isArray() && tableBboxNode.size() >= 4) {
-            tableBbox = extractBoundingBox(tableBboxNode, pageIndex, pageHeight);
-        } else {
-            return null;
+        // DLA bbox = crop origin in page pixels (300DPI, top-left origin)
+        JsonNode dlaBbox = tableEntry.get("dla_bbox");
+        double cropOriginLeft = 0;
+        double cropOriginTop = 0;
+        if (dlaBbox != null && dlaBbox.isArray() && dlaBbox.size() >= 4) {
+            cropOriginLeft = dlaBbox.get(0).asDouble();
+            cropOriginTop = dlaBbox.get(1).asDouble();
         }
 
-        // Determine dimensions
+        // Compute table bbox in page coordinates from dla_bbox
+        BoundingBox tableBbox;
+        if (dlaBbox != null && dlaBbox.isArray() && dlaBbox.size() >= 4) {
+            tableBbox = extractBoundingBox(dlaBbox, pageIndex, pageHeight);
+        } else {
+            // Fallback: use tsr.table_bbox offset by crop origin
+            JsonNode tsrTableBbox = tsr.get("table_bbox");
+            if (tsrTableBbox != null && tsrTableBbox.isArray() && tsrTableBbox.size() >= 4) {
+                tableBbox = extractBoundingBox(tsrTableBbox, pageIndex, pageHeight);
+            } else {
+                return null;
+            }
+        }
+
+        // Determine dimensions from array rowspan/colspan
         int numRows = 0;
         int numCols = 0;
         for (JsonNode cell : cellsNode) {
-            int row = cell.has("row") ? cell.get("row").asInt() : 0;
-            int col = cell.has("col") ? cell.get("col").asInt() : 0;
-            int rowspan = cell.has("rowspan") ? cell.get("rowspan").asInt() : 1;
-            int colspan = cell.has("colspan") ? cell.get("colspan").asInt() : 1;
-            numRows = Math.max(numRows, row + rowspan);
-            numCols = Math.max(numCols, col + colspan);
+            JsonNode rs = cell.get("rowspan");
+            JsonNode cs = cell.get("colspan");
+            if (rs != null && rs.isArray()) {
+                for (int i = 0; i < rs.size(); i++) {
+                    numRows = Math.max(numRows, rs.get(i).asInt() + 1);
+                }
+            } else if (rs != null && rs.isNumber()) {
+                // backward compat: integer format
+                int row = cell.has("row") ? cell.get("row").asInt() : 0;
+                numRows = Math.max(numRows, row + rs.asInt());
+            }
+            if (cs != null && cs.isArray()) {
+                for (int i = 0; i < cs.size(); i++) {
+                    numCols = Math.max(numCols, cs.get(i).asInt() + 1);
+                }
+            } else if (cs != null && cs.isNumber()) {
+                int col = cell.has("col") ? cell.get("col").asInt() : 0;
+                numCols = Math.max(numCols, col + cs.asInt());
+            }
         }
 
         if (numRows == 0 || numCols == 0) return null;
@@ -430,23 +504,57 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
         // Fill cells from API with bbox-matched word content
         for (JsonNode cellNode : cellsNode) {
-            int row = cellNode.has("row") ? cellNode.get("row").asInt() : 0;
-            int col = cellNode.has("col") ? cellNode.get("col").asInt() : 0;
-            int rowspan = cellNode.has("rowspan") ? cellNode.get("rowspan").asInt() : 1;
-            int colspan = cellNode.has("colspan") ? cellNode.get("colspan").asInt() : 1;
+            JsonNode rowspanArr = cellNode.get("rowspan");
+            JsonNode colspanArr = cellNode.get("colspan");
 
-            if (row < numRows && col < numCols) {
-                TableBorderCell cell = new TableBorderCell(row, col, rowspan, colspan, 0L);
+            int startRow, rowspan, startCol, colspan;
+
+            if (rowspanArr != null && rowspanArr.isArray() && rowspanArr.size() > 0) {
+                startRow = rowspanArr.get(0).asInt();
+                rowspan = rowspanArr.size();
+            } else if (rowspanArr != null && rowspanArr.isNumber()) {
+                // backward compat: integer format
+                startRow = cellNode.has("row") ? cellNode.get("row").asInt() : 0;
+                rowspan = rowspanArr.asInt();
+            } else {
+                startRow = 0;
+                rowspan = 1;
+            }
+
+            if (colspanArr != null && colspanArr.isArray() && colspanArr.size() > 0) {
+                startCol = colspanArr.get(0).asInt();
+                colspan = colspanArr.size();
+            } else if (colspanArr != null && colspanArr.isNumber()) {
+                startCol = cellNode.has("col") ? cellNode.get("col").asInt() : 0;
+                colspan = colspanArr.asInt();
+            } else {
+                startCol = 0;
+                colspan = 1;
+            }
+
+            if (startRow < numRows && startCol < numCols) {
+                TableBorderCell cell = new TableBorderCell(startRow, startCol, rowspan, colspan, 0L);
 
                 // Compute cell bbox: use TSR cell bbox if available, otherwise fall back to grid
                 BoundingBox cellBbox;
                 JsonNode cellBboxNode = cellNode.get("bbox");
                 if (cellBboxNode != null && cellBboxNode.isArray() && cellBboxNode.size() >= 4) {
-                    cellBbox = extractBoundingBox(cellBboxNode, pageIndex, pageHeight);
+                    // Convert cell bbox from crop coords to page coords by adding crop origin
+                    double pageCellLeft = cropOriginLeft + cellBboxNode.get(0).asDouble();
+                    double pageCellTop = cropOriginTop + cellBboxNode.get(1).asDouble();
+                    double pageCellRight = cropOriginLeft + cellBboxNode.get(2).asDouble();
+                    double pageCellBottom = cropOriginTop + cellBboxNode.get(3).asDouble();
+
+                    // Convert page pixels (300DPI, top-left) → PDF points (72DPI, bottom-left)
+                    double left = pageCellLeft * PIXEL_TO_POINT;
+                    double right = pageCellRight * PIXEL_TO_POINT;
+                    double topY = pageHeight - (pageCellTop * PIXEL_TO_POINT);
+                    double bottomY = pageHeight - (pageCellBottom * PIXEL_TO_POINT);
+                    cellBbox = new BoundingBox(pageIndex, left, bottomY, right, topY);
                 } else {
-                    double cellLeft = tableBbox.getLeftX() + col * colWidth;
+                    double cellLeft = tableBbox.getLeftX() + startCol * colWidth;
                     double cellRight = cellLeft + colspan * colWidth;
-                    double cellTop = tableBbox.getTopY() - row * rowHeight;
+                    double cellTop = tableBbox.getTopY() - startRow * rowHeight;
                     double cellBottom = cellTop - rowspan * rowHeight;
                     cellBbox = new BoundingBox(pageIndex, cellLeft, cellBottom, cellRight, cellTop);
                 }
@@ -465,7 +573,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                     cell.addContentObject(createParagraph(matchedText, cellBbox));
                 }
 
-                table.getRows()[row].getCells()[col] = cell;
+                table.getRows()[startRow].getCells()[startCol] = cell;
             }
         }
 
@@ -722,6 +830,10 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         return map;
     }
 
+    /**
+     * Extracts table pages from legacy TSR format (nested array).
+     * Used only for backward compatibility with old TSR format.
+     */
     private Map<Integer, JsonNode> extractTablePages(JsonNode tableResult) {
         Map<Integer, JsonNode> map = new HashMap<>();
         if (tableResult == null) return map;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -21,6 +21,7 @@ import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
 import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.SemanticCaption;
 import org.verapdf.wcag.algorithms.entities.SemanticHeading;
 import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
@@ -62,9 +63,10 @@ import java.util.regex.Pattern;
  *   4  → Subheading (SemanticHeading level 3)
  *   6  → Author/Meta (SemanticParagraph)
  *   7  → Table region (handled via TABLE_STRUCTURE_RECOGNITION)
+ *   8  → TableName (SemanticCaption linked to nearest Table)
  *   9  → Figure (SemanticPicture)
  *  10  → Figure with caption (SemanticPicture)
- *  11  → Caption (SemanticParagraph)
+ *  11  → FigureName (SemanticCaption linked to nearest Figure)
  *  12  → Formula (SemanticFormula)
  *  13  → Footnote (SemanticParagraph)
  *  14  → Page header (filtered)
@@ -91,6 +93,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     private static final int LABEL_SUBHEADING = 4;
     private static final int LABEL_AUTHOR = 6;
     private static final int LABEL_TABLE = 7;
+    private static final int LABEL_TABLE_NAME = 8;
     private static final int LABEL_FIGURE = 9;
     private static final int LABEL_FIGURE_CAPTION = 10;
     private static final int LABEL_CAPTION = 11;
@@ -219,6 +222,11 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             result.set(i, groupListItems(result.get(i)));
         }
 
+        // Post-process: link SemanticCaption objects to nearest Table/Picture
+        for (List<IObject> pageContents : result) {
+            linkCaptionsToFloats(pageContents);
+        }
+
         return result;
     }
 
@@ -267,10 +275,13 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             case LABEL_LIST_ITEM:
                 return text.isEmpty() ? null : createListItem(text, bbox);
 
+            case LABEL_TABLE_NAME:
+            case LABEL_CAPTION:
+                return text.isEmpty() ? null : createCaption(text, bbox);
+
             case LABEL_PARAGRAPH:
             case LABEL_AUTHOR:
             case LABEL_FOOTNOTE:
-            case LABEL_CAPTION:
                 return text.isEmpty() ? null : createParagraph(text, bbox);
 
             case LABEL_TABLE:
@@ -676,6 +687,17 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         return formula;
     }
 
+    private SemanticCaption createCaption(String text, BoundingBox bbox) {
+        TextChunk textChunk = new TextChunk(bbox, text, 12.0, 12.0);
+        textChunk.adjustSymbolEndsToBoundingBox(null);
+        TextLine textLine = new TextLine(textChunk);
+        SemanticCaption caption = new SemanticCaption();
+        caption.add(textLine);
+        caption.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+        caption.setCorrectSemanticScore(1.0);
+        return caption;
+    }
+
     private ListItem createListItem(String text, BoundingBox bbox) {
         TextChunk textChunk = new TextChunk(bbox, text, 12.0, 12.0);
         textChunk.adjustSymbolEndsToBoundingBox(null);
@@ -685,6 +707,52 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         item.add(textLine);
         item.setLabelLength(detectBulletPrefixLength(text));
         return item;
+    }
+
+    // --- Helper: caption-float linking post-processing ---
+
+    /**
+     * Links each {@link SemanticCaption} to the nearest Table or Picture on the same page
+     * by setting {@code linkedContentId} to the float's {@code recognizedStructureId}.
+     */
+    private void linkCaptionsToFloats(List<IObject> pageContents) {
+        List<SemanticCaption> captions = new ArrayList<>();
+        List<IObject> floats = new ArrayList<>();
+        for (IObject obj : pageContents) {
+            if (obj instanceof SemanticCaption) {
+                captions.add((SemanticCaption) obj);
+            }
+            if (obj instanceof TableBorder || obj instanceof SemanticPicture) {
+                floats.add(obj);
+            }
+        }
+        for (SemanticCaption cap : captions) {
+            IObject nearest = findNearestFloat(cap, floats);
+            if (nearest != null) {
+                cap.setLinkedContentId(nearest.getRecognizedStructureId());
+            }
+        }
+    }
+
+    /**
+     * Finds the float (Table or Picture) nearest to the caption by center Y distance.
+     */
+    private IObject findNearestFloat(SemanticCaption caption, List<IObject> floats) {
+        if (floats.isEmpty() || caption.getBoundingBox() == null) {
+            return null;
+        }
+        double captionCenterY = caption.getBoundingBox().getCenterY();
+        IObject nearest = null;
+        double minDist = Double.MAX_VALUE;
+        for (IObject f : floats) {
+            if (f.getBoundingBox() == null) continue;
+            double dist = Math.abs(f.getBoundingBox().getCenterY() - captionCenterY);
+            if (dist < minDist) {
+                minDist = dist;
+                nearest = f;
+            }
+        }
+        return nearest;
     }
 
     // --- Helper: list grouping post-processing ---

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -635,6 +635,20 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 }
 
                 table.getRows()[startRow].getCells()[startCol] = cell;
+
+                // Mark all positions covered by this cell's span with the same instance so the
+                // PDF emission loop in AutoTaggingProcessor.addTableRow (which skips slots where
+                // cell.getRowNumber()/getColNumber() don't match the current row/col) omits them.
+                // Otherwise the empty 1x1 placeholders at those slots would be emitted as TR
+                // children, producing rows whose effective column count exceeds the table's
+                // numCols — PDF/UA-2 clause 8.2.5.26 "Table rows shall have the same number of
+                // columns (taking into account column spans)".
+                for (int r = startRow; r < startRow + rowspan && r < numRows; r++) {
+                    for (int c = startCol; c < startCol + colspan && c < numCols; c++) {
+                        if (r == startRow && c == startCol) continue;
+                        table.getRows()[r].getCells()[c] = cell;
+                    }
+                }
             }
         }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -497,18 +497,27 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             cropOriginTop = dlaBbox.get(1).asDouble();
         }
 
-        // Compute table bbox in page coordinates from dla_bbox
+        // Compute table bbox in page coordinates. dla_bbox is the padded crop
+        // rectangle written by HancomAIClient (after TSR_CROP_PADDING expansion
+        // and image-bounds clamping), so using it directly inflates the table
+        // and its fallback grid cells by the padding. Prefer tsr.table_bbox
+        // (the table's true extent in crop-local coordinates) offset by the
+        // crop origin; fall back to padded dla_bbox only when TSR did not
+        // report its own table_bbox.
         BoundingBox tableBbox;
-        if (dlaBbox != null && dlaBbox.isArray() && dlaBbox.size() >= 4) {
+        JsonNode tsrTableBbox = tsr.get("table_bbox");
+        if (tsrTableBbox != null && tsrTableBbox.isArray() && tsrTableBbox.size() >= 4) {
+            double[] pageBbox = new double[] {
+                cropOriginLeft + tsrTableBbox.get(0).asDouble(),
+                cropOriginTop + tsrTableBbox.get(1).asDouble(),
+                cropOriginLeft + tsrTableBbox.get(2).asDouble(),
+                cropOriginTop + tsrTableBbox.get(3).asDouble()
+            };
+            tableBbox = extractBoundingBox(createBboxNode(pageBbox), pageIndex, pageHeight);
+        } else if (dlaBbox != null && dlaBbox.isArray() && dlaBbox.size() >= 4) {
             tableBbox = extractBoundingBox(dlaBbox, pageIndex, pageHeight);
         } else {
-            // Fallback: use tsr.table_bbox offset by crop origin
-            JsonNode tsrTableBbox = tsr.get("table_bbox");
-            if (tsrTableBbox != null && tsrTableBbox.isArray() && tsrTableBbox.size() >= 4) {
-                tableBbox = extractBoundingBox(tsrTableBbox, pageIndex, pageHeight);
-            } else {
-                return null;
-            }
+            return null;
         }
 
         // Determine dimensions from array rowspan/colspan

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -26,6 +26,8 @@ import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+import org.verapdf.wcag.algorithms.entities.lists.ListItem;
+import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
@@ -38,6 +40,8 @@ import java.util.Map;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Transforms Hancom AI HOCR SDK API responses into IObject hierarchy.
@@ -98,6 +102,10 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
     // DPI conversion: API renders at 300 DPI, PDF uses 72 DPI
     private static final double PIXEL_TO_POINT = 72.0 / 300.0;
+
+    // Bullet/number prefix pattern for list items
+    private static final Pattern BULLET_PREFIX_PATTERN = Pattern.compile(
+        "^(\u2022|\u2013|\u2014|-|\\d+[.)::]|[a-zA-Z][.):])(\\s+)");
 
     private int pictureIndex;
 
@@ -186,6 +194,11 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             });
         }
 
+        // Post-process: group consecutive ListItem objects into PDFList instances
+        for (int i = 0; i < result.size(); i++) {
+            result.set(i, groupListItems(result.get(i)));
+        }
+
         return result;
     }
 
@@ -231,8 +244,10 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 return createHeading(text, bbox, level);
             }
 
-            case LABEL_PARAGRAPH:
             case LABEL_LIST_ITEM:
+                return text.isEmpty() ? null : createListItem(text, bbox);
+
+            case LABEL_PARAGRAPH:
             case LABEL_AUTHOR:
             case LABEL_FOOTNOTE:
             case LABEL_CAPTION:
@@ -511,5 +526,94 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         SemanticFormula formula = new SemanticFormula(bbox, text);
         formula.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
         return formula;
+    }
+
+    private ListItem createListItem(String text, BoundingBox bbox) {
+        TextChunk textChunk = new TextChunk(bbox, text, 12.0, 12.0);
+        textChunk.adjustSymbolEndsToBoundingBox(null);
+        TextLine textLine = new TextLine(textChunk);
+
+        ListItem item = new ListItem(bbox, StaticLayoutContainers.incrementContentId());
+        item.add(textLine);
+        item.setLabelLength(detectBulletPrefixLength(text));
+        return item;
+    }
+
+    // --- Helper: list grouping post-processing ---
+
+    /**
+     * Groups consecutive {@link ListItem} objects into {@link PDFList} instances.
+     * Any non-ListItem object breaks the current run and starts a new list.
+     */
+    private List<IObject> groupListItems(List<IObject> pageContents) {
+        List<IObject> grouped = new ArrayList<>();
+        List<ListItem> currentRun = new ArrayList<>();
+
+        for (IObject obj : pageContents) {
+            if (obj instanceof ListItem) {
+                currentRun.add((ListItem) obj);
+            } else {
+                if (!currentRun.isEmpty()) {
+                    grouped.add(buildPDFList(currentRun));
+                    currentRun = new ArrayList<>();
+                }
+                grouped.add(obj);
+            }
+        }
+
+        // Flush remaining run
+        if (!currentRun.isEmpty()) {
+            grouped.add(buildPDFList(currentRun));
+        }
+
+        return grouped;
+    }
+
+    /**
+     * Builds a {@link PDFList} from a run of {@link ListItem} objects.
+     * Computes union bounding box and assigns a structure ID.
+     */
+    private PDFList buildPDFList(List<ListItem> items) {
+        PDFList list = new PDFList();
+        list.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+
+        double minLeft = Double.MAX_VALUE;
+        double minBottom = Double.MAX_VALUE;
+        double maxRight = -Double.MAX_VALUE;
+        double maxTop = -Double.MAX_VALUE;
+        int pageNumber = 0;
+
+        for (ListItem item : items) {
+            list.add(item);
+            BoundingBox itemBbox = item.getBoundingBox();
+            if (itemBbox != null) {
+                pageNumber = itemBbox.getPageNumber();
+                minLeft = Math.min(minLeft, itemBbox.getLeftX());
+                minBottom = Math.min(minBottom, itemBbox.getBottomY());
+                maxRight = Math.max(maxRight, itemBbox.getRightX());
+                maxTop = Math.max(maxTop, itemBbox.getTopY());
+            }
+        }
+
+        if (minLeft != Double.MAX_VALUE) {
+            list.setBoundingBox(new BoundingBox(pageNumber, minLeft, minBottom, maxRight, maxTop));
+        }
+
+        return list;
+    }
+
+    /**
+     * Detects bullet/number prefix in text and returns its length (including trailing space).
+     * Returns 0 if no bullet prefix is found.
+     */
+    static int detectBulletPrefixLength(String text) {
+        if (text == null || text.isEmpty()) {
+            return 0;
+        }
+        Matcher matcher = BULLET_PREFIX_PATTERN.matcher(text);
+        if (matcher.find()) {
+            return matcher.end();
+        }
+        return 0;
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -602,7 +602,20 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 colspan = 1;
             }
 
-            if (startRow < numRows && startCol < numCols) {
+            // Guard against malformed TSR JSON: negative indices or non-positive spans
+            // would otherwise crash TableBorderCell construction or index table.getRows()
+            // out of bounds below.
+            if (startRow < 0 || startCol < 0 || rowspan <= 0 || colspan <= 0
+                    || startRow >= numRows || startCol >= numCols) {
+                LOGGER.log(Level.FINE,
+                    "Skipping TSR cell with invalid span: row={0}, col={1}, rowspan={2}, colspan={3}",
+                    new Object[]{startRow, startCol, rowspan, colspan});
+                continue;
+            }
+            // Clamp spans so the fill loop below never writes past the grid edge.
+            rowspan = Math.min(rowspan, numRows - startRow);
+            colspan = Math.min(colspan, numCols - startCol);
+            {
                 TableBorderCell cell = new TableBorderCell(startRow, startCol, rowspan, colspan, 0L);
 
                 // Compute cell bbox: use TSR cell bbox if available, otherwise fall back to grid

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -182,12 +182,22 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
             double pageHeight = getPageHeight(pageNumber, pageHeights, page);
 
+            // Collect TSR table bboxes for this page (used by label 7 overlap check)
+            List<BoundingBox> tsrTableBboxes = new ArrayList<>();
+            JsonNode tsrPage = tableByPage.get(pageNumber);
+            if (tsrPage != null) {
+                JsonNode tBbox = tsrPage.get("table_bbox");
+                if (tBbox != null && tBbox.isArray() && tBbox.size() >= 4) {
+                    tsrTableBboxes.add(extractBoundingBox(tBbox, pageNumber, pageHeight));
+                }
+            }
+
             JsonNode objects = page.get("objects");
             if (objects == null || !objects.isArray()) continue;
 
             for (JsonNode obj : objects) {
                 IObject iobj = transformObject(obj, pageNumber, pageHeight, figureCaptionMap,
-                    headingHeightToLevel);
+                    headingHeightToLevel, tsrTableBboxes);
 
                 if (iobj != null) {
                     result.get(pageNumber).add(iobj);
@@ -247,7 +257,8 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
      */
     private IObject transformObject(JsonNode obj, int pageIndex, double pageHeight,
                                      Map<String, String> figureCaptionMap,
-                                     Map<Double, Integer> headingHeightToLevel) {
+                                     Map<Double, Integer> headingHeightToLevel,
+                                     List<BoundingBox> tsrTableBboxes) {
         int label = obj.has("label") ? obj.get("label").asInt() : -1;
 
         // Skip furniture
@@ -263,33 +274,43 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         BoundingBox bbox = extractBoundingBox(bboxNode, pageIndex, pageHeight);
         String text = obj.has("ocrtext") ? obj.get("ocrtext").asText("") : "";
 
+        IObject iobj;
         switch (label) {
             case LABEL_TITLE:
-                return createHeading(text, bbox, 1);
+                iobj = createHeading(text, bbox, 1);
+                break;
             case LABEL_HEADING:
             case LABEL_SUBHEADING: {
                 double pixelHeight = bboxNode.get(3).asDouble() - bboxNode.get(1).asDouble();
                 int level = headingHeightToLevel.getOrDefault(pixelHeight, 2);
-                return createHeading(text, bbox, level);
+                iobj = createHeading(text, bbox, level);
+                break;
             }
 
             case LABEL_LIST_ITEM:
-                return text.isEmpty() ? null : createListItem(text, bbox);
+                iobj = text.isEmpty() ? null : createListItem(text, bbox);
+                break;
 
             case LABEL_TABLE_NAME:
             case LABEL_CAPTION:
-                return text.isEmpty() ? null : createCaption(text, bbox);
+                iobj = text.isEmpty() ? null : createCaption(text, bbox);
+                break;
 
             case LABEL_FOOTNOTE:
-                return text.isEmpty() ? null : createFootnote(text, bbox);
+                iobj = text.isEmpty() ? null : createFootnote(text, bbox);
+                break;
 
             case LABEL_PARAGRAPH:
             case LABEL_AUTHOR:
-                return text.isEmpty() ? null : createParagraph(text, bbox);
+                iobj = text.isEmpty() ? null : createParagraph(text, bbox);
+                break;
 
             case LABEL_TABLE:
-                // Table region detected by DLA — treat as paragraph with table-like text
-                return text.isEmpty() ? null : createParagraph(text, bbox);
+                // Table region detected by DLA — if TSR covers it, skip (table handled separately)
+                if (hasOverlappingTsr(bbox, tsrTableBboxes)) return null;
+                // No TSR data — treat as list (parse text by newlines into ListItems)
+                iobj = text.isEmpty() ? null : createListFromText(text, bbox);
+                break;
 
             case LABEL_FIGURE:
             case LABEL_FIGURE_CAPTION: {
@@ -297,15 +318,20 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 int objectId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
                 String key = pageIndex + ":" + objectId;
                 String caption = figureCaptionMap.get(key);
-                return createPicture(bbox, caption);
+                iobj = createPicture(bbox, caption);
+                break;
             }
 
             case LABEL_FORMULA:
-                return createFormula(text, bbox);
+                iobj = createFormula(text, bbox);
+                break;
 
             default:
-                return text.isEmpty() ? null : createParagraph(text, bbox);
+                iobj = text.isEmpty() ? null : createParagraph(text, bbox);
+                break;
         }
+
+        return iobj;
     }
 
     /**
@@ -517,6 +543,67 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         double w = b.getRightX() - b.getLeftX();
         double h = b.getTopY() - b.getBottomY();
         return (w > 0 && h > 0) ? w * h : 0.0;
+    }
+
+    // --- Helper: TSR overlap check for label 7 ---
+
+    /**
+     * Checks if any TSR table bbox overlaps with the given region bbox by more than 50%.
+     * Used to determine if a label 7 (Regionlist/Table) region is already covered by TSR data.
+     */
+    private boolean hasOverlappingTsr(BoundingBox regionBbox, List<BoundingBox> tsrTableBboxes) {
+        if (tsrTableBboxes == null || tsrTableBboxes.isEmpty()) return false;
+
+        double regionArea = bboxArea(regionBbox);
+        if (regionArea <= 0) return false;
+
+        for (BoundingBox tsrBbox : tsrTableBboxes) {
+            double intersection = bboxIntersectionArea(regionBbox, tsrBbox);
+            if (intersection / regionArea > WORD_CELL_OVERLAP_THRESHOLD) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Creates a PDFList from text by splitting on newlines.
+     * Each non-empty line becomes a ListItem with bullet detection.
+     */
+    private PDFList createListFromText(String text, BoundingBox bbox) {
+        String[] lines = text.split("\n");
+        List<ListItem> items = new ArrayList<>();
+
+        int lineCount = 0;
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) continue;
+            lineCount++;
+        }
+
+        // Compute approximate per-item height
+        double itemHeight = (lineCount > 0 && bbox != null)
+            ? (bbox.getTopY() - bbox.getBottomY()) / lineCount : 0;
+
+        int index = 0;
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) continue;
+
+            // Approximate per-line bbox
+            BoundingBox itemBbox = bbox != null
+                ? new BoundingBox(bbox.getPageNumber(),
+                    bbox.getLeftX(), bbox.getTopY() - (index + 1) * itemHeight,
+                    bbox.getRightX(), bbox.getTopY() - index * itemHeight)
+                : new BoundingBox();
+
+            items.add(createListItem(trimmed, itemBbox));
+            index++;
+        }
+
+        if (items.isEmpty()) return null;
+
+        return buildPDFList(items);
     }
 
     // --- Helper: heading level inference ---

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -611,9 +611,9 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 // Fallback to TSR text field if no words matched
                 if (matchedText.isEmpty()) {
                     String tsrText = cellNode.has("text") ? cellNode.get("text").asText("") : "";
-                    if (!tsrText.isEmpty()) {
-                        cell.addContentObject(createParagraph(tsrText, cellBbox));
-                    }
+                    // Always add a paragraph (even empty) so the cell has a /K child.
+                    // Adobe Acrobat ignores table structure when cells lack children.
+                    cell.addContentObject(createParagraph(tsrText.isEmpty() ? "" : tsrText, cellBbox));
                 } else {
                     cell.addContentObject(createParagraph(matchedText, cellBbox));
                 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -64,10 +64,10 @@ import java.util.regex.Pattern;
  *   3  → List item (SemanticParagraph)
  *   4  → Subheading (SemanticHeading level 3)
  *   6  → Author/Meta (SemanticParagraph)
- *   7  → Table region (handled via TABLE_STRUCTURE_RECOGNITION)
+ *   7  → Regionlist (Table/List region, handled via TABLE_STRUCTURE_RECOGNITION or as list)
  *   8  → TableName (SemanticCaption linked to nearest Table)
- *   9  → Figure (SemanticPicture)
- *  10  → Figure with caption (SemanticPicture)
+ *   9  → Table (handled via TABLE_STRUCTURE_RECOGNITION)
+ *  10  → Figure (SemanticPicture)
  *  11  → FigureName (SemanticCaption linked to nearest Figure)
  *  12  → Formula (SemanticFormula)
  *  13  → Footnote (SemanticFootnote → FENote)
@@ -94,11 +94,11 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     private static final int LABEL_LIST_ITEM = 3;
     private static final int LABEL_SUBHEADING = 4;
     private static final int LABEL_AUTHOR = 6;
-    private static final int LABEL_TABLE = 7;
+    private static final int LABEL_REGIONLIST = 7;
     private static final int LABEL_TABLE_NAME = 8;
-    private static final int LABEL_FIGURE = 9;
-    private static final int LABEL_FIGURE_CAPTION = 10;
-    private static final int LABEL_CAPTION = 11;
+    private static final int LABEL_TABLE = 9;
+    private static final int LABEL_FIGURE = 10;
+    private static final int LABEL_FIGURE_NAME = 11;
     private static final int LABEL_FORMULA = 12;
     private static final int LABEL_FOOTNOTE = 13;
     private static final int LABEL_PAGE_HEADER = 14;
@@ -312,7 +312,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 break;
 
             case LABEL_TABLE_NAME:
-            case LABEL_CAPTION:
+            case LABEL_FIGURE_NAME:
                 iobj = text.isEmpty() ? null : createCaption(text, bbox);
                 break;
 
@@ -325,7 +325,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 iobj = text.isEmpty() ? null : createParagraph(text, bbox);
                 break;
 
-            case LABEL_TABLE:
+            case LABEL_REGIONLIST:
                 if (HybridConfig.REGIONLIST_LIST_ONLY.equals(regionlistStrategy)) {
                     // list-only: always treat as list, skip TSR check
                     iobj = text.isEmpty() ? null : createListFromText(text, bbox);
@@ -337,8 +337,11 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 }
                 break;
 
-            case LABEL_FIGURE:
-            case LABEL_FIGURE_CAPTION: {
+            case LABEL_TABLE:
+                // Table regions are handled separately by transformTablePage() via TSR
+                return null;
+
+            case LABEL_FIGURE: {
                 // Look up per-figure caption from IMAGE_CAPTIONING
                 int objectId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
                 String key = pageIndex + ":" + objectId;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -745,7 +745,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         if (wordBbox.size() >= 8) {
             // 8-point polygon: find min/max of x and y coordinates
             double minX = Double.MAX_VALUE, minY = Double.MAX_VALUE;
-            double maxX = Double.MIN_VALUE, maxY = Double.MIN_VALUE;
+            double maxX = -Double.MAX_VALUE, maxY = -Double.MAX_VALUE;
             for (int j = 0; j < wordBbox.size(); j += 2) {
                 double x = wordBbox.get(j).asDouble();
                 double y = wordBbox.get(j + 1).asDouble();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -132,10 +132,16 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     private int pictureIndex;
     private String regionlistStrategy = HybridConfig.REGIONLIST_TABLE_FIRST;
     private Map<Long, ElementMetadata> elementMetadataMap = new LinkedHashMap<>();
+    private Map<Integer, List<OcrWordInfo>> ocrWordsByPage = new HashMap<>();
 
     @Override
     public Map<Long, ElementMetadata> getElementMetadata() {
         return Collections.unmodifiableMap(elementMetadataMap);
+    }
+
+    @Override
+    public Map<Integer, List<OcrWordInfo>> getOcrWordsByPage() {
+        return Collections.unmodifiableMap(ocrWordsByPage);
     }
 
     /**
@@ -171,6 +177,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
         pictureIndex = 0;
         elementMetadataMap.clear();
+        ocrWordsByPage.clear();
 
         // Get DLA+OCR results (primary source for layout + text)
         JsonNode dlaOcr = json.get("DOCUMENT_LAYOUT_WITH_OCR");
@@ -236,6 +243,15 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
         // Collect per-page word info for cell-word bbox matching
         Map<Integer, List<WordInfo>> wordsByPage = collectWordsByPage(dlaPages, pageHeights);
+
+        // Expose OCR word data for enrichment fallback
+        for (Map.Entry<Integer, List<WordInfo>> entry : wordsByPage.entrySet()) {
+            List<OcrWordInfo> ocrWords = new ArrayList<>(entry.getValue().size());
+            for (WordInfo wi : entry.getValue()) {
+                ocrWords.add(new OcrWordInfo(wi.text, wi.bbox));
+            }
+            ocrWordsByPage.put(entry.getKey(), ocrWords);
+        }
 
         // Process DLA+OCR objects
         for (int i = 0; i < dlaPages.size(); i++) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClientFactory.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClientFactory.java
@@ -48,6 +48,9 @@ public class HybridClientFactory {
     /** Backend type constant for Hancom (not yet implemented). */
     public static final String BACKEND_HANCOM = "hancom";
 
+    /** Backend type constant for Hancom AI (HOCR SDK individual modules). */
+    public static final String BACKEND_HANCOM_AI = "hancom-ai";
+
     /** Backend type constant for Azure (not yet implemented). */
     public static final String BACKEND_AZURE = "azure";
 
@@ -91,6 +94,8 @@ public class HybridClientFactory {
             return new DoclingFastServerClient(config);
         } else if (BACKEND_HANCOM.equals(hybrid)) {
             return new HancomClient(config);
+        } else if (BACKEND_HANCOM_AI.equals(hybrid)) {
+            return new HancomAIClient(config);
         } else if (BACKEND_AZURE.equals(hybrid)) {
             throw new UnsupportedOperationException("Azure Document Intelligence backend is not yet implemented");
         } else if (BACKEND_GOOGLE.equals(hybrid)) {
@@ -140,6 +145,8 @@ public class HybridClientFactory {
                 ((DoclingFastServerClient) client).shutdown();
             } else if (client instanceof HancomClient) {
                 ((HancomClient) client).shutdown();
+            } else if (client instanceof HancomAIClient) {
+                ((HancomAIClient) client).shutdown();
             }
         }
         CLIENT_CACHE.clear();
@@ -157,7 +164,8 @@ public class HybridClientFactory {
         }
 
         String lowerHybrid = hybrid.toLowerCase();
-        return BACKEND_DOCLING_FAST.equals(lowerHybrid) || BACKEND_HANCOM.equals(lowerHybrid);
+        return BACKEND_DOCLING_FAST.equals(lowerHybrid) || BACKEND_HANCOM.equals(lowerHybrid)
+            || BACKEND_HANCOM_AI.equals(lowerHybrid);
     }
 
     /**
@@ -166,7 +174,7 @@ public class HybridClientFactory {
      * @return A string listing all supported backends.
      */
     public static String getSupportedBackends() {
-        return String.join(", ", BACKEND_DOCLING_FAST, BACKEND_HANCOM);
+        return String.join(", ", BACKEND_DOCLING_FAST, BACKEND_HANCOM, BACKEND_HANCOM_AI);
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClientFactory.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClientFactory.java
@@ -45,7 +45,7 @@ public class HybridClientFactory {
     /** Backend type constant for Docling Fast Server. */
     public static final String BACKEND_DOCLING_FAST = "docling-fast";
 
-    /** Backend type constant for Hancom (not yet implemented). */
+    /** Backend type constant for Hancom (Studio Lite API). */
     public static final String BACKEND_HANCOM = "hancom";
 
     /** Backend type constant for Hancom AI (HOCR SDK individual modules). */

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
@@ -59,6 +59,15 @@ public class HybridConfig {
 
     private String regionlistStrategy = REGIONLIST_TABLE_FIRST;
 
+    /** Page image cache strategy: "memory" (default) or "disk". */
+    private String imageCache = "memory";
+
+    /** Whether to save cropped figure images to disk for debugging. */
+    private boolean saveCrops = false;
+
+    /** Output directory for saved crops (set by CLI when --save-crops is used). */
+    private String cropOutputDir = null;
+
     /**
      * Default constructor initializing the configuration with default values.
      */
@@ -241,5 +250,59 @@ public class HybridConfig {
      */
     public boolean isRegionlistListOnly() {
         return REGIONLIST_LIST_ONLY.equals(regionlistStrategy);
+    }
+
+    /**
+     * Gets the page image cache strategy.
+     *
+     * @return "memory" or "disk".
+     */
+    public String getImageCache() {
+        return imageCache;
+    }
+
+    /**
+     * Sets the page image cache strategy.
+     *
+     * @param imageCache "memory" (in-heap HashMap) or "disk" (temp PNG files).
+     */
+    public void setImageCache(String imageCache) {
+        this.imageCache = imageCache;
+    }
+
+    /**
+     * Checks if cropped figure images should be saved to disk.
+     *
+     * @return true if save-crops is enabled.
+     */
+    public boolean isSaveCrops() {
+        return saveCrops;
+    }
+
+    /**
+     * Sets whether to save cropped figure images to disk.
+     *
+     * @param saveCrops true to save crops.
+     */
+    public void setSaveCrops(boolean saveCrops) {
+        this.saveCrops = saveCrops;
+    }
+
+    /**
+     * Gets the output directory for saved crops.
+     *
+     * @return the crop output directory path, or null if not set.
+     */
+    public String getCropOutputDir() {
+        return cropOutputDir;
+    }
+
+    /**
+     * Sets the output directory for saved crops.
+     *
+     * @param cropOutputDir the directory path.
+     */
+    public void setCropOutputDir(String cropOutputDir) {
+        this.cropOutputDir = cropOutputDir;
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
@@ -38,6 +38,9 @@ public class HybridConfig {
     /** Default URL for Hancom Document AI API. */
     public static final String HANCOM_DEFAULT_URL = "https://dataloader.cloud.hancom.com/studio-lite/api";
 
+    /** Default URL for Hancom AI HOCR SDK API. */
+    public static final String HANCOM_AI_DEFAULT_URL = "http://localhost:18008/api/v1";
+
     private String url;
     private int timeoutMs = DEFAULT_TIMEOUT_MS;
     private boolean fallbackToJava = false;
@@ -152,6 +155,9 @@ public class HybridConfig {
         }
         if ("hancom".equals(lowerHybrid)) {
             return HANCOM_DEFAULT_URL;
+        }
+        if ("hancom-ai".equals(lowerHybrid)) {
+            return HANCOM_AI_DEFAULT_URL;
         }
         // azure, google require explicit URL
         return null;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
@@ -52,6 +52,13 @@ public class HybridConfig {
 
     private String mode = MODE_AUTO;
 
+    /** Regionlist strategy: table-first (default) — check TSR overlap, skip if TSR exists. */
+    public static final String REGIONLIST_TABLE_FIRST = "table-first";
+    /** Regionlist strategy: list-only — always treat label 7 as list, skip TSR check. */
+    public static final String REGIONLIST_LIST_ONLY = "list-only";
+
+    private String regionlistStrategy = REGIONLIST_TABLE_FIRST;
+
     /**
      * Default constructor initializing the configuration with default values.
      */
@@ -202,5 +209,37 @@ public class HybridConfig {
      */
     public boolean isFullMode() {
         return MODE_FULL.equals(mode);
+    }
+
+    /**
+     * Gets the regionlist strategy for label 7 (Table region) handling.
+     *
+     * @return The regionlist strategy (table-first or list-only).
+     */
+    public String getRegionlistStrategy() {
+        return regionlistStrategy;
+    }
+
+    /**
+     * Sets the regionlist strategy for label 7 (Table region) handling.
+     *
+     * <ul>
+     *   <li>{@code "table-first"} (default): check TSR overlap, skip if TSR exists, else treat as list</li>
+     *   <li>{@code "list-only"}: always treat as list, skip TSR check entirely</li>
+     * </ul>
+     *
+     * @param regionlistStrategy The regionlist strategy to use.
+     */
+    public void setRegionlistStrategy(String regionlistStrategy) {
+        this.regionlistStrategy = regionlistStrategy;
+    }
+
+    /**
+     * Checks if regionlist strategy is list-only (always treat label 7 as list).
+     *
+     * @return true if strategy is list-only, false otherwise.
+     */
+    public boolean isRegionlistListOnly() {
+        return REGIONLIST_LIST_ONLY.equals(regionlistStrategy);
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
@@ -59,6 +59,15 @@ public class HybridConfig {
 
     private String regionlistStrategy = REGIONLIST_TABLE_FIRST;
 
+    /** OCR strategy: off (stream only, no OCR fallback). */
+    public static final String OCR_OFF = "off";
+    /** OCR strategy: auto (stream first, OCR fallback when enrichment fails). */
+    public static final String OCR_AUTO = "auto";
+    /** OCR strategy: force (OCR only, skip stream-based enrichment). */
+    public static final String OCR_FORCE = "force";
+
+    private String ocrStrategy = OCR_OFF;
+
     /** Page image cache strategy: "memory" (default) or "disk". */
     private String imageCache = "memory";
 
@@ -304,5 +313,47 @@ public class HybridConfig {
      */
     public void setCropOutputDir(String cropOutputDir) {
         this.cropOutputDir = cropOutputDir;
+    }
+
+    /**
+     * Gets the OCR strategy for enrichment fallback.
+     *
+     * @return The OCR strategy (off, auto, or force).
+     */
+    public String getOcrStrategy() {
+        return ocrStrategy;
+    }
+
+    /**
+     * Sets the OCR strategy for enrichment fallback.
+     *
+     * <ul>
+     *   <li>{@code "off"} (default): stream-based enrichment only, no OCR fallback</li>
+     *   <li>{@code "auto"}: try stream enrichment first, fall back to OCR words when no match</li>
+     *   <li>{@code "force"}: skip stream enrichment, always use OCR words</li>
+     * </ul>
+     *
+     * @param ocrStrategy The OCR strategy to use.
+     */
+    public void setOcrStrategy(String ocrStrategy) {
+        this.ocrStrategy = ocrStrategy;
+    }
+
+    /**
+     * Checks if OCR strategy is auto (stream first, OCR fallback).
+     *
+     * @return true if strategy is auto, false otherwise.
+     */
+    public boolean isOcrAuto() {
+        return OCR_AUTO.equals(ocrStrategy);
+    }
+
+    /**
+     * Checks if OCR strategy is force (OCR only).
+     *
+     * @return true if strategy is force, false otherwise.
+     */
+    public boolean isOcrForce() {
+        return OCR_FORCE.equals(ocrStrategy);
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
@@ -249,6 +249,13 @@ public class HybridConfig {
      * @param regionlistStrategy The regionlist strategy to use.
      */
     public void setRegionlistStrategy(String regionlistStrategy) {
+        if (regionlistStrategy != null
+                && !REGIONLIST_TABLE_FIRST.equals(regionlistStrategy)
+                && !REGIONLIST_LIST_ONLY.equals(regionlistStrategy)) {
+            throw new IllegalArgumentException("Invalid regionlistStrategy: "
+                + regionlistStrategy + " (expected " + REGIONLIST_TABLE_FIRST
+                + " or " + REGIONLIST_LIST_ONLY + ")");
+        }
         this.regionlistStrategy = regionlistStrategy;
     }
 
@@ -276,6 +283,11 @@ public class HybridConfig {
      * @param imageCache "memory" (in-heap HashMap) or "disk" (temp PNG files).
      */
     public void setImageCache(String imageCache) {
+        if (imageCache != null
+                && !"memory".equals(imageCache) && !"disk".equals(imageCache)) {
+            throw new IllegalArgumentException("Invalid imageCache: "
+                + imageCache + " (expected \"memory\" or \"disk\")");
+        }
         this.imageCache = imageCache;
     }
 
@@ -328,14 +340,22 @@ public class HybridConfig {
      * Sets the OCR strategy for enrichment fallback.
      *
      * <ul>
-     *   <li>{@code "off"} (default): stream-based enrichment only, no OCR fallback</li>
-     *   <li>{@code "auto"}: try stream enrichment first, fall back to OCR words when no match</li>
+     *   <li>{@code "off"}: stream-based enrichment only, no OCR fallback</li>
+     *   <li>{@code "auto"} (default): try stream enrichment first, fall back to OCR words when no match</li>
      *   <li>{@code "force"}: skip stream enrichment, always use OCR words</li>
      * </ul>
      *
      * @param ocrStrategy The OCR strategy to use.
      */
     public void setOcrStrategy(String ocrStrategy) {
+        if (ocrStrategy != null
+                && !OCR_OFF.equals(ocrStrategy)
+                && !OCR_AUTO.equals(ocrStrategy)
+                && !OCR_FORCE.equals(ocrStrategy)) {
+            throw new IllegalArgumentException("Invalid ocrStrategy: "
+                + ocrStrategy + " (expected " + OCR_OFF + ", " + OCR_AUTO
+                + ", or " + OCR_FORCE + ")");
+        }
         this.ocrStrategy = ocrStrategy;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
@@ -66,7 +66,7 @@ public class HybridConfig {
     /** OCR strategy: force (OCR only, skip stream-based enrichment). */
     public static final String OCR_FORCE = "force";
 
-    private String ocrStrategy = OCR_OFF;
+    private String ocrStrategy = OCR_AUTO;
 
     /** Page image cache strategy: "memory" (default) or "disk". */
     private String imageCache = "memory";

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridSchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridSchemaTransformer.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
 import org.verapdf.wcag.algorithms.entities.IObject;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -67,4 +68,14 @@ public interface HybridSchemaTransformer {
      * @return The backend name (e.g., "docling", "hancom").
      */
     String getBackendType();
+
+    /**
+     * Returns per-element metadata produced during the last {@link #transform} call.
+     * Keys are {@code IObject.recognizedStructureId} values.
+     *
+     * @return unmodifiable map of element metadata, empty by default
+     */
+    default Map<Long, ElementMetadata> getElementMetadata() {
+        return Collections.emptyMap();
+    }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridSchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridSchemaTransformer.java
@@ -22,6 +22,7 @@ import org.verapdf.wcag.algorithms.entities.IObject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 
 /**
  * Interface for transforming hybrid backend responses to IObject hierarchy.
@@ -76,6 +77,20 @@ public interface HybridSchemaTransformer {
      * @return unmodifiable map of element metadata, empty by default
      */
     default Map<Long, ElementMetadata> getElementMetadata() {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Returns per-page OCR word data collected during the last {@link #transform} call.
+     * Keys are 0-indexed page numbers. Each list contains word-level OCR data with
+     * text and bounding box in PDF coordinate space.
+     *
+     * <p>Only populated by backends that perform OCR (e.g., hancom-ai).
+     * Used by OCR enrichment fallback when Java TextChunks are not available.
+     *
+     * @return unmodifiable map of page number to OCR words, empty by default
+     */
+    default Map<Integer, List<OcrWordInfo>> getOcrWordsByPage() {
         return Collections.emptyMap();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/MemoryPageImageCache.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/MemoryPageImageCache.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * In-memory page image cache. Stores images in a HashMap; evict() removes
+ * entries so GC can reclaim memory (~25MB per page image).
+ */
+public class MemoryPageImageCache implements PageImageCache {
+
+    private final Map<Integer, BufferedImage> cache = new HashMap<>();
+
+    @Override
+    public BufferedImage getOrFetch(int pageIndex, PageImageFetcher fetcher) throws IOException {
+        BufferedImage image = cache.get(pageIndex);
+        if (image == null) {
+            image = fetcher.fetch(pageIndex);
+            cache.put(pageIndex, image);
+        }
+        return image;
+    }
+
+    @Override
+    public void evict(int pageIndex) {
+        cache.remove(pageIndex);
+    }
+
+    @Override
+    public void close() {
+        cache.clear();
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/MemoryPageImageCache.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/MemoryPageImageCache.java
@@ -33,6 +33,9 @@ public class MemoryPageImageCache implements PageImageCache {
         BufferedImage image = cache.get(pageIndex);
         if (image == null) {
             image = fetcher.fetch(pageIndex);
+            if (image == null) {
+                throw new IOException("Page image fetcher returned null for page " + pageIndex);
+            }
             cache.put(pageIndex, image);
         }
         return image;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/OcrWordInfo.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/OcrWordInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+
+/**
+ * Holds OCR-recognized text and its bounding box in PDF coordinate space.
+ *
+ * <p>Used to preserve word-level OCR data from the DLA+OCR pipeline so that
+ * the enrichment step can create invisible text operators when Java TextChunks
+ * are not available (e.g., scanned/image-based pages).
+ */
+public class OcrWordInfo {
+
+    private final String text;
+    private final BoundingBox bbox;
+
+    public OcrWordInfo(String text, BoundingBox bbox) {
+        this.text = text;
+        this.bbox = bbox;
+    }
+
+    /**
+     * Gets the OCR-recognized text for this word.
+     *
+     * @return the recognized text
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Gets the bounding box in PDF coordinate space (72 DPI, bottom-left origin).
+     *
+     * @return the bounding box
+     */
+    public BoundingBox getBbox() {
+        return bbox;
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/PageImageCache.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/PageImageCache.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+/**
+ * Cache for page images (pdf2img results). Implementations control where
+ * images are stored and when they are evicted.
+ */
+public interface PageImageCache extends AutoCloseable {
+
+    /**
+     * Get a cached page image or fetch it using the supplier.
+     *
+     * @param pageIndex 0-indexed page number
+     * @param fetcher called if image not in cache; may throw IOException
+     * @return the page image, never null
+     * @throws IOException if the fetcher fails
+     */
+    BufferedImage getOrFetch(int pageIndex, PageImageFetcher fetcher) throws IOException;
+
+    /**
+     * Hint that this page is no longer needed.
+     * Memory impl evicts immediately; disk impl keeps for potential re-read.
+     *
+     * @param pageIndex 0-indexed page number
+     */
+    void evict(int pageIndex);
+
+    /**
+     * Clean up all resources. Disk impl deletes temp files.
+     */
+    @Override
+    void close() throws IOException;
+
+    /**
+     * Functional interface for fetching a page image on cache miss.
+     */
+    @FunctionalInterface
+    interface PageImageFetcher {
+        BufferedImage fetch(int pageIndex) throws IOException;
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/TextSimilarity.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/TextSimilarity.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+/**
+ * Computes text similarity for stream vs OCR comparison.
+ * Used by enrichment to decide whether stream text is corrupted.
+ */
+public final class TextSimilarity {
+
+    /** Default similarity threshold. Below this, stream text is considered corrupted. */
+    public static final double DEFAULT_THRESHOLD = 0.5;
+
+    private TextSimilarity() {}
+
+    /**
+     * Computes normalized similarity between two strings (0.0 = completely different, 1.0 = identical).
+     * Uses Levenshtein distance normalized by the longer string's length.
+     */
+    public static double similarity(String a, String b) {
+        if (a == null || b == null) return 0.0;
+        if (a.equals(b)) return 1.0;
+        if (a.isEmpty() || b.isEmpty()) return 0.0;
+
+        int distance = levenshteinDistance(a, b);
+        int maxLen = Math.max(a.length(), b.length());
+        return 1.0 - ((double) distance / maxLen);
+    }
+
+    /**
+     * Returns true if stream text should be trusted over OCR text.
+     */
+    public static boolean trustStream(String streamText, String ocrText, double threshold) {
+        if (streamText == null || streamText.isEmpty()) return false;
+        if (ocrText == null || ocrText.isEmpty()) return true;
+        return similarity(streamText, ocrText) >= threshold;
+    }
+
+    private static int levenshteinDistance(String a, String b) {
+        int[] prev = new int[b.length() + 1];
+        int[] curr = new int[b.length() + 1];
+        for (int j = 0; j <= b.length(); j++) prev[j] = j;
+        for (int i = 1; i <= a.length(); i++) {
+            curr[0] = i;
+            for (int j = 1; j <= b.length(); j++) {
+                int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+                curr[j] = Math.min(Math.min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
+            }
+            int[] temp = prev; prev = curr; curr = temp;
+        }
+        return prev[b.length()];
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonName.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonName.java
@@ -65,4 +65,7 @@ public class JsonName {
     public static final String IMAGE_FORMAT = "format";
     public static final String FORMULA_TYPE = "formula";
     public static final String DESCRIPTION = "description";
+    public static final String CONFIDENCE = "confidence";
+    public static final String SOURCE_LABEL = "source label";
+    public static final String HYBRID = "hybrid";
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonWriter.java
@@ -28,13 +28,17 @@ import org.verapdf.cos.COSTrailer;
 import org.verapdf.gf.model.impl.cos.GFCosInfo;
 import org.verapdf.pd.PDDocument;
 import org.verapdf.tools.StaticResources;
+import org.opendataloader.pdf.hybrid.ElementMetadata;
+import org.opendataloader.pdf.json.serializers.SerializerUtil;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.content.LineArtChunk;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -48,26 +52,55 @@ public class JsonWriter {
     }
 
     public static void writeToJson(File inputPDF, String outputFolder, List<List<IObject>> contents) throws IOException {
+        writeToJson(inputPDF, outputFolder, contents, Collections.emptyMap(), null);
+    }
+
+    public static void writeToJson(File inputPDF, String outputFolder, List<List<IObject>> contents,
+                                   Map<Long, ElementMetadata> elementMetadata) throws IOException {
+        writeToJson(inputPDF, outputFolder, contents, elementMetadata, null);
+    }
+
+    public static void writeToJson(File inputPDF, String outputFolder, List<List<IObject>> contents,
+                                   Map<Long, ElementMetadata> elementMetadata,
+                                   Map<String, Object> hybridInfo) throws IOException {
         StaticLayoutContainers.resetImageIndex();
         String jsonFileName = outputFolder + File.separator + inputPDF.getName().substring(0, inputPDF.getName().length() - 3) + "json";
         try (JsonGenerator jsonGenerator = getJsonGenerator(jsonFileName)) {
             jsonGenerator.writeStartObject();
             writeDocumentInfo(jsonGenerator, inputPDF.getName());
-            jsonGenerator.writeArrayFieldStart(JsonName.KIDS);
-            for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
-                for (IObject content : contents.get(pageNumber)) {
-                    if (!(content instanceof LineArtChunk)) {
-                        jsonGenerator.writePOJO(content);
-                    }
-                }
+
+            if (hybridInfo != null && !hybridInfo.isEmpty()) {
+                writeHybridBlock(jsonGenerator, hybridInfo);
             }
 
-            jsonGenerator.writeEndArray();
+            SerializerUtil.setElementMetadata(elementMetadata);
+            try {
+                jsonGenerator.writeArrayFieldStart(JsonName.KIDS);
+                for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
+                    for (IObject content : contents.get(pageNumber)) {
+                        if (!(content instanceof LineArtChunk)) {
+                            jsonGenerator.writePOJO(content);
+                        }
+                    }
+                }
+                jsonGenerator.writeEndArray();
+            } finally {
+                SerializerUtil.clearElementMetadata();
+            }
+
             jsonGenerator.writeEndObject();
             LOGGER.log(Level.INFO, "Created {0}", jsonFileName);
         } catch (Exception ex) {
             LOGGER.log(Level.WARNING, "Unable to create JSON output: " + ex.getMessage());
         }
+    }
+
+    private static void writeHybridBlock(JsonGenerator generator, Map<String, Object> hybridInfo) throws IOException {
+        generator.writeObjectFieldStart(JsonName.HYBRID);
+        for (Map.Entry<String, Object> entry : hybridInfo.entrySet()) {
+            generator.writePOJOField(entry.getKey(), entry.getValue());
+        }
+        generator.writeEndObject();
     }
 
     private static void writeDocumentInfo(JsonGenerator generator, String pdfName) throws IOException {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/CaptionSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/CaptionSerializer.java
@@ -46,6 +46,7 @@ public class CaptionSerializer extends StdSerializer<SemanticCaption> {
             jsonGenerator.writeNumberField("linked content id", caption.getLinkedContentId());
         }
         SerializerUtil.writeTextInfo(jsonGenerator, caption);
+        SerializerUtil.writeMetadataIfPresent(jsonGenerator, caption);
         jsonGenerator.writeEndObject();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/FormulaSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/FormulaSerializer.java
@@ -49,6 +49,7 @@ public class FormulaSerializer extends StdSerializer<SemanticFormula> {
         jsonGenerator.writeStartObject();
         SerializerUtil.writeEssentialInfo(jsonGenerator, formula, JsonName.FORMULA_TYPE);
         jsonGenerator.writeStringField(JsonName.CONTENT, formula.getLatex());
+        SerializerUtil.writeMetadataIfPresent(jsonGenerator, formula);
         jsonGenerator.writeEndObject();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/HeadingSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/HeadingSerializer.java
@@ -45,6 +45,7 @@ public class HeadingSerializer extends StdSerializer<SemanticHeading> {
         SerializerUtil.writeEssentialInfo(jsonGenerator, heading, JsonName.HEADING_TYPE);
         jsonGenerator.writeNumberField(JsonName.HEADING_LEVEL, heading.getHeadingLevel());
         SerializerUtil.writeTextInfo(jsonGenerator, heading);
+        SerializerUtil.writeMetadataIfPresent(jsonGenerator, heading);
         jsonGenerator.writeEndObject();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/ListSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/ListSerializer.java
@@ -49,6 +49,7 @@ public class ListSerializer extends StdSerializer<PDFList> {
         }
 
         jsonGenerator.writeEndArray();
+        SerializerUtil.writeMetadataIfPresent(jsonGenerator, list);
         jsonGenerator.writeEndObject();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/ParagraphSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/ParagraphSerializer.java
@@ -35,6 +35,7 @@ public class ParagraphSerializer extends StdSerializer<SemanticParagraph> {
         jsonGenerator.writeStartObject();
         SerializerUtil.writeEssentialInfo(jsonGenerator, textParagraph, JsonName.PARAGRAPH_TYPE);
         SerializerUtil.writeTextInfo(jsonGenerator, textParagraph);
+        SerializerUtil.writeMetadataIfPresent(jsonGenerator, textParagraph);
         jsonGenerator.writeEndObject();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/PictureSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/PictureSerializer.java
@@ -66,6 +66,7 @@ public class PictureSerializer extends StdSerializer<SemanticPicture> {
                 jsonGenerator.writeStringField(JsonName.SOURCE, relativePath);
             }
         }
+        SerializerUtil.writeMetadataIfPresent(jsonGenerator, picture);
         jsonGenerator.writeEndObject();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/SerializerUtil.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/SerializerUtil.java
@@ -16,6 +16,7 @@
 package org.opendataloader.pdf.json.serializers;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import org.opendataloader.pdf.hybrid.ElementMetadata;
 import org.opendataloader.pdf.json.JsonName;
 import org.opendataloader.pdf.utils.TextNodeUtils;
 import org.verapdf.wcag.algorithms.entities.IObject;
@@ -23,8 +24,94 @@ import org.verapdf.wcag.algorithms.entities.SemanticTextNode;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 public class SerializerUtil {
+
+    private static final ThreadLocal<Map<Long, ElementMetadata>> ELEMENT_METADATA =
+            ThreadLocal.withInitial(Collections::emptyMap);
+
+    public static void setElementMetadata(Map<Long, ElementMetadata> metadata) {
+        ELEMENT_METADATA.set(metadata != null ? metadata : Collections.emptyMap());
+    }
+
+    public static void clearElementMetadata() {
+        ELEMENT_METADATA.remove();
+    }
+
+    /**
+     * Writes element-level metadata fields (confidence, source label, etc.) if available.
+     * Call this before writeEndObject() in each serializer.
+     */
+    public static void writeMetadataIfPresent(JsonGenerator gen, IObject object) throws IOException {
+        if (object == null || object.getRecognizedStructureId() == null) return;
+        Map<Long, ElementMetadata> metadata = ELEMENT_METADATA.get();
+        if (metadata.isEmpty()) return;
+
+        ElementMetadata meta = metadata.get(object.getRecognizedStructureId());
+        if (meta == null) return;
+
+        if (meta.getConfidence() != 1.0) {
+            gen.writeNumberField(JsonName.CONFIDENCE, meta.getConfidence());
+        }
+        if (meta.getSourceLabel() >= 0) {
+            gen.writeNumberField(JsonName.SOURCE_LABEL, meta.getSourceLabel());
+        }
+
+        if (meta.getHeadingInferenceMethod() != null) {
+            gen.writeObjectFieldStart("heading inference");
+            gen.writeStringField("method", meta.getHeadingInferenceMethod());
+            if (meta.getBboxHeightPx() != null) {
+                gen.writeNumberField("bbox height px", meta.getBboxHeightPx());
+            }
+            gen.writeEndObject();
+        }
+
+        if (meta.getTsr() != null) {
+            gen.writeObjectFieldStart("tsr");
+            gen.writeNumberField("num cells", meta.getTsr().getNumCells());
+            if (meta.getTsr().getHtml() != null && !meta.getTsr().getHtml().isEmpty()) {
+                gen.writeStringField("html", meta.getTsr().getHtml());
+            }
+            if (meta.getTsr().getRunTimeMs() > 0) {
+                gen.writeNumberField("run time ms", meta.getTsr().getRunTimeMs());
+            }
+            gen.writeEndObject();
+        }
+
+        if (meta.getCaption() != null) {
+            gen.writeObjectFieldStart("caption");
+            if (meta.getCaption().getText() != null) {
+                gen.writeStringField("text", meta.getCaption().getText());
+            }
+            if (meta.getCaption().getLanguage() != null) {
+                gen.writeStringField("language", meta.getCaption().getLanguage());
+            }
+            if (meta.getCaption().getRunTimeMs() > 0) {
+                gen.writeNumberField("run time ms", meta.getCaption().getRunTimeMs());
+            }
+            gen.writeEndObject();
+        }
+
+        if (meta.getRegionlistResolution() != null) {
+            gen.writeObjectFieldStart("regionlist resolution");
+            gen.writeStringField("strategy", meta.getRegionlistResolution().getStrategy());
+            gen.writeBooleanField("tsr attempted", meta.getRegionlistResolution().isTsrAttempted());
+            if (meta.getRegionlistResolution().getTsrResult() != null) {
+                gen.writeStringField("tsr result", meta.getRegionlistResolution().getTsrResult());
+            }
+            gen.writeEndObject();
+        }
+
+        if (meta.getWordMatchMethod() != null) {
+            gen.writeObjectFieldStart("word match");
+            gen.writeStringField("method", meta.getWordMatchMethod());
+            gen.writeNumberField("matched words", meta.getMatchedWordCount());
+            gen.writeEndObject();
+        }
+    }
+
     public static void writeEssentialInfo(JsonGenerator jsonGenerator, IObject object, String type) throws IOException {
         jsonGenerator.writeStringField(JsonName.TYPE, type);
         Long id = object.getRecognizedStructureId();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/SerializerUtil.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/SerializerUtil.java
@@ -110,6 +110,13 @@ public class SerializerUtil {
             gen.writeNumberField("matched words", meta.getMatchedWordCount());
             gen.writeEndObject();
         }
+
+        if (meta.getTextSource() != null) {
+            gen.writeStringField("text source", meta.getTextSource());
+        }
+        if (meta.getStreamOcrSimilarity() != null) {
+            gen.writeNumberField("stream ocr similarity", meta.getStreamOcrSimilarity());
+        }
     }
 
     public static void writeEssentialInfo(JsonGenerator jsonGenerator, IObject object, String type) throws IOException {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/TableSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/TableSerializer.java
@@ -60,6 +60,7 @@ public class TableSerializer extends StdSerializer<TableBorder> {
             }
             jsonGenerator.writeEndArray();
         }
+        SerializerUtil.writeMetadataIfPresent(jsonGenerator, table);
         jsonGenerator.writeEndObject();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -3,6 +3,7 @@ package org.opendataloader.pdf.processors;
 import org.opendataloader.pdf.autotagging.ChunksWriter;
 import org.opendataloader.pdf.autotagging.OperatorStreamKey;
 import org.opendataloader.pdf.entities.EnrichedImageChunk;
+import org.opendataloader.pdf.entities.SemanticFootnote;
 import org.opendataloader.pdf.entities.SemanticFormula;
 import org.verapdf.as.ASAtom;
 import org.verapdf.as.io.ASMemoryInStream;
@@ -385,6 +386,8 @@ public class AutoTaggingProcessor {
             // Fallback: heading inside a nested context (list/table) — use original level
             createHeadingStructElem((SemanticHeading) object, parentStructElem, cosDocument,
                     ((SemanticHeading) object).getHeadingLevel());
+        } else if (object instanceof SemanticFootnote) {
+            createFootnoteStructElem((SemanticFootnote) object, parentStructElem, cosDocument);
         } else if (object instanceof SemanticParagraph) {
             createParagraphStructElem((SemanticParagraph) object, parentStructElem, cosDocument);
         } else if (object instanceof PDFList) {
@@ -417,6 +420,12 @@ public class AutoTaggingProcessor {
     private static void createParagraphStructElem(SemanticParagraph paragraph, COSObject parent, COSDocument cosDocument) {
         COSObject paragraphObject = addStructElement(parent, cosDocument, TaggedPDFConstants.P, paragraph.getPageNumber());
         processTextNode(paragraph, paragraphObject);
+    }
+
+    private static void createFootnoteStructElem(SemanticFootnote footnote, COSObject parent, COSDocument cosDocument) {
+        COSObject noteObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FENOTE, footnote.getPageNumber());
+        noteObject.setKey(ASAtom.NOTE_TYPE, COSName.construct(ASAtom.getASAtom("Footnote")));
+        processTextNode(footnote, noteObject);
     }
 
     private static void createCaptionStructElem(SemanticCaption caption, COSObject parent, COSDocument cosDocument, boolean isFirstChild) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -348,18 +348,23 @@ public class AutoTaggingProcessor {
                 }
                 // Create Link struct element
                 COSObject linkElem = addStructElement(seDocument, cosDocument, TaggedPDFConstants.LINK, pageNumber);
-                // Set Alt text to URI or "Link"
-                String altText = uriString != null ? uriString : "Link";
+                // PDF/UA-2 clause 8.9.4.2.1 requires the annotation's Contents and the enclosing
+                // struct element's Alt to be identical when both are present. Prefer any existing
+                // Contents authored on the annotation (accessibility text the author already
+                // wrote), otherwise fall back to URI, then to "Link".
+                String existingContents = annotation.getContents();
+                String altText;
+                if (existingContents != null && !existingContents.isEmpty()) {
+                    altText = existingContents;
+                } else {
+                    altText = uriString != null ? uriString : "Link";
+                    annotObj.setKey(ASAtom.CONTENTS,
+                        COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                }
                 linkElem.setKey(ASAtom.ALT, COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
                 // Assign StructParent integer to annotation and register in parent tree
                 int structParentInt = annotStructParentKey++;
                 annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
-                // Set Contents on annotation if absent.
-                String contents = annotation.getContents();
-                if (contents == null || contents.isEmpty()) {
-                    annotObj.setKey(ASAtom.CONTENTS,
-                        COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
-                }
                 annotationStructParents.put(structParentInt, linkElem);
                 rewriteDestinationToStructDestination(annotObj, document, pageNumber);
                 cosDocument.addChangedObject(annotObj);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -42,6 +42,8 @@ public class AutoTaggingProcessor {
     private static final Map<Integer, COSObject> annotationStructParents = new HashMap<>();
     // First created struct element per page, used to rewrite page destinations to structure destinations.
     private static final Map<Integer, COSObject> pageNumberToFirstStructElement = new HashMap<>();
+    // Namespace for PDF 2.0-only structure types (FENote, etc.), created in createStructTreeRoot.
+    private static COSObject pdf2_0Namespace;
     // Caption elements keyed by their linked content ID (Raman's approach from #377)
     private static final Map<Long, SemanticCaption> structElementIdToCaptionMap = new HashMap<>();
     private static boolean isPDF2_0 = false;
@@ -149,6 +151,16 @@ public class AutoTaggingProcessor {
         structTreeRoot.setKey(ASAtom.TYPE, COSName.construct(ASAtom.STRUCT_TREE_ROOT));
         cosDocument.addObject(structTreeRoot);
         structTreeRoot.setKey(ASAtom.PARENT_TREE_NEXT_KEY, COSInteger.construct(document.getNumberOfPages()));
+        // Create the PDF 2.0 namespace (pdf2/ssn) so PDF 2.0-only structure types (FENote, ...)
+        // can be tagged with an explicit /NS. PDF/UA-2 clause 8.2.4.1 rejects non-standard types
+        // under the default pdf/ssn namespace; inheritance alone isn't enough for veraPDF.
+        pdf2_0Namespace = COSDictionary.construct(ASAtom.NS, TaggedPDFConstants.PDF2_NAMESPACE);
+        pdf2_0Namespace.setNameKey(ASAtom.TYPE, ASAtom.NAMESPACE);
+        pdf2_0Namespace = COSIndirect.construct(pdf2_0Namespace, cosDocument);
+        cosDocument.addObject(pdf2_0Namespace);
+        COSObject namespaces = COSArray.construct();
+        namespaces.add(pdf2_0Namespace);
+        structTreeRoot.setKey(ASAtom.NAMESPACES, namespaces);
         cosDocument.addChangedObject(catalog.getObject());
         return structTreeRoot;
     }
@@ -503,6 +515,10 @@ public class AutoTaggingProcessor {
 
     private static void createFootnoteStructElem(SemanticFootnote footnote, COSObject parent, COSDocument cosDocument) {
         COSObject noteObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FENOTE, footnote.getPageNumber());
+        // FENote is a PDF 2.0-only type; explicit /NS is required for PDF/UA-2 validators.
+        if (pdf2_0Namespace != null) {
+            noteObject.setKey(ASAtom.NS, pdf2_0Namespace);
+        }
         noteObject.setKey(ASAtom.NOTE_TYPE, COSName.construct(ASAtom.getASAtom("Footnote")));
         processTextNode(footnote, noteObject);
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -40,6 +40,8 @@ public class AutoTaggingProcessor {
     private static final Map<OperatorStreamKey, Integer> structParentsIntegers = new LinkedHashMap<>();
     // annotation StructParent entries: int key -> single struct element (Link)
     private static final Map<Integer, COSObject> annotationStructParents = new HashMap<>();
+    // First created struct element per page, used to rewrite page destinations to structure destinations.
+    private static final Map<Integer, COSObject> pageNumberToFirstStructElement = new HashMap<>();
     // Caption elements keyed by their linked content ID (Raman's approach from #377)
     private static final Map<Long, SemanticCaption> structElementIdToCaptionMap = new HashMap<>();
     private static boolean isPDF2_0 = false;
@@ -60,6 +62,7 @@ public class AutoTaggingProcessor {
         structParents.clear();
         structParentsIntegers.clear();
         annotationStructParents.clear();
+        pageNumberToFirstStructElement.clear();
         structElementIdToCaptionMap.clear();
         imageChunkFigureCounter = 0;
         isPDF2_0 = document.getVersion() == 2.0F;
@@ -199,6 +202,7 @@ public class AutoTaggingProcessor {
         structElement.setKey(ASAtom.P, parent);
         if (pageNumber != null) {
             structElement.setKey(ASAtom.PG, cosDocument.getPDDocument().getPages().get(pageNumber).getObject());
+            pageNumberToFirstStructElement.putIfAbsent(pageNumber, structElement);
         }
         cosDocument.addObject(structElement);
         return structElement;
@@ -357,6 +361,7 @@ public class AutoTaggingProcessor {
                         COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
                 }
                 annotationStructParents.put(structParentInt, linkElem);
+                rewriteDestinationToStructDestination(annotObj, document, pageNumber);
                 cosDocument.addChangedObject(annotObj);
                 pageChanged = true;
                 // Create OBJR pointing to the annotation
@@ -379,6 +384,75 @@ public class AutoTaggingProcessor {
                 cosDocument.addChangedObject(page.getObject());
             }
         }
+    }
+
+    /**
+     * Make a Link annotation's destination compliant with PDF/UA-2 clause 8.8 (all internal
+     * destinations must be structure destinations).
+     *
+     * <p>Behaviour differs between annotation {@code /Dest} and action {@code /A /D}:
+     * <ul>
+     *   <li>For annotation {@code /Dest}: veraPDF checks the array's first element is a struct
+     *       element (via {@code at(0).knownKey(S)}), so rewrite the first slot to a struct elem ref.
+     *   <li>For a GoTo action: veraPDF first checks {@code /SD} on the action dict itself, so add
+     *       an {@code /SD [structElem /Fit]} entry alongside (or instead of) the existing {@code /D}.
+     * </ul>
+     */
+    private static void rewriteDestinationToStructDestination(COSObject annotObj, PDDocument document, int annotPageNumber) {
+        COSDocument cosDocument = document.getDocument();
+        COSObject dest = annotObj.getKey(ASAtom.DEST);
+        if (dest != null && !dest.empty()) {
+            COSObject structDestArray = buildStructDestArray(dest, document, annotPageNumber);
+            if (structDestArray != null) {
+                annotObj.setKey(ASAtom.DEST, structDestArray);
+            }
+        }
+        COSObject action = annotObj.getKey(ASAtom.A);
+        if (action == null || action.empty() || action.getType() != COSObjType.COS_DICT) {
+            return;
+        }
+        if (!ASAtom.GO_TO.equals(action.getNameKey(ASAtom.S))) {
+            return;
+        }
+        COSObject d = action.getKey(ASAtom.D);
+        COSObject structDestArray = buildStructDestArray(d, document, annotPageNumber);
+        if (structDestArray != null) {
+            action.setKey(ASAtom.getASAtom("SD"), structDestArray);
+            cosDocument.addChangedObject(action);
+        }
+    }
+
+    /**
+     * Build a {@code [structElem /Fit]} array suitable as a structure destination. Uses the
+     * target page from an array-form page destination when available, otherwise falls back to
+     * the annotation's own page.
+     */
+    private static COSObject buildStructDestArray(COSObject originalDest, PDDocument document, int annotPageNumber) {
+        COSObject target = null;
+        if (originalDest != null && !originalDest.empty()
+                && originalDest.getType() == COSObjType.COS_ARRAY && originalDest.size() >= 1) {
+            COSObject first = originalDest.at(0);
+            if (first != null && !first.empty() && first.getType() == COSObjType.COS_DICT
+                    && ASAtom.PAGE.equals(first.getNameKey(ASAtom.TYPE))) {
+                List<PDPage> pages = document.getPages();
+                for (int i = 0; i < pages.size(); i++) {
+                    if (pages.get(i).getObject().getObjectKey().equals(first.getObjectKey())) {
+                        target = pageNumberToFirstStructElement.get(i);
+                        break;
+                    }
+                }
+            }
+        }
+        if (target == null) {
+            target = pageNumberToFirstStructElement.get(annotPageNumber);
+        }
+        if (target == null) {
+            return null;
+        }
+        COSObject arr = COSArray.construct();
+        arr.add(target);
+        arr.add(COSName.construct(ASAtom.getASAtom("Fit")));
+        return arr;
     }
 
     private static void createStructElem(IObject object, COSObject parentStructElem, COSDocument cosDocument) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -513,6 +513,25 @@ public class AutoTaggingProcessor {
         processTextNode(paragraph, paragraphObject);
     }
 
+    /**
+     * Remove Unicode Private Use Area code points. PDF/UA-2 clause 8.4.3.3 forbids PUA chars in
+     * /Alt entries. Iterates by code point so surrogate pairs for supplementary PUA are handled.
+     */
+    private static String stripPuaCodePoints(String in) {
+        if (in == null || in.isEmpty()) return in;
+        StringBuilder sb = new StringBuilder(in.length());
+        int i = 0;
+        while (i < in.length()) {
+            int cp = in.codePointAt(i);
+            boolean isPua = (cp >= 0xE000 && cp <= 0xF8FF)
+                    || (cp >= 0xF0000 && cp <= 0xFFFFD)
+                    || (cp >= 0x100000 && cp <= 0x10FFFD);
+            if (!isPua) sb.appendCodePoint(cp);
+            i += Character.charCount(cp);
+        }
+        return sb.toString();
+    }
+
     private static void createFootnoteStructElem(SemanticFootnote footnote, COSObject parent, COSDocument cosDocument) {
         COSObject noteObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FENOTE, footnote.getPageNumber());
         // FENote is a PDF 2.0-only type; explicit /NS is required for PDF/UA-2 validators.
@@ -541,6 +560,10 @@ public class AutoTaggingProcessor {
         String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
                 ? ((EnrichedImageChunk) image).sanitizeDescription()
                 : "image " + (++imageChunkFigureCounter);
+        altText = stripPuaCodePoints(altText);
+        if (altText.isEmpty()) {
+            altText = "image " + (++imageChunkFigureCounter);
+        }
         figureObject.setKey(ASAtom.ALT,
                 COSString.construct(altText.getBytes(StandardCharsets.UTF_16), false));
         cosDocument.addChangedObject(figureObject);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -151,16 +151,20 @@ public class AutoTaggingProcessor {
         structTreeRoot.setKey(ASAtom.TYPE, COSName.construct(ASAtom.STRUCT_TREE_ROOT));
         cosDocument.addObject(structTreeRoot);
         structTreeRoot.setKey(ASAtom.PARENT_TREE_NEXT_KEY, COSInteger.construct(document.getNumberOfPages()));
-        // Create the PDF 2.0 namespace (pdf2/ssn) so PDF 2.0-only structure types (FENote, ...)
-        // can be tagged with an explicit /NS. PDF/UA-2 clause 8.2.4.1 rejects non-standard types
-        // under the default pdf/ssn namespace; inheritance alone isn't enough for veraPDF.
-        pdf2_0Namespace = COSDictionary.construct(ASAtom.NS, TaggedPDFConstants.PDF2_NAMESPACE);
-        pdf2_0Namespace.setNameKey(ASAtom.TYPE, ASAtom.NAMESPACE);
-        pdf2_0Namespace = COSIndirect.construct(pdf2_0Namespace, cosDocument);
-        cosDocument.addObject(pdf2_0Namespace);
-        COSObject namespaces = COSArray.construct();
-        namespaces.add(pdf2_0Namespace);
-        structTreeRoot.setKey(ASAtom.NAMESPACES, namespaces);
+        // Only emit the PDF 2.0 namespace (pdf2/ssn) when the output is PDF 2.0.
+        // The namespace gates PDF 2.0-only structure types like FENote (tagged
+        // with an explicit /NS to satisfy PDF/UA-2 clause 8.2.4.1). Attaching
+        // /Namespaces on a PDF 1.x file would produce invalid output.
+        pdf2_0Namespace = null;
+        if (isPDF2_0) {
+            pdf2_0Namespace = COSDictionary.construct(ASAtom.NS, TaggedPDFConstants.PDF2_NAMESPACE);
+            pdf2_0Namespace.setNameKey(ASAtom.TYPE, ASAtom.NAMESPACE);
+            pdf2_0Namespace = COSIndirect.construct(pdf2_0Namespace, cosDocument);
+            cosDocument.addObject(pdf2_0Namespace);
+            COSObject namespaces = COSArray.construct();
+            namespaces.add(pdf2_0Namespace);
+            structTreeRoot.setKey(ASAtom.NAMESPACES, namespaces);
+        }
         cosDocument.addChangedObject(catalog.getObject());
         return structTreeRoot;
     }
@@ -461,8 +465,11 @@ public class AutoTaggingProcessor {
 
     /**
      * Build a {@code [structElem /Fit]} array suitable as a structure destination. Uses the
-     * target page from an array-form page destination when available, otherwise falls back to
-     * the annotation's own page.
+     * target page from an array-form page destination when available. Falls back to the
+     * annotation's own page only when the destination is entirely absent — a present-but-
+     * unresolvable destination (named, non-array, or an unmatched page) returns {@code null}
+     * so the caller leaves the original destination untouched rather than silently
+     * redirecting a cross-page link to the annotation's own page.
      */
     private static COSObject buildStructDestArray(COSObject originalDest, PDDocument document, int annotPageNumber) {
         COSObject target = null;
@@ -560,12 +567,17 @@ public class AutoTaggingProcessor {
     }
 
     private static void createFootnoteStructElem(SemanticFootnote footnote, COSObject parent, COSDocument cosDocument) {
-        COSObject noteObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FENOTE, footnote.getPageNumber());
-        // FENote is a PDF 2.0-only type; explicit /NS is required for PDF/UA-2 validators.
-        if (pdf2_0Namespace != null) {
+        // FENote + /NS + /NoteType is the PDF 2.0 path (PDF/UA-2 clause 8.2.4.1).
+        // For PDF 1.x output, fall back to the Note standard structure type so the
+        // result is valid for PDF 1.7 tagged-PDF consumers.
+        boolean usePdf2Footnote = isPDF2_0 && pdf2_0Namespace != null;
+        COSObject noteObject = addStructElement(parent, cosDocument,
+                usePdf2Footnote ? TaggedPDFConstants.FENOTE : TaggedPDFConstants.NOTE,
+                footnote.getPageNumber());
+        if (usePdf2Footnote) {
             noteObject.setKey(ASAtom.NS, pdf2_0Namespace);
+            noteObject.setKey(ASAtom.NOTE_TYPE, COSName.construct(ASAtom.getASAtom("Footnote")));
         }
-        noteObject.setKey(ASAtom.NOTE_TYPE, COSName.construct(ASAtom.getASAtom("Footnote")));
         processTextNode(footnote, noteObject);
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -366,14 +366,26 @@ public class AutoTaggingProcessor {
                 // wrote), otherwise fall back to URI, then to "Link".
                 String existingContents = annotation.getContents();
                 String altText;
+                byte[] altBytes;
                 if (existingContents != null && !existingContents.isEmpty()) {
                     altText = existingContents;
+                    // Preserve the annotation's raw Contents bytes so /Alt is byte-identical to
+                    // /Contents (PDF/UA-2 clause 8.9.4.2.1 requires identity). Re-encoding via
+                    // String would change the PDF literal-vs-hex form and fail the equality check.
+                    COSObject contentsObj = annotObj.getKey(ASAtom.CONTENTS);
+                    if (contentsObj != null && contentsObj.getType() == COSObjType.COS_STRING) {
+                        altBytes = contentsObj.getString().getBytes(StandardCharsets.UTF_16);
+                    } else {
+                        altBytes = altText.getBytes(StandardCharsets.UTF_16);
+                    }
                 } else {
                     altText = uriString != null ? uriString : "Link";
-                    annotObj.setKey(ASAtom.CONTENTS,
-                        COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                    // UTF-16 with BOM. Without BOM, PDF readers interpret a COSString as
+                    // PDFDocEncoding and silently corrupt non-ASCII (e.g. NBSP 0xA0 → €).
+                    altBytes = altText.getBytes(StandardCharsets.UTF_16);
+                    annotObj.setKey(ASAtom.CONTENTS, COSString.construct(altBytes));
                 }
-                linkElem.setKey(ASAtom.ALT, COSString.construct(altText.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                linkElem.setKey(ASAtom.ALT, COSString.construct(altBytes));
                 // Assign StructParent integer to annotation and register in parent tree
                 int structParentInt = annotStructParentKey++;
                 annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -365,27 +365,31 @@ public class AutoTaggingProcessor {
                 // Contents authored on the annotation (accessibility text the author already
                 // wrote), otherwise fall back to URI, then to "Link".
                 String existingContents = annotation.getContents();
-                String altText;
-                byte[] altBytes;
+                // Build a single COSString object and use it for both /Contents and
+                // /Alt so PDF/UA-2 clause 8.9.4.2.1 (byte-identity) holds. Hex form
+                // (isHex=true) is required because UTF-16BE code units whose low
+                // byte is 0x5C would be misparsed as a backslash escape inside a
+                // PDF literal string, corrupting non-ASCII text. UTF-16 with BOM
+                // keeps readers from interpreting the string as PDFDocEncoding.
+                COSObject linkTextObject;
                 if (existingContents != null && !existingContents.isEmpty()) {
-                    altText = existingContents;
-                    // Preserve the annotation's raw Contents bytes so /Alt is byte-identical to
-                    // /Contents (PDF/UA-2 clause 8.9.4.2.1 requires identity). Re-encoding via
-                    // String would change the PDF literal-vs-hex form and fail the equality check.
+                    // Preserve the annotation's existing COSString reference when
+                    // present — re-encoding would change literal/hex form and
+                    // break the equality check.
                     COSObject contentsObj = annotObj.getKey(ASAtom.CONTENTS);
                     if (contentsObj != null && contentsObj.getType() == COSObjType.COS_STRING) {
-                        altBytes = contentsObj.getString().getBytes(StandardCharsets.UTF_16);
+                        linkTextObject = contentsObj;
                     } else {
-                        altBytes = altText.getBytes(StandardCharsets.UTF_16);
+                        linkTextObject = COSString.construct(
+                                existingContents.getBytes(StandardCharsets.UTF_16), true);
                     }
                 } else {
-                    altText = uriString != null ? uriString : "Link";
-                    // UTF-16 with BOM. Without BOM, PDF readers interpret a COSString as
-                    // PDFDocEncoding and silently corrupt non-ASCII (e.g. NBSP 0xA0 → €).
-                    altBytes = altText.getBytes(StandardCharsets.UTF_16);
-                    annotObj.setKey(ASAtom.CONTENTS, COSString.construct(altBytes));
+                    String altText = uriString != null ? uriString : "Link";
+                    linkTextObject = COSString.construct(
+                            altText.getBytes(StandardCharsets.UTF_16), true);
+                    annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
                 }
-                linkElem.setKey(ASAtom.ALT, COSString.construct(altBytes));
+                linkElem.setKey(ASAtom.ALT, linkTextObject);
                 // Assign StructParent integer to annotation and register in parent tree
                 int structParentInt = annotStructParentKey++;
                 annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -509,16 +509,11 @@ public class AutoTaggingProcessor {
     private static COSObject createTableStructElemReturning(TableBorder table, COSObject parent, COSDocument cosDocument) {
         COSObject tableObject = addStructElement(parent, cosDocument, TaggedPDFConstants.TABLE, table.getPageNumber());
 
-        // THead wraps the first row (row 0)
-        COSObject theadObject = addStructElement(tableObject, cosDocument, "THead", table.getPageNumber());
-        addTableRow(table, 0, theadObject, cosDocument, true);
-
-        // TBody wraps remaining rows (row 1+), only if data rows exist
-        if (table.getNumberOfRows() > 1) {
-            COSObject tbodyObject = addStructElement(tableObject, cosDocument, "TBody", table.getPageNumber());
-            for (int rowNumber = 1; rowNumber < table.getNumberOfRows(); rowNumber++) {
-                addTableRow(table, rowNumber, tbodyObject, cosDocument, false);
-            }
+        // Flat structure: Table > TR > TH/TD (no THead/TBody wrappers)
+        // First row uses TH + Scope="Column" for header identification.
+        // This is compatible with both Adobe Acrobat and veraPDF PDF/UA-2 validation.
+        for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
+            addTableRow(table, rowNumber, tableObject, cosDocument, rowNumber == 0);
         }
 
         addCaptionIfPresent(table, tableObject, cosDocument);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -499,31 +499,45 @@ public class AutoTaggingProcessor {
 
     private static COSObject createTableStructElemReturning(TableBorder table, COSObject parent, COSDocument cosDocument) {
         COSObject tableObject = addStructElement(parent, cosDocument, TaggedPDFConstants.TABLE, table.getPageNumber());
-        for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
-            TableBorderRow row = table.getRow(rowNumber);
-            COSObject rowObject = addStructElement(tableObject, cosDocument, TaggedPDFConstants.TR, row.getPageNumber());
-            boolean isHeaderRow = (rowNumber == 0);
-            for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
-                TableBorderCell cell = row.getCell(colNumber);
-                if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
-                    String cellTag = isHeaderRow ? TaggedPDFConstants.TH : TaggedPDFConstants.TD;
-                    COSObject cellObject = addStructElement(rowObject, cosDocument, cellTag, cell.getPageNumber());
-                    if (isHeaderRow) {
-                        addAttributeToStructElem(cellObject, ASAtom.TABLE,
-                            ASAtom.SCOPE, COSName.construct(ASAtom.getASAtom("Column")));
-                    }
-                    if (cell.getColSpan() != 1) {
-                        addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.COL_SPAN, COSInteger.construct(cell.getColSpan()));
-                    }
-                    if (cell.getRowSpan() != 1) {
-                        addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.ROW_SPAN, COSInteger.construct(cell.getRowSpan()));
-                    }
-                    addKids(cell.getContents(), cellObject, cosDocument);
-                }
+
+        // THead wraps the first row (row 0)
+        COSObject theadObject = addStructElement(tableObject, cosDocument, "THead", table.getPageNumber());
+        addTableRow(table, 0, theadObject, cosDocument, true);
+
+        // TBody wraps remaining rows (row 1+), only if data rows exist
+        if (table.getNumberOfRows() > 1) {
+            COSObject tbodyObject = addStructElement(tableObject, cosDocument, "TBody", table.getPageNumber());
+            for (int rowNumber = 1; rowNumber < table.getNumberOfRows(); rowNumber++) {
+                addTableRow(table, rowNumber, tbodyObject, cosDocument, false);
             }
         }
+
         addCaptionIfPresent(table, tableObject, cosDocument);
         return tableObject;
+    }
+
+    private static void addTableRow(TableBorder table, int rowNumber, COSObject parent,
+                                    COSDocument cosDocument, boolean isHeaderRow) {
+        TableBorderRow row = table.getRow(rowNumber);
+        COSObject rowObject = addStructElement(parent, cosDocument, TaggedPDFConstants.TR, row.getPageNumber());
+        for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
+            TableBorderCell cell = row.getCell(colNumber);
+            if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
+                String cellTag = isHeaderRow ? TaggedPDFConstants.TH : TaggedPDFConstants.TD;
+                COSObject cellObject = addStructElement(rowObject, cosDocument, cellTag, cell.getPageNumber());
+                if (isHeaderRow) {
+                    addAttributeToStructElem(cellObject, ASAtom.TABLE,
+                        ASAtom.SCOPE, COSName.construct(ASAtom.getASAtom("Column")));
+                }
+                if (cell.getColSpan() != 1) {
+                    addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.COL_SPAN, COSInteger.construct(cell.getColSpan()));
+                }
+                if (cell.getRowSpan() != 1) {
+                    addAttributeToStructElem(cellObject, ASAtom.TABLE, ASAtom.ROW_SPAN, COSInteger.construct(cell.getRowSpan()));
+                }
+                addKids(cell.getContents(), cellObject, cosDocument);
+            }
+        }
     }
 
     private static void createStructElemForTextBlock(TableBorder table, COSObject parent, COSDocument cosDocument) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -475,8 +475,17 @@ public class AutoTaggingProcessor {
             addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.CONTINUED_FROM,
                 COSString.construct(String.valueOf(list.getPreviousList().getRecognizedStructureId()).getBytes()));
         }
-        addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.LIST_NUMBERING,
-            COSName.construct(ListProcessor.getListNumbering(list.getNumberingStyle())));
+        ASAtom numbering = ListProcessor.getListNumbering(list.getNumberingStyle());
+        if (numbering == ASAtom.NONE) {
+            boolean hasLabel = false;
+            for (ListItem item : list.getListItems()) {
+                if (item.getLabelLength() > 0) { hasLabel = true; break; }
+            }
+            if (hasLabel) {
+                numbering = ASAtom.ORDERED;
+            }
+        }
+        addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.LIST_NUMBERING, COSName.construct(numbering));
 
         for (ListItem listItem : list.getListItems()) {
             COSObject listItemObject = addStructElement(listObject, cosDocument, TaggedPDFConstants.LI, listItem.getPageNumber());

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -458,8 +458,10 @@ public class AutoTaggingProcessor {
      */
     private static COSObject buildStructDestArray(COSObject originalDest, PDDocument document, int annotPageNumber) {
         COSObject target = null;
-        if (originalDest != null && !originalDest.empty()
-                && originalDest.getType() == COSObjType.COS_ARRAY && originalDest.size() >= 1) {
+        boolean destIsPresent = originalDest != null && !originalDest.empty();
+        boolean destIsResolvableArray = destIsPresent
+            && originalDest.getType() == COSObjType.COS_ARRAY && originalDest.size() >= 1;
+        if (destIsResolvableArray) {
             COSObject first = originalDest.at(0);
             if (first != null && !first.empty() && first.getType() == COSObjType.COS_DICT
                     && ASAtom.PAGE.equals(first.getNameKey(ASAtom.TYPE))) {
@@ -472,7 +474,12 @@ public class AutoTaggingProcessor {
                 }
             }
         }
-        if (target == null) {
+        // Fallback to the annotation's own page only when the destination is entirely
+        // absent. If a destination is present but unresolvable (named destination,
+        // non-array form, or page not found) we must NOT rewrite it to the link's own
+        // page — that silently redirects cross-page GoTo links. Return null so the
+        // caller can leave the destination untouched.
+        if (target == null && !destIsPresent) {
             target = pageNumberToFirstStructElement.get(annotPageNumber);
         }
         if (target == null) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -564,8 +564,11 @@ public class AutoTaggingProcessor {
         if (altText.isEmpty()) {
             altText = "image " + (++imageChunkFigureCounter);
         }
+        // Write as hex string (isHex=true). UTF-16BE code units whose low byte is 0x5C (e.g. U+D55C "한")
+        // would be misparsed as a backslash escape inside a PDF literal string, shifting all subsequent
+        // bytes by one and producing PUA code points that fail PDF/UA-2 clause 8.4.3.3.
         figureObject.setKey(ASAtom.ALT,
-                COSString.construct(altText.getBytes(StandardCharsets.UTF_16), false));
+                COSString.construct(altText.getBytes(StandardCharsets.UTF_16), true));
         cosDocument.addChangedObject(figureObject);
         processImageNode(image, figureObject);
         addCaptionIfPresent(image, figureObject, cosDocument);
@@ -578,7 +581,7 @@ public class AutoTaggingProcessor {
         addAttributeToStructElem(formulaObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         String altText = formula.getLatex().isEmpty() ? "formula" : formula.getLatex();
         formulaObject.setKey(ASAtom.ALT,
-                COSString.construct(altText.getBytes(StandardCharsets.UTF_16), false));
+                COSString.construct(altText.getBytes(StandardCharsets.UTF_16), true));
         cosDocument.addChangedObject(formulaObject);
         addMcidChildren(formula.getStreamInfos(), formula.getPageNumber(), formulaObject);
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -380,8 +380,12 @@ public class AutoTaggingProcessor {
                     if (contentsObj != null && contentsObj.getType() == COSObjType.COS_STRING) {
                         linkTextObject = contentsObj;
                     } else {
+                        // Non-string /Contents (rare, e.g. indirect/array shape). Build a hex
+                        // UTF-16 COSString from the parsed text and write it back to /Contents
+                        // too so the annotation and /Alt remain byte-identical per §8.9.4.2.1.
                         linkTextObject = COSString.construct(
                                 existingContents.getBytes(StandardCharsets.UTF_16), true);
+                        annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
                     }
                 } else {
                     String altText = uriString != null ? uriString : "Link";
@@ -620,14 +624,15 @@ public class AutoTaggingProcessor {
                 COSString.construct(String.valueOf(list.getPreviousList().getRecognizedStructureId()).getBytes()));
         }
         ASAtom numbering = ListProcessor.getListNumbering(list.getNumberingStyle());
-        if (numbering == ASAtom.NONE) {
+        // ListProcessor.getListNumbering returns null for unmapped styles. Fold
+        // null into NONE so the hasLabel promotion and COSName.construct below
+        // never receive null.
+        if (numbering == null || numbering == ASAtom.NONE) {
             boolean hasLabel = false;
             for (ListItem item : list.getListItems()) {
                 if (item.getLabelLength() > 0) { hasLabel = true; break; }
             }
-            if (hasLabel) {
-                numbering = ASAtom.ORDERED;
-            }
+            numbering = hasLabel ? ASAtom.ORDERED : ASAtom.NONE;
         }
         addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.LIST_NUMBERING, COSName.construct(numbering));
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -132,7 +132,8 @@ public class DocumentProcessor {
         contentSanitizer.sanitizeContents(contents);
         long extractionNs = System.nanoTime() - t0;
 
-        return new ExtractionResult(contents, extractionNs, HybridDocumentProcessor.getLastHybridTimings());
+        return new ExtractionResult(contents, extractionNs, HybridDocumentProcessor.getLastHybridTimings(),
+            HybridDocumentProcessor.getLastElementMetadata());
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -16,6 +16,7 @@
 package org.opendataloader.pdf.processors;
 
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.hybrid.ElementMetadata;
 import org.opendataloader.pdf.processors.readingorder.XYCutPlusPlusSorter;
 import org.opendataloader.pdf.json.JsonWriter;
 import org.opendataloader.pdf.markdown.MarkdownGenerator;
@@ -94,7 +95,7 @@ public class DocumentProcessor {
 
         // Phase 2: Output (JSON/MD/HTML/PDF/Text)
         long t0 = System.nanoTime();
-        generateOutputs(inputPdfName, extraction.getContents(), config);
+        generateOutputs(inputPdfName, extraction.getContents(), config, extraction.getElementMetadata());
         long outputNs = System.nanoTime() - t0;
 
         return new ProcessingResult(extraction.getHybridTimings(), extraction.getExtractionNs(), outputNs);
@@ -350,7 +351,8 @@ public class DocumentProcessor {
         return pagesToProcess == null || pagesToProcess.contains(pageNumber);
     }
 
-    private static void generateOutputs(String inputPdfName, List<List<IObject>> contents, Config config) throws IOException {
+    private static void generateOutputs(String inputPdfName, List<List<IObject>> contents, Config config,
+                                           Map<Long, ElementMetadata> elementMetadata) throws IOException {
         // Stdout mode: write primary format to stdout, skip file I/O
         if (config.isOutputStdout()) {
             java.io.Writer stdoutWriter = new java.io.BufferedWriter(
@@ -392,7 +394,7 @@ public class DocumentProcessor {
             pdfWriter.updatePDF(inputPDF, config.getPassword(), config.getOutputFolder(), contents);
         }
         if (config.isGenerateJSON()) {
-            JsonWriter.writeToJson(inputPDF, config.getOutputFolder(), contents);
+            JsonWriter.writeToJson(inputPDF, config.getOutputFolder(), contents, elementMetadata);
         }
         if (config.isGenerateMarkdown()) {
             try (MarkdownGenerator markdownGenerator = MarkdownGeneratorFactory.getMarkdownGenerator(inputPDF,

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -133,8 +133,14 @@ public class DocumentProcessor {
         contentSanitizer.sanitizeContents(contents);
         long extractionNs = System.nanoTime() - t0;
 
+        // Re-key metadata by actual IObject IDs in contents.
+        // After enrichment, IObject recognizedStructureIds may differ from transformer-assigned IDs.
+        // Match metadata to IObjects by bbox proximity.
+        Map<Long, ElementMetadata> rawMetadata = HybridDocumentProcessor.getLastElementMetadata();
+        Map<Long, ElementMetadata> remappedMetadata = remapMetadataToContents(rawMetadata, contents);
+
         return new ExtractionResult(contents, extractionNs, HybridDocumentProcessor.getLastHybridTimings(),
-            HybridDocumentProcessor.getLastElementMetadata());
+            remappedMetadata);
     }
 
     /**
@@ -347,6 +353,34 @@ public class DocumentProcessor {
      * @param pagesToProcess set of valid page numbers to process, or null for all pages
      * @return true if the page should be processed
      */
+    /**
+     * Re-maps ElementMetadata from transformer-assigned IDs to the actual IObject IDs
+     * present in contents after enrichment. Uses bbox center proximity matching.
+     */
+    private static Map<Long, ElementMetadata> remapMetadataToContents(
+            Map<Long, ElementMetadata> rawMetadata, List<List<IObject>> contents) {
+        if (rawMetadata == null || rawMetadata.isEmpty()) return Collections.emptyMap();
+
+        // Assign metadata to contents IObjects in page order.
+        // Both transformer output and final contents follow the same reading order.
+        Map<Long, ElementMetadata> remapped = new LinkedHashMap<>();
+        List<ElementMetadata> metaList = new ArrayList<>(rawMetadata.values());
+        int metaIdx = 0;
+
+        for (List<IObject> pageContents : contents) {
+            for (IObject obj : pageContents) {
+                if (metaIdx >= metaList.size()) break;
+                Long id = obj.getRecognizedStructureId();
+                if (id != null && id != 0L) {
+                    remapped.put(id, metaList.get(metaIdx));
+                    metaIdx++;
+                }
+            }
+        }
+
+        return remapped;
+    }
+
     private static boolean shouldProcessPage(int pageNumber, Set<Integer> pagesToProcess) {
         return pagesToProcess == null || pagesToProcess.contains(pageNumber);
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -354,30 +354,28 @@ public class DocumentProcessor {
      * @return true if the page should be processed
      */
     /**
-     * Re-maps ElementMetadata from transformer-assigned IDs to the actual IObject IDs
-     * present in contents after enrichment. Uses bbox center proximity matching.
+     * Filters ElementMetadata down to entries whose transformer-assigned ID still
+     * matches an IObject in the post-enrichment contents. This is deliberately
+     * ID-based (not positional): sorting, filtering, and enrichment can reorder
+     * or drop IObjects, so positional matching would attach the wrong
+     * confidence/source label to an element. IObjects whose ID was rewritten
+     * during enrichment simply lose their metadata — preferable to a wrong one.
      */
     private static Map<Long, ElementMetadata> remapMetadataToContents(
             Map<Long, ElementMetadata> rawMetadata, List<List<IObject>> contents) {
         if (rawMetadata == null || rawMetadata.isEmpty()) return Collections.emptyMap();
 
-        // Assign metadata to contents IObjects in page order.
-        // Both transformer output and final contents follow the same reading order.
         Map<Long, ElementMetadata> remapped = new LinkedHashMap<>();
-        List<ElementMetadata> metaList = new ArrayList<>(rawMetadata.values());
-        int metaIdx = 0;
-
         for (List<IObject> pageContents : contents) {
             for (IObject obj : pageContents) {
-                if (metaIdx >= metaList.size()) break;
                 Long id = obj.getRecognizedStructureId();
-                if (id != null && id != 0L) {
-                    remapped.put(id, metaList.get(metaIdx));
-                    metaIdx++;
+                if (id == null || id == 0L) continue;
+                ElementMetadata meta = rawMetadata.get(id);
+                if (meta != null) {
+                    remapped.put(id, meta);
                 }
             }
         }
-
         return remapped;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ExtractionResult.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ExtractionResult.java
@@ -16,9 +16,12 @@
 package org.opendataloader.pdf.processors;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.opendataloader.pdf.hybrid.ElementMetadata;
 import org.verapdf.wcag.algorithms.entities.IObject;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Internal result of the extraction pipeline (preprocessing + content extraction + sanitization).
@@ -29,11 +32,18 @@ public class ExtractionResult {
     private final List<List<IObject>> contents;
     private final long extractionNs;
     private final JsonNode hybridTimings;
+    private final Map<Long, ElementMetadata> elementMetadata;
 
-    public ExtractionResult(List<List<IObject>> contents, long extractionNs, JsonNode hybridTimings) {
+    public ExtractionResult(List<List<IObject>> contents, long extractionNs, JsonNode hybridTimings,
+                             Map<Long, ElementMetadata> elementMetadata) {
         this.contents = contents;
         this.extractionNs = extractionNs;
         this.hybridTimings = hybridTimings;
+        this.elementMetadata = elementMetadata != null ? elementMetadata : Collections.emptyMap();
+    }
+
+    public ExtractionResult(List<List<IObject>> contents, long extractionNs, JsonNode hybridTimings) {
+        this(contents, extractionNs, hybridTimings, Collections.emptyMap());
     }
 
     public List<List<IObject>> getContents() {
@@ -46,5 +56,9 @@ public class ExtractionResult {
 
     public JsonNode getHybridTimings() {
         return hybridTimings;
+    }
+
+    public Map<Long, ElementMetadata> getElementMetadata() {
+        return elementMetadata;
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -817,6 +817,7 @@ public class HybridDocumentProcessor {
      * Replaces a single SemanticTextNode's TextChunks with matching Java TextChunks.
      * In OCR auto mode, compares stream vs OCR text similarity before deciding.
      * In OCR force mode, always keeps OCR text (backend TextChunks).
+     * Records the text source decision in ElementMetadata.
      */
     private static void enrichSingleTextNode(
             SemanticTextNode textNode, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices,
@@ -824,6 +825,7 @@ public class HybridDocumentProcessor {
 
         // Force mode: always keep OCR text, don't replace with stream
         if (config != null && config.isOcrForce()) {
+            recordTextSource(textNode, "ocr", null);
             return;
         }
 
@@ -851,6 +853,7 @@ public class HybridDocumentProcessor {
         if (matched.isEmpty()) {
             LOGGER.fine(() -> "enrichSingleTextNode: no Java TextChunk matched for backend node at bbox ["
                 + String.format("%.1f,%.1f,%.1f,%.1f", nLeft, nBottom, nRight, nTop) + "]");
+            recordTextSource(textNode, "ocr-fallback", null);
             return;
         }
 
@@ -858,15 +861,20 @@ public class HybridDocumentProcessor {
         if (config != null && config.isOcrAuto()) {
             String streamText = extractTextFromChunks(matched);
             String ocrText = extractTextFromNode(textNode);
+            double sim = TextSimilarity.similarity(streamText, ocrText);
 
             if (!TextSimilarity.trustStream(streamText, ocrText, TextSimilarity.DEFAULT_THRESHOLD)) {
                 // Stream text is corrupted — keep OCR text (backend TextChunks)
                 LOGGER.fine(() -> "OCR auto: stream text untrusted (sim="
-                    + String.format("%.2f", TextSimilarity.similarity(streamText, ocrText))
+                    + String.format("%.2f", sim)
                     + "), keeping OCR for node at ["
                     + String.format("%.1f,%.1f,%.1f,%.1f", nLeft, nBottom, nRight, nTop) + "]");
+                recordTextSource(textNode, "ocr", sim);
                 return;
             }
+            recordTextSource(textNode, "stream", sim);
+        } else {
+            recordTextSource(textNode, "stream", null);
         }
 
         // Off mode or auto mode with trusted stream: replace with Java TextChunks
@@ -876,6 +884,23 @@ public class HybridDocumentProcessor {
             newCol.add(new TextLine(tc));
         }
         textNode.getColumns().add(newCol);
+    }
+
+    /**
+     * Records the text source decision in ElementMetadata for a SemanticTextNode.
+     *
+     * @param textNode   the text node whose metadata to update
+     * @param source     "stream", "ocr", or "ocr-fallback"
+     * @param similarity the stream-OCR similarity score, or null if not applicable
+     */
+    private static void recordTextSource(SemanticTextNode textNode, String source, Double similarity) {
+        if (lastElementMetadata == null || textNode.getRecognizedStructureId() == null) return;
+        ElementMetadata meta = lastElementMetadata.get(textNode.getRecognizedStructureId());
+        if (meta == null) return;
+        meta.setTextSource(source);
+        if (similarity != null) {
+            meta.setStreamOcrSimilarity(similarity);
+        }
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -21,6 +21,7 @@ import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.hybrid.DoclingSchemaTransformer;
+import org.opendataloader.pdf.hybrid.ElementMetadata;
 import org.opendataloader.pdf.hybrid.HancomAISchemaTransformer;
 import org.opendataloader.pdf.hybrid.HancomSchemaTransformer;
 import org.opendataloader.pdf.hybrid.HybridClient;
@@ -90,9 +91,20 @@ public class HybridDocumentProcessor {
      */
     private static volatile JsonNode lastHybridTimings;
 
+    /**
+     * Stores element metadata from the most recent hybrid backend processing.
+     * Reset at the start of each {@code processDocument} call.
+     */
+    private static volatile Map<Long, ElementMetadata> lastElementMetadata;
+
     /** Returns the hybrid server timings from the most recent {@link #processDocument} call. */
     public static JsonNode getLastHybridTimings() {
         return lastHybridTimings;
+    }
+
+    /** Returns the element metadata from the most recent {@link #processDocument} call. */
+    public static Map<Long, ElementMetadata> getLastElementMetadata() {
+        return lastElementMetadata;
     }
 
     /**
@@ -143,6 +155,7 @@ public class HybridDocumentProcessor {
             Path outputDir) throws IOException {
 
         lastHybridTimings = null; // Reset for this processing run
+        lastElementMetadata = null;
 
         int totalPages = StaticContainers.getDocument().getNumberOfPages();
         LOGGER.log(Level.INFO, "Starting hybrid processing for {0} pages", totalPages);
@@ -498,6 +511,9 @@ public class HybridDocumentProcessor {
                 }
             }
         }
+
+        // Capture element metadata from the transformer (e.g., HancomAISchemaTransformer)
+        lastElementMetadata = transformer.getElementMetadata();
 
         // Note: Client is cached and reused across documents.
         // HybridClientFactory.shutdown() should be called at CLI exit.

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -21,6 +21,7 @@ import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.hybrid.DoclingSchemaTransformer;
+import org.opendataloader.pdf.hybrid.HancomAISchemaTransformer;
 import org.opendataloader.pdf.hybrid.HancomSchemaTransformer;
 import org.opendataloader.pdf.hybrid.HybridClient;
 import org.opendataloader.pdf.hybrid.HybridClientFactory;
@@ -527,6 +528,11 @@ public class HybridDocumentProcessor {
         // hancom uses HancomSchemaTransformer
         if (Config.HYBRID_HANCOM.equals(hybrid)) {
             return new HancomSchemaTransformer();
+        }
+
+        // hancom-ai uses HancomAISchemaTransformer
+        if (Config.HYBRID_HANCOM_AI.equals(hybrid)) {
+            return new HancomAISchemaTransformer();
         }
 
         throw new IllegalArgumentException("Unsupported hybrid backend: " + hybrid);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -32,6 +32,7 @@ import org.opendataloader.pdf.hybrid.HybridClient.OutputFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opendataloader.pdf.hybrid.HybridConfig;
 import org.opendataloader.pdf.hybrid.HybridSchemaTransformer;
+import org.opendataloader.pdf.hybrid.OcrWordInfo;
 import org.opendataloader.pdf.hybrid.TriageLogger;
 import org.opendataloader.pdf.hybrid.TriageProcessor;
 import org.opendataloader.pdf.hybrid.TriageProcessor.TriageDecision;
@@ -97,6 +98,13 @@ public class HybridDocumentProcessor {
      */
     private static volatile Map<Long, ElementMetadata> lastElementMetadata;
 
+    /**
+     * Stores per-page OCR word data from the most recent hybrid backend processing.
+     * Used for OCR enrichment fallback when Java TextChunks are not available.
+     * Reset at the start of each {@code processDocument} call.
+     */
+    private static volatile Map<Integer, List<OcrWordInfo>> lastOcrWordsByPage;
+
     /** Returns the hybrid server timings from the most recent {@link #processDocument} call. */
     public static JsonNode getLastHybridTimings() {
         return lastHybridTimings;
@@ -105,6 +113,11 @@ public class HybridDocumentProcessor {
     /** Returns the element metadata from the most recent {@link #processDocument} call. */
     public static Map<Long, ElementMetadata> getLastElementMetadata() {
         return lastElementMetadata;
+    }
+
+    /** Returns the OCR word data from the most recent {@link #processDocument} call. */
+    public static Map<Integer, List<OcrWordInfo>> getLastOcrWordsByPage() {
+        return lastOcrWordsByPage;
     }
 
     /**
@@ -156,6 +169,7 @@ public class HybridDocumentProcessor {
 
         lastHybridTimings = null; // Reset for this processing run
         lastElementMetadata = null;
+        lastOcrWordsByPage = null;
 
         int totalPages = StaticContainers.getDocument().getNumberOfPages();
         LOGGER.log(Level.INFO, "Starting hybrid processing for {0} pages", totalPages);
@@ -224,7 +238,7 @@ public class HybridDocumentProcessor {
         try {
             backendResults = processBackendPath(inputPdfName, backendPages, config, backendFailedPages);
             // Enrich backend results: copy StreamInfos from Java-extracted content for MCID linkage
-            enrichBackendResults(backendResults, filteredContents);
+            enrichBackendResults(backendResults, filteredContents, config.getHybridConfig());
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Backend processing failed: {0}", e.getMessage());
             if (config.getHybridConfig().isFallbackToJava()) {
@@ -512,8 +526,9 @@ public class HybridDocumentProcessor {
             }
         }
 
-        // Capture element metadata from the transformer (e.g., HancomAISchemaTransformer)
+        // Capture element metadata and OCR words from the transformer (e.g., HancomAISchemaTransformer)
         lastElementMetadata = transformer.getElementMetadata();
+        lastOcrWordsByPage = transformer.getOcrWordsByPage();
 
         // Note: Client is cached and reused across documents.
         // HybridClientFactory.shutdown() should be called at CLI exit.
@@ -585,7 +600,8 @@ public class HybridDocumentProcessor {
      */
     private static void enrichBackendResults(
             Map<Integer, List<IObject>> backendResults,
-            Map<Integer, List<IObject>> filteredContents) {
+            Map<Integer, List<IObject>> filteredContents,
+            HybridConfig hybridConfig) {
 
         for (Map.Entry<Integer, List<IObject>> entry : backendResults.entrySet()) {
             int pageNumber = entry.getKey();
@@ -626,10 +642,86 @@ public class HybridDocumentProcessor {
                 enrichFormulaStreamInfos(backendPage, javaTextChunks);
             }
 
+            // OCR fallback: log elements that still lack StreamInfo after enrichment
+            if (hybridConfig.isOcrAuto() || hybridConfig.isOcrForce()) {
+                Map<Integer, List<OcrWordInfo>> ocrWords = lastOcrWordsByPage;
+                if (ocrWords != null) {
+                    List<OcrWordInfo> pageOcrWords = ocrWords.getOrDefault(pageNumber, List.of());
+                    logOcrFallbackCandidates(backendPage, pageNumber, pageOcrWords);
+                }
+            }
+
             final int pg = pageNumber;
             final int javaTotal = javaTextChunks.size();
             LOGGER.fine(() -> "Page " + pg + ": enrichment complete — "
                 + javaTotal + " Java TextChunks available");
+        }
+    }
+
+    /**
+     * Logs backend elements that still lack StreamInfo after enrichment and could
+     * benefit from OCR fallback. Walks the IObject tree recursively to find
+     * SemanticTextNodes with no StreamInfo in any of their TextChunks.
+     *
+     * <p>This is Phase A (logging only). Phase B will actually insert invisible
+     * text operators into the content stream for these elements.
+     */
+    private static void logOcrFallbackCandidates(
+            List<IObject> backendPage, int pageNumber, List<OcrWordInfo> ocrWords) {
+        int candidateCount = 0;
+        int ocrWordMatchCount = 0;
+
+        for (IObject obj : backendPage) {
+            if (obj instanceof SemanticTextNode) {
+                SemanticTextNode textNode = (SemanticTextNode) obj;
+                boolean hasStreamInfo = false;
+                for (TextColumn col : textNode.getColumns()) {
+                    for (TextLine line : col.getLines()) {
+                        for (TextChunk chunk : line.getTextChunks()) {
+                            if (!chunk.getStreamInfos().isEmpty()) {
+                                hasStreamInfo = true;
+                                break;
+                            }
+                        }
+                        if (hasStreamInfo) break;
+                    }
+                    if (hasStreamInfo) break;
+                }
+                if (!hasStreamInfo) {
+                    candidateCount++;
+                    // Count OCR words that overlap with this text node's bbox
+                    double nLeft = textNode.getLeftX();
+                    double nRight = textNode.getRightX();
+                    double nBottom = textNode.getBottomY();
+                    double nTop = textNode.getTopY();
+                    double tol = 5.0;
+                    int matchedWords = 0;
+                    for (OcrWordInfo word : ocrWords) {
+                        BoundingBox wb = word.getBbox();
+                        double cx = (wb.getLeftX() + wb.getRightX()) / 2.0;
+                        double cy = (wb.getBottomY() + wb.getTopY()) / 2.0;
+                        if (cx >= nLeft - tol && cx <= nRight + tol
+                                && cy >= nBottom - tol && cy <= nTop + tol) {
+                            matchedWords++;
+                        }
+                    }
+                    if (matchedWords > 0) {
+                        ocrWordMatchCount += matchedWords;
+                        final int mw = matchedWords;
+                        LOGGER.fine(() -> "Page " + pageNumber + ": OCR fallback candidate — "
+                            + "SemanticTextNode at ["
+                            + String.format("%.1f,%.1f,%.1f,%.1f", nLeft, nBottom, nRight, nTop)
+                            + "] has " + mw + " matching OCR words");
+                    }
+                }
+            }
+        }
+
+        if (candidateCount > 0) {
+            final int cc = candidateCount;
+            final int owm = ocrWordMatchCount;
+            LOGGER.info(() -> "Page " + pageNumber + ": " + cc
+                + " element(s) need OCR fallback, " + owm + " OCR words available");
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -32,6 +32,7 @@ import org.opendataloader.pdf.hybrid.HybridClient.OutputFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opendataloader.pdf.hybrid.HybridConfig;
 import org.opendataloader.pdf.hybrid.HybridSchemaTransformer;
+import org.opendataloader.pdf.hybrid.TextSimilarity;
 import org.opendataloader.pdf.hybrid.OcrWordInfo;
 import org.opendataloader.pdf.hybrid.TriageLogger;
 import org.opendataloader.pdf.hybrid.TriageProcessor;
@@ -638,7 +639,7 @@ public class HybridDocumentProcessor {
             // Replace backend TextChunks with Java TextChunks that carry StreamInfo,
             // and copy StreamInfos to SemanticFormula objects
             if (!javaTextChunks.isEmpty()) {
-                enrichTextStreamInfos(backendPage, javaTextChunks);
+                enrichTextStreamInfos(backendPage, javaTextChunks, hybridConfig);
                 enrichFormulaStreamInfos(backendPage, javaTextChunks);
             }
 
@@ -758,11 +759,12 @@ public class HybridDocumentProcessor {
      * This preserves the backend's structural decisions (heading/paragraph/reading order)
      * while using the Java TextChunks that carry StreamInfo.
      */
-    private static void enrichTextStreamInfos(List<IObject> backendPage, List<TextChunk> javaTextChunks) {
+    private static void enrichTextStreamInfos(List<IObject> backendPage, List<TextChunk> javaTextChunks,
+                                               HybridConfig config) {
         if (javaTextChunks.isEmpty()) return;
 
         Set<Integer> usedJavaIndices = new HashSet<>();
-        enrichTextStreamInfosRecursive(backendPage, javaTextChunks, usedJavaIndices);
+        enrichTextStreamInfosRecursive(backendPage, javaTextChunks, usedJavaIndices, config);
     }
 
     /**
@@ -771,14 +773,15 @@ public class HybridDocumentProcessor {
      * and any other container that holds nested IObjects.
      */
     private static void enrichTextStreamInfosRecursive(
-            List<IObject> objects, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices) {
+            List<IObject> objects, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices,
+            HybridConfig config) {
 
         for (IObject obj : objects) {
             if (obj instanceof SemanticFormula) {
                 // Formula inside table/list — enrich StreamInfos by bbox overlap
                 enrichSingleFormula((SemanticFormula) obj, javaTextChunks);
             } else if (obj instanceof SemanticTextNode) {
-                enrichSingleTextNode((SemanticTextNode) obj, javaTextChunks, usedJavaIndices);
+                enrichSingleTextNode((SemanticTextNode) obj, javaTextChunks, usedJavaIndices, config);
             } else if (obj instanceof TableBorder) {
                 TableBorder table = (TableBorder) obj;
                 for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
@@ -786,7 +789,7 @@ public class HybridDocumentProcessor {
                     for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
                         TableBorderCell cell = row.getCell(colNumber);
                         if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
-                            enrichTextStreamInfosRecursive(cell.getContents(), javaTextChunks, usedJavaIndices);
+                            enrichTextStreamInfosRecursive(cell.getContents(), javaTextChunks, usedJavaIndices, config);
                         }
                     }
                 }
@@ -794,15 +797,17 @@ public class HybridDocumentProcessor {
                 PDFList list = (PDFList) obj;
                 for (ListItem item : list.getListItems()) {
                     // Enrich ListItem's own text lines (used by AutoTaggingProcessor for Lbl/LBody)
-                    for (TextLine line : item.getLines()) {
-                        for (TextChunk backendChunk : line.getTextChunks()) {
-                            if (backendChunk.getStreamInfos().isEmpty()) {
-                                matchAndReplaceStreamInfos(backendChunk, javaTextChunks, usedJavaIndices);
+                    if (config == null || !config.isOcrForce()) {
+                        for (TextLine line : item.getLines()) {
+                            for (TextChunk backendChunk : line.getTextChunks()) {
+                                if (backendChunk.getStreamInfos().isEmpty()) {
+                                    matchAndReplaceStreamInfos(backendChunk, javaTextChunks, usedJavaIndices, config);
+                                }
                             }
                         }
                     }
                     // Enrich nested contents (images, paragraphs, sub-lists)
-                    enrichTextStreamInfosRecursive(item.getContents(), javaTextChunks, usedJavaIndices);
+                    enrichTextStreamInfosRecursive(item.getContents(), javaTextChunks, usedJavaIndices, config);
                 }
             }
         }
@@ -810,9 +815,17 @@ public class HybridDocumentProcessor {
 
     /**
      * Replaces a single SemanticTextNode's TextChunks with matching Java TextChunks.
+     * In OCR auto mode, compares stream vs OCR text similarity before deciding.
+     * In OCR force mode, always keeps OCR text (backend TextChunks).
      */
     private static void enrichSingleTextNode(
-            SemanticTextNode textNode, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices) {
+            SemanticTextNode textNode, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices,
+            HybridConfig config) {
+
+        // Force mode: always keep OCR text, don't replace with stream
+        if (config != null && config.isOcrForce()) {
+            return;
+        }
 
         double nLeft = textNode.getLeftX();
         double nRight = textNode.getRightX();
@@ -835,26 +848,73 @@ public class HybridDocumentProcessor {
             }
         }
 
-        if (!matched.isEmpty()) {
-            textNode.getColumns().clear();
-            TextColumn newCol = new TextColumn();
-            for (TextChunk tc : matched) {
-                newCol.add(new TextLine(tc));
-            }
-            textNode.getColumns().add(newCol);
-        } else {
+        if (matched.isEmpty()) {
             LOGGER.fine(() -> "enrichSingleTextNode: no Java TextChunk matched for backend node at bbox ["
                 + String.format("%.1f,%.1f,%.1f,%.1f", nLeft, nBottom, nRight, nTop) + "]");
+            return;
         }
+
+        // Auto mode: compare stream vs OCR text similarity
+        if (config != null && config.isOcrAuto()) {
+            String streamText = extractTextFromChunks(matched);
+            String ocrText = extractTextFromNode(textNode);
+
+            if (!TextSimilarity.trustStream(streamText, ocrText, TextSimilarity.DEFAULT_THRESHOLD)) {
+                // Stream text is corrupted — keep OCR text (backend TextChunks)
+                LOGGER.fine(() -> "OCR auto: stream text untrusted (sim="
+                    + String.format("%.2f", TextSimilarity.similarity(streamText, ocrText))
+                    + "), keeping OCR for node at ["
+                    + String.format("%.1f,%.1f,%.1f,%.1f", nLeft, nBottom, nRight, nTop) + "]");
+                return;
+            }
+        }
+
+        // Off mode or auto mode with trusted stream: replace with Java TextChunks
+        textNode.getColumns().clear();
+        TextColumn newCol = new TextColumn();
+        for (TextChunk tc : matched) {
+            newCol.add(new TextLine(tc));
+        }
+        textNode.getColumns().add(newCol);
+    }
+
+    /**
+     * Extracts concatenated text from a list of TextChunks.
+     */
+    private static String extractTextFromChunks(List<TextChunk> chunks) {
+        StringBuilder sb = new StringBuilder();
+        for (TextChunk tc : chunks) {
+            if (sb.length() > 0) sb.append(' ');
+            sb.append(tc.getValue());
+        }
+        return sb.toString().trim();
+    }
+
+    /**
+     * Extracts concatenated text from a SemanticTextNode's columns/lines/chunks.
+     */
+    private static String extractTextFromNode(SemanticTextNode node) {
+        StringBuilder sb = new StringBuilder();
+        for (TextColumn col : node.getColumns()) {
+            for (TextLine line : col.getLines()) {
+                for (TextChunk chunk : line.getTextChunks()) {
+                    if (sb.length() > 0) sb.append(' ');
+                    sb.append(chunk.getValue());
+                }
+            }
+        }
+        return sb.toString().trim();
     }
 
     /**
      * Copies StreamInfos from matching Java TextChunks to a backend TextChunk that lacks them.
      * Used for ListItem lines where the text is stored directly in TextLine/TextChunk
      * rather than in a SemanticTextNode wrapper.
+     * In OCR auto mode, compares stream vs OCR text similarity before copying.
      */
     private static void matchAndReplaceStreamInfos(
-            TextChunk backendChunk, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices) {
+            TextChunk backendChunk, List<TextChunk> javaTextChunks, Set<Integer> usedJavaIndices,
+            HybridConfig config) {
         double bCx = backendChunk.getCenterX();
         double bCy = backendChunk.getCenterY();
         double tol = 5.0;
@@ -865,6 +925,15 @@ public class HybridDocumentProcessor {
             double jCx = javaChunk.getCenterX();
             double jCy = javaChunk.getCenterY();
             if (Math.abs(bCx - jCx) <= tol && Math.abs(bCy - jCy) <= tol) {
+                // In auto mode, check if stream text is trustworthy
+                if (config != null && config.isOcrAuto()) {
+                    String streamText = javaChunk.getValue();
+                    String ocrText = backendChunk.getValue();
+                    if (!TextSimilarity.trustStream(streamText, ocrText, TextSimilarity.DEFAULT_THRESHOLD)) {
+                        LOGGER.fine(() -> "OCR auto: stream text untrusted for ListItem chunk, keeping OCR");
+                        return;
+                    }
+                }
                 backendChunk.getStreamInfos().addAll(javaChunk.getStreamInfos());
                 usedJavaIndices.add(i);
                 return;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -562,9 +562,17 @@ public class HybridDocumentProcessor {
             return new HancomSchemaTransformer();
         }
 
-        // hancom-ai uses HancomAISchemaTransformer
+        // hancom-ai uses HancomAISchemaTransformer. Thread the regionlist strategy
+        // from HybridConfig so --regionlist-strategy is honoured instead of silently
+        // falling back to the transformer's default.
         if (Config.HYBRID_HANCOM_AI.equals(hybrid)) {
-            return new HancomAISchemaTransformer();
+            HancomAISchemaTransformer transformer = new HancomAISchemaTransformer();
+            String regionlistStrategy = config.getHybridConfig() != null
+                ? config.getHybridConfig().getRegionlistStrategy() : null;
+            if (regionlistStrategy != null) {
+                transformer.setRegionlistStrategy(regionlistStrategy);
+            }
+            return transformer;
         }
 
         throw new IllegalArgumentException("Unsupported hybrid backend: " + hybrid);
@@ -641,6 +649,12 @@ public class HybridDocumentProcessor {
             if (!javaTextChunks.isEmpty()) {
                 enrichTextStreamInfos(backendPage, javaTextChunks, hybridConfig);
                 enrichFormulaStreamInfos(backendPage, javaTextChunks);
+            } else if (hybridConfig.isOcrAuto() || hybridConfig.isOcrForce()) {
+                // OCR-only (scanned) page: no Java TextChunks to compare against,
+                // so text_source cannot be inferred from stream/OCR similarity.
+                // Record "ocr" for every SemanticTextNode so the JSON output still
+                // reflects that the text came from OCR rather than the PDF stream.
+                markAllTextSourcesAsOcr(backendPage);
             }
 
             // OCR fallback: log elements that still lack StreamInfo after enrichment
@@ -884,6 +898,38 @@ public class HybridDocumentProcessor {
             newCol.add(new TextLine(tc));
         }
         textNode.getColumns().add(newCol);
+    }
+
+    /**
+     * Records "ocr" as the text source for every SemanticTextNode in the page,
+     * used on scanned pages where there are no Java TextChunks to compare with.
+     * Mirrors {@link #enrichTextStreamInfosRecursive} in how it descends into
+     * TableBorder/PDFList — the shared IObject tree has no generic children API,
+     * so both walks enumerate the containers they know about.
+     */
+    private static void markAllTextSourcesAsOcr(List<IObject> objects) {
+        if (objects == null) return;
+        for (IObject obj : objects) {
+            if (obj instanceof SemanticTextNode) {
+                recordTextSource((SemanticTextNode) obj, "ocr", null);
+            } else if (obj instanceof TableBorder) {
+                TableBorder table = (TableBorder) obj;
+                for (int rowNumber = 0; rowNumber < table.getNumberOfRows(); rowNumber++) {
+                    TableBorderRow row = table.getRow(rowNumber);
+                    for (int colNumber = 0; colNumber < table.getNumberOfColumns(); colNumber++) {
+                        TableBorderCell cell = row.getCell(colNumber);
+                        if (cell.getRowNumber() == rowNumber && cell.getColNumber() == colNumber) {
+                            markAllTextSourcesAsOcr(cell.getContents());
+                        }
+                    }
+                }
+            } else if (obj instanceof PDFList) {
+                PDFList list = (PDFList) obj;
+                for (ListItem item : list.getListItems()) {
+                    markAllTextSourcesAsOcr(item.getContents());
+                }
+            }
+        }
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DiskPageImageCacheTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DiskPageImageCacheTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DiskPageImageCacheTest {
+
+    private static BufferedImage createTestImage() {
+        return new BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB);
+    }
+
+    @Test
+    void getOrFetch_writesToDisk(@TempDir Path tempDir) throws IOException {
+        try (DiskPageImageCache cache = new DiskPageImageCache(tempDir)) {
+            AtomicInteger fetchCount = new AtomicInteger(0);
+
+            BufferedImage img = cache.getOrFetch(0, idx -> {
+                fetchCount.incrementAndGet();
+                return createTestImage();
+            });
+
+            assertNotNull(img);
+            assertEquals(1, fetchCount.get());
+            assertTrue(Files.exists(tempDir.resolve("page-0.png")), "PNG file should exist on disk");
+        }
+    }
+
+    @Test
+    void getOrFetch_secondCallReadesFromDisk(@TempDir Path tempDir) throws IOException {
+        try (DiskPageImageCache cache = new DiskPageImageCache(tempDir)) {
+            AtomicInteger fetchCount = new AtomicInteger(0);
+
+            cache.getOrFetch(0, idx -> {
+                fetchCount.incrementAndGet();
+                return createTestImage();
+            });
+            assertEquals(1, fetchCount.get());
+
+            // Second call should read from disk, not call fetcher
+            BufferedImage img2 = cache.getOrFetch(0, idx -> {
+                fetchCount.incrementAndGet();
+                return createTestImage();
+            });
+
+            assertNotNull(img2);
+            assertEquals(1, fetchCount.get(), "Fetcher should not be called on second access");
+        }
+    }
+
+    @Test
+    void evict_isNoOp(@TempDir Path tempDir) throws IOException {
+        try (DiskPageImageCache cache = new DiskPageImageCache(tempDir)) {
+            cache.getOrFetch(0, idx -> createTestImage());
+            cache.evict(0);
+
+            assertTrue(Files.exists(tempDir.resolve("page-0.png")),
+                "File should still exist after evict (no-op)");
+        }
+    }
+
+    @Test
+    void close_deletesTempFiles(@TempDir Path tempDir) throws IOException {
+        // Create a subdirectory inside tempDir to simulate real usage
+        Path cacheDir = tempDir.resolve("odl-cache");
+        Files.createDirectory(cacheDir);
+
+        DiskPageImageCache cache = new DiskPageImageCache(cacheDir);
+        cache.getOrFetch(0, idx -> createTestImage());
+        cache.getOrFetch(1, idx -> createTestImage());
+
+        assertTrue(Files.exists(cacheDir.resolve("page-0.png")));
+        assertTrue(Files.exists(cacheDir.resolve("page-1.png")));
+
+        cache.close();
+
+        assertFalse(Files.exists(cacheDir.resolve("page-0.png")), "Files should be deleted");
+        assertFalse(Files.exists(cacheDir.resolve("page-1.png")), "Files should be deleted");
+        assertFalse(Files.exists(cacheDir), "Directory should be deleted");
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DiskPageImageCacheTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DiskPageImageCacheTest.java
@@ -49,7 +49,7 @@ class DiskPageImageCacheTest {
     }
 
     @Test
-    void getOrFetch_secondCallReadesFromDisk(@TempDir Path tempDir) throws IOException {
+    void getOrFetch_secondCallReadsFromDisk(@TempDir Path tempDir) throws IOException {
         try (DiskPageImageCache cache = new DiskPageImageCache(tempDir)) {
             AtomicInteger fetchCount = new AtomicInteger(0);
 

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/ElementMetadataTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/ElementMetadataTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for ElementMetadata JSON serialization.
+ */
+public class ElementMetadataTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void defaultValuesProduceEmptyJson() throws Exception {
+        ElementMetadata meta = new ElementMetadata();
+        String json = mapper.writeValueAsString(meta);
+        assertEquals("{}", json);
+    }
+
+    @Test
+    void onlyNonDefaultFieldsAppearInJson() throws Exception {
+        ElementMetadata meta = new ElementMetadata()
+                .setConfidence(0.85)
+                .setSourceLabel(3)
+                .setHeadingInferenceMethod("bbox-height")
+                .setBboxHeightPx(24.5);
+
+        String json = mapper.writeValueAsString(meta);
+        JsonNode node = mapper.readTree(json);
+
+        assertEquals(0.85, node.get("confidence").asDouble(), 0.001);
+        assertEquals(3, node.get("sourceLabel").asInt());
+        assertEquals("bbox-height", node.get("headingInferenceMethod").asText());
+        assertEquals(24.5, node.get("bboxHeightPx").asDouble(), 0.001);
+
+        // Default fields must be absent
+        assertFalse(node.has("matchedWordCount"));
+        assertFalse(node.has("tsr"));
+        assertFalse(node.has("caption"));
+        assertFalse(node.has("regionlistResolution"));
+        assertFalse(node.has("wordMatchMethod"));
+    }
+
+    @Test
+    void tsrMetadataSerializesCorrectly() throws Exception {
+        ElementMetadata.TsrMetadata tsr = new ElementMetadata.TsrMetadata()
+                .setNumCells(12)
+                .setHtml("<table><tr><td>A</td></tr></table>")
+                .setRunTimeMs(150);
+
+        ElementMetadata meta = new ElementMetadata()
+                .setSourceLabel(5)
+                .setTsr(tsr);
+
+        String json = mapper.writeValueAsString(meta);
+        JsonNode node = mapper.readTree(json);
+
+        assertTrue(node.has("tsr"));
+        assertEquals(12, node.get("tsr").get("numCells").asInt());
+        assertEquals(150, node.get("tsr").get("runTimeMs").asLong());
+    }
+
+    @Test
+    void captionMetadataSerializesCorrectly() throws Exception {
+        ElementMetadata.CaptionMetadata caption = new ElementMetadata.CaptionMetadata()
+                .setText("Figure 1: Overview")
+                .setLanguage("en");
+
+        ElementMetadata meta = new ElementMetadata()
+                .setCaption(caption);
+
+        String json = mapper.writeValueAsString(meta);
+        JsonNode node = mapper.readTree(json);
+
+        assertTrue(node.has("caption"));
+        assertEquals("Figure 1: Overview", node.get("caption").get("text").asText());
+        assertEquals("en", node.get("caption").get("language").asText());
+        // runTimeMs is default (0), should be absent
+        assertFalse(node.get("caption").has("runTimeMs"));
+    }
+
+    @Test
+    void regionlistResolutionSerializesCorrectly() throws Exception {
+        ElementMetadata.RegionlistResolution resolution = new ElementMetadata.RegionlistResolution()
+                .setStrategy("table-first")
+                .setTsrAttempted(true)
+                .setTsrResult("success");
+
+        ElementMetadata meta = new ElementMetadata()
+                .setRegionlistResolution(resolution);
+
+        String json = mapper.writeValueAsString(meta);
+        JsonNode node = mapper.readTree(json);
+
+        assertTrue(node.has("regionlistResolution"));
+        assertEquals("table-first", node.get("regionlistResolution").get("strategy").asText());
+        assertTrue(node.get("regionlistResolution").get("tsrAttempted").asBoolean());
+        assertEquals("success", node.get("regionlistResolution").get("tsrResult").asText());
+    }
+
+    @Test
+    void fluentSettersReturnSameInstance() {
+        ElementMetadata meta = new ElementMetadata();
+        ElementMetadata returned = meta.setConfidence(0.5).setSourceLabel(2);
+        assertTrue(meta == returned);
+    }
+
+    @Test
+    void roundTripDeserialization() throws Exception {
+        ElementMetadata original = new ElementMetadata()
+                .setConfidence(0.92)
+                .setSourceLabel(7)
+                .setWordMatchMethod("bbox-intersection")
+                .setMatchedWordCount(5);
+
+        String json = mapper.writeValueAsString(original);
+        ElementMetadata deserialized = mapper.readValue(json, ElementMetadata.class);
+
+        assertEquals(original.getConfidence(), deserialized.getConfidence(), 0.001);
+        assertEquals(original.getSourceLabel(), deserialized.getSourceLabel());
+        assertEquals(original.getWordMatchMethod(), deserialized.getWordMatchMethod());
+        assertEquals(original.getMatchedWordCount(), deserialized.getMatchedWordCount());
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAIClientRequestIdTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAIClientRequestIdTest.java
@@ -1,0 +1,84 @@
+package org.opendataloader.pdf.hybrid;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.security.MessageDigest;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HancomAIClientRequestIdTest {
+
+    private MockWebServer server;
+    private HancomAIClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        client = new HancomAIClient(
+            server.url("").toString().replaceAll("/$", ""),
+            new OkHttpClient(),
+            new ObjectMapper()
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void callModule_request_id_includes_sha_short() throws Exception {
+        byte[] pdfBytes = "PDF_CONTENT_FOR_TEST".getBytes();
+        String shaShort = sha256Hex(pdfBytes).substring(0, 12);
+
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody("{\"SUCCESS\":true,\"RESULT\":[]}"));
+
+        // invokeCallModule is a package-private test hook added by the patch.
+        client.invokeCallModule(pdfBytes, "DOCUMENT_LAYOUT_WITH_OCR");
+
+        RecordedRequest req = server.takeRequest();
+        String body = req.getBody().readUtf8();
+        assertTrue(body.contains("odl-" + shaShort + "-dla-ocr"),
+            "REQUEST_ID should include sha_short and module short name; body=" + body);
+    }
+
+    @Test
+    void callImageCaptioning_request_id_includes_page_obj() throws Exception {
+        byte[] pdfBytes = "PDF_CONTENT_FOR_TEST".getBytes();
+        String shaShort = sha256Hex(pdfBytes).substring(0, 12);
+        client.setSourcePdfShaShort(shaShort); // test hook
+
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setBody("{\"SUCCESS\":true,\"RESULT\":[[{\"caption\":\"x\"}]]}"));
+
+        client.invokeCallImageCaptioning(new byte[]{1, 2, 3}, /*pageNum*/ 2, /*objectId*/ 7);
+
+        RecordedRequest req = server.takeRequest();
+        String body = req.getBody().readUtf8();
+        assertTrue(body.contains("odl-" + shaShort + "-p2-o7-caption"),
+            "image REQUEST_ID format mismatch; body=" + body);
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) sb.append(String.format("%02x", b));
+        return sb.toString();
+    }
+
+    private static String sha256Hex(byte[] b) throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        return bytesToHex(md.digest(b));
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
+import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.SemanticHeading;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for HancomAISchemaTransformer heading level inference.
+ *
+ * <p>Tests that label 1 (ParaTitle) and label 4 (RegionTitle) headings
+ * are assigned H2~H6 based on bbox height (font-size proxy), while
+ * label 0 (DocTitle) always maps to H1.
+ */
+public class HancomAISchemaTransformerTest {
+
+    private HancomAISchemaTransformer transformer;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new HancomAISchemaTransformer();
+        objectMapper = new ObjectMapper();
+        StaticLayoutContainers.setCurrentContentId(1L);
+    }
+
+    // --- Label 0 (DocTitle) always H1 ---
+
+    @Test
+    void titleLabel0_alwaysH1() {
+        ObjectNode json = createHancomAIJson(
+            createObject(0, "Document Title", 100, 50, 500, 100)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).hasSize(1);
+        SemanticHeading heading = (SemanticHeading) result.get(0).get(0);
+        assertThat(heading.getHeadingLevel()).isEqualTo(1);
+        assertThat(heading.getValue()).isEqualTo("Document Title");
+    }
+
+    // --- Single heading size defaults to H2 ---
+
+    @Test
+    void singleHeadingSize_label1_defaultsToH2() {
+        ObjectNode json = createHancomAIJson(
+            createObject(1, "Only Heading", 100, 200, 500, 250)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        SemanticHeading heading = (SemanticHeading) result.get(0).get(0);
+        assertThat(heading.getHeadingLevel()).isEqualTo(2);
+    }
+
+    @Test
+    void singleHeadingSize_label4_defaultsToH2() {
+        ObjectNode json = createHancomAIJson(
+            createObject(4, "Only Subheading", 100, 200, 500, 240)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        SemanticHeading heading = (SemanticHeading) result.get(0).get(0);
+        assertThat(heading.getHeadingLevel()).isEqualTo(2);
+    }
+
+    // --- Two different heading sizes → H2 and H3 ---
+
+    @Test
+    void twoDifferentHeightHeadings_tallIsH2_shortIsH3() {
+        // Taller bbox (height 60px) = bigger font = H2
+        // Shorter bbox (height 30px) = smaller font = H3
+        ObjectNode json = createHancomAIJson(
+            createObject(1, "Big Section", 100, 100, 500, 160),    // height=60
+            createObject(1, "Small Section", 100, 300, 500, 330)   // height=30
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(2);
+
+        // Results are sorted by reading order (top to bottom), so Big Section first
+        SemanticHeading big = (SemanticHeading) result.get(0).get(0);
+        SemanticHeading small = (SemanticHeading) result.get(0).get(1);
+
+        assertThat(big.getValue()).isEqualTo("Big Section");
+        assertThat(big.getHeadingLevel()).isEqualTo(2);
+
+        assertThat(small.getValue()).isEqualTo("Small Section");
+        assertThat(small.getHeadingLevel()).isEqualTo(3);
+    }
+
+    // --- Same height → same level ---
+
+    @Test
+    void sameHeight_sameLevelHeading() {
+        ObjectNode json = createHancomAIJson(
+            createObject(1, "Section A", 100, 100, 500, 150),  // height=50
+            createObject(1, "Section B", 100, 300, 500, 350)   // height=50
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(2);
+        SemanticHeading a = (SemanticHeading) result.get(0).get(0);
+        SemanticHeading b = (SemanticHeading) result.get(0).get(1);
+
+        assertThat(a.getHeadingLevel()).isEqualTo(b.getHeadingLevel());
+        assertThat(a.getHeadingLevel()).isEqualTo(2);
+    }
+
+    // --- Mixed label 1 and label 4 share the same height pool ---
+
+    @Test
+    void mixedLabel1And4_shareHeightPool() {
+        ObjectNode json = createHancomAIJson(
+            createObject(1, "Para Title", 100, 100, 500, 160),     // height=60 → H2
+            createObject(4, "Region Title", 100, 300, 500, 330)    // height=30 → H3
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(2);
+        SemanticHeading paraTitle = (SemanticHeading) result.get(0).get(0);
+        SemanticHeading regionTitle = (SemanticHeading) result.get(0).get(1);
+
+        assertThat(paraTitle.getHeadingLevel()).isEqualTo(2);
+        assertThat(regionTitle.getHeadingLevel()).isEqualTo(3);
+    }
+
+    // --- Three different heights → H2, H3, H4 ---
+
+    @Test
+    void threeDifferentHeights_H2H3H4() {
+        ObjectNode json = createHancomAIJson(
+            createObject(1, "Large", 100, 100, 500, 200),      // height=100 → H2
+            createObject(1, "Medium", 100, 300, 500, 360),      // height=60  → H3
+            createObject(4, "Small", 100, 500, 500, 530)        // height=30  → H4
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(3);
+        SemanticHeading large = (SemanticHeading) result.get(0).get(0);
+        SemanticHeading medium = (SemanticHeading) result.get(0).get(1);
+        SemanticHeading small = (SemanticHeading) result.get(0).get(2);
+
+        assertThat(large.getHeadingLevel()).isEqualTo(2);
+        assertThat(medium.getHeadingLevel()).isEqualTo(3);
+        assertThat(small.getHeadingLevel()).isEqualTo(4);
+    }
+
+    // --- Cap at H6 ---
+
+    @Test
+    void moreThanFiveSizes_cappedAtH6() {
+        // 6 different sizes → H2, H3, H4, H5, H6, H6 (capped)
+        ObjectNode json = createHancomAIJson(
+            createObject(1, "Size1", 100, 50, 500, 110),       // height=60
+            createObject(1, "Size2", 100, 150, 500, 200),      // height=50
+            createObject(1, "Size3", 100, 250, 500, 290),      // height=40
+            createObject(1, "Size4", 100, 350, 500, 380),      // height=30
+            createObject(1, "Size5", 100, 450, 500, 470),      // height=20
+            createObject(1, "Size6", 100, 550, 500, 560)       // height=10
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(6);
+
+        // Sorted by reading order (top to bottom, which matches our order)
+        assertThat(((SemanticHeading) result.get(0).get(0)).getHeadingLevel()).isEqualTo(2);
+        assertThat(((SemanticHeading) result.get(0).get(1)).getHeadingLevel()).isEqualTo(3);
+        assertThat(((SemanticHeading) result.get(0).get(2)).getHeadingLevel()).isEqualTo(4);
+        assertThat(((SemanticHeading) result.get(0).get(3)).getHeadingLevel()).isEqualTo(5);
+        assertThat(((SemanticHeading) result.get(0).get(4)).getHeadingLevel()).isEqualTo(6);
+        assertThat(((SemanticHeading) result.get(0).get(5)).getHeadingLevel()).isEqualTo(6);
+    }
+
+    // --- Document-wide inference (across pages) ---
+
+    @Test
+    void headingLevels_consistentAcrossPages() {
+        // Page 0: large heading (height=60)
+        // Page 1: small heading (height=30)
+        // Both should share same height pool → H2 and H3
+        ObjectNode json = createHancomAIJsonMultiPage(
+            new ObjectNode[][]{
+                {createObject(1, "Page1 Heading", 100, 100, 500, 160)},   // height=60
+                {createObject(1, "Page2 Heading", 100, 100, 500, 130)}    // height=30
+            }
+        );
+
+        Map<Integer, Double> pageHeights = new HashMap<>();
+        pageHeights.put(1, 842.0);
+        pageHeights.put(2, 842.0);
+
+        HybridResponse response = new HybridResponse("", json, null);
+        List<List<IObject>> result = transformer.transform(response, pageHeights);
+
+        assertThat(result).hasSize(2);
+        SemanticHeading page1Heading = (SemanticHeading) result.get(0).get(0);
+        SemanticHeading page2Heading = (SemanticHeading) result.get(1).get(0);
+
+        assertThat(page1Heading.getHeadingLevel()).isEqualTo(2);
+        assertThat(page2Heading.getHeadingLevel()).isEqualTo(3);
+    }
+
+    @Test
+    void headingLevels_sameHeightDifferentPages_sameLevel() {
+        // Same height on different pages → same level
+        ObjectNode json = createHancomAIJsonMultiPage(
+            new ObjectNode[][]{
+                {createObject(1, "Page1 Heading", 100, 100, 500, 150)},   // height=50
+                {createObject(4, "Page2 Heading", 100, 100, 500, 150)}    // height=50
+            }
+        );
+
+        Map<Integer, Double> pageHeights = new HashMap<>();
+        pageHeights.put(1, 842.0);
+        pageHeights.put(2, 842.0);
+
+        HybridResponse response = new HybridResponse("", json, null);
+        List<List<IObject>> result = transformer.transform(response, pageHeights);
+
+        assertThat(result).hasSize(2);
+        SemanticHeading h1 = (SemanticHeading) result.get(0).get(0);
+        SemanticHeading h2 = (SemanticHeading) result.get(1).get(0);
+
+        assertThat(h1.getHeadingLevel()).isEqualTo(h2.getHeadingLevel());
+        assertThat(h1.getHeadingLevel()).isEqualTo(2);
+    }
+
+    // --- Title (label 0) is not affected by inference ---
+
+    @Test
+    void titleH1_notAffectedByOtherHeadingSizes() {
+        // Title + heading: title stays H1 regardless
+        ObjectNode json = createHancomAIJson(
+            createObject(0, "Doc Title", 100, 50, 500, 120),       // label 0 → always H1
+            createObject(1, "Chapter", 100, 200, 500, 260),        // height=60 → H2
+            createObject(1, "Subsection", 100, 400, 500, 430)      // height=30 → H3
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(3);
+        SemanticHeading title = (SemanticHeading) result.get(0).get(0);
+        SemanticHeading chapter = (SemanticHeading) result.get(0).get(1);
+        SemanticHeading subsection = (SemanticHeading) result.get(0).get(2);
+
+        assertThat(title.getHeadingLevel()).isEqualTo(1);
+        assertThat(chapter.getHeadingLevel()).isEqualTo(2);
+        assertThat(subsection.getHeadingLevel()).isEqualTo(3);
+    }
+
+    // --- No heading level skipping ---
+
+    @Test
+    void noHeadingLevelSkipping() {
+        // Even with very different heights, levels are sequential: H2, H3, H4
+        ObjectNode json = createHancomAIJson(
+            createObject(1, "Huge", 100, 100, 500, 300),        // height=200
+            createObject(1, "Tiny", 100, 400, 500, 410),        // height=10
+            createObject(1, "Medium", 100, 500, 500, 550)       // height=50
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(3);
+
+        // Sorted by reading order: Huge(top=100), Tiny(top=400), Medium(top=500)
+        SemanticHeading huge = (SemanticHeading) result.get(0).get(0);
+        SemanticHeading tiny = (SemanticHeading) result.get(0).get(1);
+        SemanticHeading medium = (SemanticHeading) result.get(0).get(2);
+
+        assertThat(huge.getHeadingLevel()).isEqualTo(2);      // tallest → H2
+        assertThat(medium.getHeadingLevel()).isEqualTo(3);     // middle → H3
+        assertThat(tiny.getHeadingLevel()).isEqualTo(4);       // shortest → H4
+
+        // No skipping: levels are 2, 3, 4 (no gap)
+    }
+
+    // --- Helper methods ---
+
+    private List<List<IObject>> transform(ObjectNode json) {
+        HybridResponse response = new HybridResponse("", json, null);
+        Map<Integer, Double> pageHeights = new HashMap<>();
+        pageHeights.put(1, 842.0);
+        return transformer.transform(response, pageHeights);
+    }
+
+    /**
+     * Creates an object node representing a Hancom AI detected object.
+     * bbox format: [left, top, right, bottom]
+     */
+    private ObjectNode createObject(int label, String text, double left, double top,
+                                     double right, double bottom) {
+        ObjectNode obj = objectMapper.createObjectNode();
+        obj.put("label", label);
+        obj.put("ocrtext", text);
+        obj.put("confidence", 0.95);
+
+        ArrayNode bbox = obj.putArray("bbox");
+        bbox.add(left);
+        bbox.add(top);
+        bbox.add(right);
+        bbox.add(bottom);
+
+        return obj;
+    }
+
+    /**
+     * Creates Hancom AI JSON with a single page containing given objects.
+     */
+    private ObjectNode createHancomAIJson(ObjectNode... objects) {
+        ObjectNode json = objectMapper.createObjectNode();
+        ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+        ArrayNode pages = dlaOcr.addArray();
+
+        ObjectNode page = pages.addObject();
+        page.put("page_number", 0);
+        page.put("image_height", 3508);
+        ArrayNode objectsArray = page.putArray("objects");
+        for (ObjectNode obj : objects) {
+            objectsArray.add(obj);
+        }
+
+        return json;
+    }
+
+    /**
+     * Creates Hancom AI JSON with multiple pages.
+     * Each inner array is the objects for that page.
+     */
+    private ObjectNode createHancomAIJsonMultiPage(ObjectNode[][] pageObjects) {
+        ObjectNode json = objectMapper.createObjectNode();
+        ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+        ArrayNode pages = dlaOcr.addArray();
+
+        for (int i = 0; i < pageObjects.length; i++) {
+            ObjectNode page = pages.addObject();
+            page.put("page_number", i);
+            page.put("image_height", 3508);
+            ArrayNode objectsArray = page.putArray("objects");
+            for (ObjectNode obj : pageObjects[i]) {
+                objectsArray.add(obj);
+            }
+        }
+
+        return json;
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.entities.SemanticFootnote;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
 import org.verapdf.wcag.algorithms.entities.IObject;
@@ -817,6 +818,23 @@ public class HancomAISchemaTransformerTest {
         assertThat(caption).isNotNull();
         assertThat(table).isNotNull();
         assertThat(caption.getLinkedContentId()).isEqualTo(table.getRecognizedStructureId());
+    }
+
+    // --- Task 6: Footnote (label 13) ---
+
+    @Test
+    void footnote_becomesSemanticFootnote() {
+        // label 13 → SemanticFootnote (not SemanticParagraph)
+        ObjectNode json = createHancomAIJson(
+            createObject(13, "1. See reference [3].", 100, 700, 500, 720)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        assertThat(result.get(0).get(0)).isInstanceOf(SemanticFootnote.class);
+        SemanticFootnote footnote = (SemanticFootnote) result.get(0).get(0);
+        assertThat(footnote.getValue()).isEqualTo("1. See reference [3].");
     }
 
     @Test

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -501,6 +501,25 @@ public class HancomAISchemaTransformerTest {
     }
 
     /**
+     * Creates an object node with a specific confidence value.
+     */
+    private ObjectNode createObjectWithConfidence(int label, String text, double left, double top,
+                                                   double right, double bottom, double confidence) {
+        ObjectNode obj = objectMapper.createObjectNode();
+        obj.put("label", label);
+        obj.put("ocrtext", text);
+        obj.put("confidence", confidence);
+
+        ArrayNode bbox = obj.putArray("bbox");
+        bbox.add(left);
+        bbox.add(top);
+        bbox.add(right);
+        bbox.add(bottom);
+
+        return obj;
+    }
+
+    /**
      * Creates Hancom AI JSON with a single page containing given objects.
      */
     private ObjectNode createHancomAIJson(ObjectNode... objects) {
@@ -911,6 +930,51 @@ public class HancomAISchemaTransformerTest {
         List<List<IObject>> result = transform(json);
 
         assertThat(result.get(0)).isEmpty();
+    }
+
+    // --- Task 8: confidence → correctSemanticScore ---
+
+    @Test
+    void confidence_mappedToCorrectSemanticScore() {
+        // object with confidence 0.85 → correctSemanticScore = 0.85
+        ObjectNode obj = createObjectWithConfidence(2, "Test paragraph", 100, 100, 500, 130, 0.85);
+        ObjectNode json = createHancomAIJson(obj);
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        SemanticParagraph para = (SemanticParagraph) result.get(0).get(0);
+        assertThat(para.getCorrectSemanticScore()).isEqualTo(0.85);
+    }
+
+    @Test
+    void confidence_defaultsTo1WhenMissing() {
+        // object without confidence field → correctSemanticScore = 1.0
+        ObjectNode obj = objectMapper.createObjectNode();
+        obj.put("label", 2);
+        obj.put("ocrtext", "No confidence field");
+        ArrayNode bbox = obj.putArray("bbox");
+        bbox.add(100); bbox.add(100); bbox.add(500); bbox.add(130);
+
+        ObjectNode json = createHancomAIJson(obj);
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        SemanticParagraph para = (SemanticParagraph) result.get(0).get(0);
+        assertThat(para.getCorrectSemanticScore()).isEqualTo(1.0);
+    }
+
+    @Test
+    void confidence_appliedToHeading() {
+        // heading with confidence 0.72 → correctSemanticScore = 0.72
+        ObjectNode obj = createObjectWithConfidence(0, "Title", 100, 50, 500, 100, 0.72);
+        ObjectNode json = createHancomAIJson(obj);
+
+        List<List<IObject>> result = transform(json);
+
+        SemanticHeading heading = (SemanticHeading) result.get(0).get(0);
+        assertThat(heading.getCorrectSemanticScore()).isEqualTo(0.72);
     }
 
     @Test

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -1367,6 +1367,177 @@ public class HancomAISchemaTransformerTest {
         assertThat(tableCount).isEqualTo(2);
     }
 
+    // --- Task G: ElementMetadata ---
+
+    @Test
+    void metadata_paragraphHasConfidenceAndSourceLabel() {
+        ObjectNode obj = createObjectWithConfidence(2, "Test paragraph", 100, 100, 500, 130, 0.88);
+        ObjectNode json = createHancomAIJson(obj);
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        IObject iobj = result.get(0).get(0);
+        assertThat(iobj.getRecognizedStructureId()).isNotNull();
+
+        Map<Long, ElementMetadata> metadata = transformer.getElementMetadata();
+        assertThat(metadata).containsKey(iobj.getRecognizedStructureId());
+
+        ElementMetadata meta = metadata.get(iobj.getRecognizedStructureId());
+        assertThat(meta.getConfidence()).isEqualTo(0.88);
+        assertThat(meta.getSourceLabel()).isEqualTo(2);
+        assertThat(meta.getHeadingInferenceMethod()).isNull();
+    }
+
+    @Test
+    void metadata_headingHasBboxHeightInference() {
+        ObjectNode json = createHancomAIJson(
+            createObjectWithConfidence(1, "Section Title", 100, 100, 500, 160, 0.92)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        SemanticHeading heading = (SemanticHeading) result.get(0).get(0);
+        Map<Long, ElementMetadata> metadata = transformer.getElementMetadata();
+        ElementMetadata meta = metadata.get(heading.getRecognizedStructureId());
+
+        assertThat(meta).isNotNull();
+        assertThat(meta.getSourceLabel()).isEqualTo(1);
+        assertThat(meta.getHeadingInferenceMethod()).isEqualTo("bbox-height");
+        assertThat(meta.getBboxHeightPx()).isEqualTo(60.0);  // 160 - 100
+    }
+
+    @Test
+    void metadata_titleHasFixedInference() {
+        ObjectNode json = createHancomAIJson(
+            createObject(0, "Document Title", 100, 50, 500, 100)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        SemanticHeading heading = (SemanticHeading) result.get(0).get(0);
+        Map<Long, ElementMetadata> metadata = transformer.getElementMetadata();
+        ElementMetadata meta = metadata.get(heading.getRecognizedStructureId());
+
+        assertThat(meta).isNotNull();
+        assertThat(meta.getHeadingInferenceMethod()).isEqualTo("fixed");
+        assertThat(meta.getBboxHeightPx()).isNull();
+    }
+
+    @Test
+    void metadata_tableHasTsrMetadata() {
+        ObjectNode tsrCell = createTsrCell(0, 0, 1, 1, "cell", 100, 100, 300, 200);
+        double[] tableBbox = {100, 100, 300, 200};
+        ObjectNode json = createHancomAIJsonWithTable(
+            new ObjectNode[]{},
+            tableBbox,
+            new ObjectNode[]{tsrCell}
+        );
+
+        // Add num_cells to the tsr object
+        // The helper already sets num_cells = tsrCells.length
+
+        List<List<IObject>> result = transform(json);
+
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof TableBorder) {
+                table = (TableBorder) obj;
+                break;
+            }
+        }
+        assertThat(table).isNotNull();
+
+        Map<Long, ElementMetadata> metadata = transformer.getElementMetadata();
+        ElementMetadata meta = metadata.get(table.getRecognizedStructureId());
+
+        assertThat(meta).isNotNull();
+        assertThat(meta.getSourceLabel()).isEqualTo(9);
+        assertThat(meta.getTsr()).isNotNull();
+        assertThat(meta.getTsr().getNumCells()).isEqualTo(1);
+    }
+
+    @Test
+    void metadata_figureHasCaptionMetadata() {
+        // Create figure with caption from FIGURE_CAPTIONS
+        ObjectNode json = objectMapper.createObjectNode();
+
+        // DLA+OCR with a figure object
+        ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+        ArrayNode dlaPages = dlaOcr.addArray();
+        ObjectNode page = dlaPages.addObject();
+        page.put("page_number", 0);
+        page.put("image_height", 3508);
+        ArrayNode objects = page.putArray("objects");
+        ObjectNode figObj = objects.addObject();
+        figObj.put("label", 10);
+        figObj.put("ocrtext", "");
+        figObj.put("confidence", 0.91);
+        figObj.put("object_id", 5);
+        ArrayNode bbox = figObj.putArray("bbox");
+        bbox.add(100); bbox.add(100); bbox.add(500); bbox.add(400);
+
+        // FIGURE_CAPTIONS
+        ArrayNode figureCaptions = json.putArray("FIGURE_CAPTIONS");
+        ObjectNode cap = figureCaptions.addObject();
+        cap.put("page_number", 0);
+        cap.put("object_id", 5);
+        cap.put("caption", "A beautiful chart");
+
+        List<List<IObject>> result = transform(json);
+
+        SemanticPicture pic = (SemanticPicture) result.get(0).get(0);
+        Map<Long, ElementMetadata> metadata = transformer.getElementMetadata();
+        ElementMetadata meta = metadata.get(pic.getRecognizedStructureId());
+
+        assertThat(meta).isNotNull();
+        assertThat(meta.getSourceLabel()).isEqualTo(10);
+        assertThat(meta.getCaption()).isNotNull();
+        assertThat(meta.getCaption().getText()).isEqualTo("A beautiful chart");
+        assertThat(meta.getCaption().getLanguage()).isEqualTo("en");
+    }
+
+    @Test
+    void metadata_regionlistHasResolution() {
+        // label 7 without TSR → list-only style resolution
+        ObjectNode json = createHancomAIJson(
+            createObjectWithConfidence(7, "Line one\nLine two", 100, 100, 500, 200, 0.80)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        IObject iobj = result.get(0).get(0);
+
+        Map<Long, ElementMetadata> metadata = transformer.getElementMetadata();
+        ElementMetadata meta = metadata.get(iobj.getRecognizedStructureId());
+
+        assertThat(meta).isNotNull();
+        assertThat(meta.getSourceLabel()).isEqualTo(7);
+        assertThat(meta.getRegionlistResolution()).isNotNull();
+        assertThat(meta.getRegionlistResolution().getStrategy()).isEqualTo("table-first");
+        assertThat(meta.getRegionlistResolution().isTsrAttempted()).isTrue();
+        assertThat(meta.getRegionlistResolution().getTsrResult()).isEqualTo("no-cells");
+    }
+
+    @Test
+    void metadata_clearedBetweenTransformCalls() {
+        // First transform
+        ObjectNode json1 = createHancomAIJson(
+            createObject(2, "First call", 100, 100, 500, 130)
+        );
+        transform(json1);
+        assertThat(transformer.getElementMetadata()).hasSize(1);
+
+        // Second transform should clear previous metadata
+        ObjectNode json2 = createHancomAIJson(
+            createObject(2, "Second call A", 100, 100, 500, 130),
+            createObject(2, "Second call B", 100, 200, 500, 230)
+        );
+        transform(json2);
+        assertThat(transformer.getElementMetadata()).hasSize(2);
+    }
+
     @Test
     void tableCellText_pageHeaderFooterWords_excluded() {
         // Words with label 14 (page header), 15 (page footer), 17 (page number) should not

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -27,6 +27,8 @@ import org.verapdf.wcag.algorithms.entities.SemanticHeading;
 import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
 import org.verapdf.wcag.algorithms.entities.lists.ListItem;
 import org.verapdf.wcag.algorithms.entities.lists.PDFList;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
 
 import java.util.HashMap;
 import java.util.List;
@@ -534,5 +536,251 @@ public class HancomAISchemaTransformerTest {
         }
 
         return json;
+    }
+
+    // --- Cell-word bbox intersection matching (Task 4) ---
+
+    /**
+     * Helper: creates a Hancom AI JSON with DLA+OCR objects AND TABLE_STRUCTURE_RECOGNITION data.
+     * DLA objects and TSR cells use Hancom AI pixel coordinates [left, top, right, bottom].
+     */
+    private ObjectNode createHancomAIJsonWithTable(ObjectNode[] dlaObjects,
+                                                    double[] tableBbox,
+                                                    ObjectNode[] tsrCells) {
+        ObjectNode json = objectMapper.createObjectNode();
+
+        // DLA+OCR
+        ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+        ArrayNode dlaPages = dlaOcr.addArray();
+        ObjectNode dlaPage = dlaPages.addObject();
+        dlaPage.put("page_number", 0);
+        dlaPage.put("image_height", 3508);
+        ArrayNode objectsArray = dlaPage.putArray("objects");
+        for (ObjectNode obj : dlaObjects) {
+            objectsArray.add(obj);
+        }
+
+        // TABLE_STRUCTURE_RECOGNITION
+        ArrayNode tsr = json.putArray("TABLE_STRUCTURE_RECOGNITION");
+        ArrayNode tsrPages = tsr.addArray();
+        ObjectNode tsrPage = tsrPages.addObject();
+        tsrPage.put("page_number", 0);
+        tsrPage.put("num_cells", tsrCells.length);
+
+        ArrayNode tbbox = tsrPage.putArray("table_bbox");
+        for (double v : tableBbox) tbbox.add(v);
+
+        ArrayNode cellsArray = tsrPage.putArray("cells");
+        for (ObjectNode cell : tsrCells) {
+            cellsArray.add(cell);
+        }
+
+        return json;
+    }
+
+    /**
+     * Helper: creates a TSR cell node.
+     */
+    private ObjectNode createTsrCell(int row, int col, int rowspan, int colspan,
+                                      String text, double left, double top,
+                                      double right, double bottom) {
+        ObjectNode cell = objectMapper.createObjectNode();
+        cell.put("row", row);
+        cell.put("col", col);
+        cell.put("rowspan", rowspan);
+        cell.put("colspan", colspan);
+        cell.put("text", text);
+        ArrayNode bbox = cell.putArray("bbox");
+        bbox.add(left);
+        bbox.add(top);
+        bbox.add(right);
+        bbox.add(bottom);
+        return cell;
+    }
+
+    /**
+     * Helper: extract text from a TableBorderCell's first content object (SemanticParagraph).
+     */
+    private String getCellText(TableBorder table, int row, int col) {
+        TableBorderCell cell = table.getCell(row, col);
+        if (cell == null || cell.getContents() == null || cell.getContents().isEmpty()) {
+            return "";
+        }
+        IObject content = cell.getContents().get(0);
+        if (content instanceof SemanticParagraph) {
+            return ((SemanticParagraph) content).getValue();
+        }
+        return "";
+    }
+
+    @Test
+    void tableCellText_comesFromBboxWordMatching_notTsrTextField() {
+        // DLA+OCR words positioned inside specific cells
+        // Table at pixel coords [100, 100, 500, 300] (2 rows x 2 cols)
+        // Cell (0,0): [100,100,300,200], Cell (0,1): [300,100,500,200]
+        // Cell (1,0): [100,200,300,300], Cell (1,1): [300,200,500,300]
+        ObjectNode word1 = createObject(2, "Hello", 120, 120, 280, 180);   // inside cell (0,0)
+        ObjectNode word2 = createObject(2, "World", 320, 120, 480, 180);   // inside cell (0,1)
+        ObjectNode word3 = createObject(2, "Foo", 120, 220, 280, 280);     // inside cell (1,0)
+        ObjectNode word4 = createObject(2, "Bar", 320, 220, 480, 280);     // inside cell (1,1)
+
+        // TSR cells have WRONG text (to prove we use bbox matching, not TSR text)
+        ObjectNode tsrCell00 = createTsrCell(0, 0, 1, 1, "WRONG0", 100, 100, 300, 200);
+        ObjectNode tsrCell01 = createTsrCell(0, 1, 1, 1, "WRONG1", 300, 100, 500, 200);
+        ObjectNode tsrCell10 = createTsrCell(1, 0, 1, 1, "WRONG2", 100, 200, 300, 300);
+        ObjectNode tsrCell11 = createTsrCell(1, 1, 1, 1, "WRONG3", 300, 200, 500, 300);
+
+        double[] tableBbox = {100, 100, 500, 300};
+        ObjectNode json = createHancomAIJsonWithTable(
+            new ObjectNode[]{word1, word2, word3, word4},
+            tableBbox,
+            new ObjectNode[]{tsrCell00, tsrCell01, tsrCell10, tsrCell11}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        // Find the TableBorder in results
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof TableBorder) {
+                table = (TableBorder) obj;
+                break;
+            }
+        }
+        assertThat(table).isNotNull();
+
+        // Cell text should come from DLA words, NOT TSR text field
+        assertThat(getCellText(table, 0, 0)).isEqualTo("Hello");
+        assertThat(getCellText(table, 0, 1)).isEqualTo("World");
+        assertThat(getCellText(table, 1, 0)).isEqualTo("Foo");
+        assertThat(getCellText(table, 1, 1)).isEqualTo("Bar");
+    }
+
+    @Test
+    void tableCellText_wordStraddlingTwoCells_assignedToMajorityOverlap() {
+        // Word bbox straddles cell (0,0) and cell (0,1), but majority is in (0,0)
+        // Table: [100, 100, 500, 300], 1 row x 2 cols
+        // Cell (0,0): [100,100,300,300], Cell (0,1): [300,100,500,300]
+        // Word at [120, 120, 310, 280] → overlaps (0,0) by 180x160=28800, (0,1) by 10x160=1600
+        // 28800/(190*160)=0.947 > 0.5 → assigned to (0,0)
+        // 1600/(190*160)=0.053 < 0.5 → NOT assigned to (0,1)
+        ObjectNode word = createObject(2, "Straddler", 120, 120, 310, 280);
+
+        ObjectNode tsrCell0 = createTsrCell(0, 0, 1, 1, "TSR0", 100, 100, 300, 300);
+        ObjectNode tsrCell1 = createTsrCell(0, 1, 1, 1, "TSR1", 300, 100, 500, 300);
+
+        double[] tableBbox = {100, 100, 500, 300};
+        ObjectNode json = createHancomAIJsonWithTable(
+            new ObjectNode[]{word},
+            tableBbox,
+            new ObjectNode[]{tsrCell0, tsrCell1}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof TableBorder) {
+                table = (TableBorder) obj;
+                break;
+            }
+        }
+        assertThat(table).isNotNull();
+
+        // Word assigned to cell (0,0) where majority overlap is
+        assertThat(getCellText(table, 0, 0)).isEqualTo("Straddler");
+        // Cell (0,1) should fall back to TSR text since no matching words
+        assertThat(getCellText(table, 0, 1)).isEqualTo("TSR1");
+    }
+
+    @Test
+    void tableCellText_noMatchingWords_fallsBackToTsrText() {
+        // No DLA words on this page — cells should use TSR text field as fallback
+        ObjectNode tsrCell0 = createTsrCell(0, 0, 1, 1, "Fallback Text", 100, 100, 300, 200);
+        ObjectNode tsrCell1 = createTsrCell(0, 1, 1, 1, "Also Fallback", 300, 100, 500, 200);
+
+        double[] tableBbox = {100, 100, 500, 200};
+        ObjectNode json = createHancomAIJsonWithTable(
+            new ObjectNode[]{},   // no DLA words
+            tableBbox,
+            new ObjectNode[]{tsrCell0, tsrCell1}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof TableBorder) {
+                table = (TableBorder) obj;
+                break;
+            }
+        }
+        assertThat(table).isNotNull();
+
+        assertThat(getCellText(table, 0, 0)).isEqualTo("Fallback Text");
+        assertThat(getCellText(table, 0, 1)).isEqualTo("Also Fallback");
+    }
+
+    @Test
+    void tableCellText_multipleWordsInCell_sortedByReadingOrder() {
+        // Two words in cell (0,0): one higher up, one lower
+        // They should be joined in reading order (top-to-bottom, left-to-right)
+        ObjectNode word1 = createObject(2, "First", 120, 120, 280, 150);   // higher (top=120)
+        ObjectNode word2 = createObject(2, "Second", 120, 160, 280, 190);  // lower (top=160)
+
+        ObjectNode tsrCell = createTsrCell(0, 0, 1, 1, "WRONG", 100, 100, 300, 200);
+        double[] tableBbox = {100, 100, 300, 200};
+
+        ObjectNode json = createHancomAIJsonWithTable(
+            new ObjectNode[]{word2, word1},  // intentionally reversed to test sorting
+            tableBbox,
+            new ObjectNode[]{tsrCell}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof TableBorder) {
+                table = (TableBorder) obj;
+                break;
+            }
+        }
+        assertThat(table).isNotNull();
+
+        // Words should be sorted: First (higher) then Second (lower)
+        assertThat(getCellText(table, 0, 0)).isEqualTo("First Second");
+    }
+
+    @Test
+    void tableCellText_pageHeaderFooterWords_excluded() {
+        // Words with label 14 (page header), 15 (page footer), 17 (page number) should not
+        // be matched to cells even if their bbox overlaps
+        ObjectNode headerWord = createObject(14, "HEADER", 120, 120, 280, 180);
+        ObjectNode footerWord = createObject(15, "FOOTER", 120, 120, 280, 180);
+        ObjectNode pageNumWord = createObject(17, "42", 120, 120, 280, 180);
+
+        ObjectNode tsrCell = createTsrCell(0, 0, 1, 1, "Fallback", 100, 100, 300, 200);
+        double[] tableBbox = {100, 100, 300, 200};
+
+        ObjectNode json = createHancomAIJsonWithTable(
+            new ObjectNode[]{headerWord, footerWord, pageNumWord},
+            tableBbox,
+            new ObjectNode[]{tsrCell}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof TableBorder) {
+                table = (TableBorder) obj;
+                break;
+            }
+        }
+        assertThat(table).isNotNull();
+
+        // Furniture words excluded, so falls back to TSR text
+        assertThat(getCellText(table, 0, 0)).isEqualTo("Fallback");
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -932,6 +932,68 @@ public class HancomAISchemaTransformerTest {
         assertThat(result.get(0)).isEmpty();
     }
 
+    // --- Task E: regionlistStrategy ---
+
+    @Test
+    void regionlistStrategy_listOnly_withTsrOverlap_stillBecomesList() {
+        // list-only strategy: label 7 with overlapping TSR should NOT be skipped
+        // — it should become a PDFList regardless of TSR presence
+        transformer.setRegionlistStrategy(HybridConfig.REGIONLIST_LIST_ONLY);
+
+        ObjectNode regionObj = createObject(7, "Row 1\nRow 2\nRow 3", 100, 100, 500, 300);
+
+        ObjectNode tsrCell = createTsrCell(0, 0, 1, 1, "cell", 100, 100, 500, 300);
+        double[] tableBbox = {100, 100, 500, 300};
+        ObjectNode json = createHancomAIJsonWithTable(
+            new ObjectNode[]{regionObj},
+            tableBbox,
+            new ObjectNode[]{tsrCell}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        // Should find a PDFList from label 7 (not skipped despite TSR overlap)
+        boolean hasList = result.get(0).stream().anyMatch(o -> o instanceof PDFList);
+        assertThat(hasList).isTrue();
+
+        PDFList list = (PDFList) result.get(0).stream()
+            .filter(o -> o instanceof PDFList).findFirst().orElse(null);
+        assertThat(list).isNotNull();
+        assertThat(list.getListItems()).hasSize(3);
+        assertThat(list.getListItems().get(0).getFirstLine().getValue()).isEqualTo("Row 1");
+    }
+
+    @Test
+    void regionlistStrategy_tableFirst_withTsrOverlap_skipsLabel7() {
+        // table-first (default): label 7 with TSR overlap is skipped (existing behavior)
+        transformer.setRegionlistStrategy(HybridConfig.REGIONLIST_TABLE_FIRST);
+
+        ObjectNode regionObj = createObject(7, "Table data here", 100, 100, 500, 300);
+
+        ObjectNode tsrCell = createTsrCell(0, 0, 1, 1, "cell", 100, 100, 500, 300);
+        double[] tableBbox = {100, 100, 500, 300};
+        ObjectNode json = createHancomAIJsonWithTable(
+            new ObjectNode[]{regionObj},
+            tableBbox,
+            new ObjectNode[]{tsrCell}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        // No PDFList from label 7 — only the TableBorder from TSR
+        for (IObject obj : result.get(0)) {
+            assertThat(obj).isNotInstanceOf(PDFList.class);
+        }
+        assertThat(result.get(0).stream().anyMatch(o -> o instanceof TableBorder)).isTrue();
+    }
+
+    @Test
+    void regionlistStrategy_defaultIsTableFirst() {
+        // Default strategy should be table-first
+        HancomAISchemaTransformer freshTransformer = new HancomAISchemaTransformer();
+        assertThat(freshTransformer.getRegionlistStrategy()).isEqualTo(HybridConfig.REGIONLIST_TABLE_FIRST);
+    }
+
     // --- Task 8: confidence → correctSemanticScore ---
 
     @Test

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -564,11 +564,48 @@ public class HancomAISchemaTransformerTest {
 
     /**
      * Helper: creates a Hancom AI JSON with DLA+OCR objects AND TABLE_STRUCTURE_RECOGNITION data.
-     * DLA objects and TSR cells use Hancom AI pixel coordinates [left, top, right, bottom].
+     * Uses the new per-table entry format with dla_bbox and tsr sub-object.
+     *
+     * <p>For backward-compat with existing tests where cell bboxes are in page pixels:
+     * dla_bbox is set to tableBbox (so overlap checks work correctly), and the cell bboxes
+     * are adjusted by subtracting the table origin so they become crop-relative.
+     * The tsr.table_bbox is set to a zero-origin version of tableBbox.
      */
     private ObjectNode createHancomAIJsonWithTable(ObjectNode[] dlaObjects,
                                                     double[] tableBbox,
                                                     ObjectNode[] tsrCells) {
+        // Make cell bboxes crop-relative by subtracting table origin
+        double originLeft = tableBbox[0];
+        double originTop = tableBbox[1];
+        ObjectNode[] adjustedCells = new ObjectNode[tsrCells.length];
+        for (int i = 0; i < tsrCells.length; i++) {
+            adjustedCells[i] = tsrCells[i].deepCopy();
+            com.fasterxml.jackson.databind.node.ArrayNode cellBbox =
+                (com.fasterxml.jackson.databind.node.ArrayNode) adjustedCells[i].get("bbox");
+            if (cellBbox != null && cellBbox.size() >= 4) {
+                double l = cellBbox.get(0).asDouble() - originLeft;
+                double t = cellBbox.get(1).asDouble() - originTop;
+                double r = cellBbox.get(2).asDouble() - originLeft;
+                double b = cellBbox.get(3).asDouble() - originTop;
+                cellBbox.removeAll();
+                cellBbox.add(l); cellBbox.add(t); cellBbox.add(r); cellBbox.add(b);
+            }
+        }
+        // tsr.table_bbox in crop coords (zero-origin)
+        double[] cropTableBbox = {0, 0, tableBbox[2] - tableBbox[0], tableBbox[3] - tableBbox[1]};
+        return createHancomAIJsonWithTableAndOffset(dlaObjects, tableBbox, cropTableBbox, adjustedCells);
+    }
+
+    /**
+     * Helper: creates Hancom AI JSON with separate dla_bbox (page coords) and crop-relative cells.
+     * @param dlaBbox the padded DLA bbox in page pixels [left, top, right, bottom]
+     * @param tsrTableBbox the table_bbox in crop-image coords
+     * @param tsrCells cells with crop-relative bboxes
+     */
+    private ObjectNode createHancomAIJsonWithTableAndOffset(ObjectNode[] dlaObjects,
+                                                             double[] dlaBbox,
+                                                             double[] tsrTableBbox,
+                                                             ObjectNode[] tsrCells) {
         ObjectNode json = objectMapper.createObjectNode();
 
         // DLA+OCR
@@ -582,17 +619,24 @@ public class HancomAISchemaTransformerTest {
             objectsArray.add(obj);
         }
 
-        // TABLE_STRUCTURE_RECOGNITION
+        // TABLE_STRUCTURE_RECOGNITION — new per-table entry format
         ArrayNode tsr = json.putArray("TABLE_STRUCTURE_RECOGNITION");
-        ArrayNode tsrPages = tsr.addArray();
-        ObjectNode tsrPage = tsrPages.addObject();
-        tsrPage.put("page_number", 0);
-        tsrPage.put("num_cells", tsrCells.length);
+        ObjectNode tableEntry = tsr.addObject();
+        tableEntry.put("page_number", 0);
+        tableEntry.put("object_id", 0);
+        tableEntry.put("label", 9);
 
-        ArrayNode tbbox = tsrPage.putArray("table_bbox");
-        for (double v : tableBbox) tbbox.add(v);
+        ArrayNode dlaBboxArr = tableEntry.putArray("dla_bbox");
+        for (double v : dlaBbox) dlaBboxArr.add(v);
 
-        ArrayNode cellsArray = tsrPage.putArray("cells");
+        ObjectNode tsrObj = tableEntry.putObject("tsr");
+        tsrObj.put("page_number", 0);
+        tsrObj.put("num_cells", tsrCells.length);
+
+        ArrayNode tbbox = tsrObj.putArray("table_bbox");
+        for (double v : tsrTableBbox) tbbox.add(v);
+
+        ArrayNode cellsArray = tsrObj.putArray("cells");
         for (ObjectNode cell : tsrCells) {
             cellsArray.add(cell);
         }
@@ -601,17 +645,24 @@ public class HancomAISchemaTransformerTest {
     }
 
     /**
-     * Helper: creates a TSR cell node.
+     * Helper: creates a TSR cell node with array-format rowspan/colspan (real API format).
+     * rowspan/colspan are arrays of row/col indices this cell spans.
      */
     private ObjectNode createTsrCell(int row, int col, int rowspan, int colspan,
                                       String text, double left, double top,
                                       double right, double bottom) {
         ObjectNode cell = objectMapper.createObjectNode();
-        cell.put("row", row);
-        cell.put("col", col);
-        cell.put("rowspan", rowspan);
-        cell.put("colspan", colspan);
+        cell.put("cell_id", row * 10 + col);  // synthetic cell_id
         cell.put("text", text);
+
+        // Array-format rowspan: [startRow, startRow+1, ..., startRow+rowspan-1]
+        ArrayNode rsArr = cell.putArray("rowspan");
+        for (int i = 0; i < rowspan; i++) rsArr.add(row + i);
+
+        // Array-format colspan: [startCol, startCol+1, ..., startCol+colspan-1]
+        ArrayNode csArr = cell.putArray("colspan");
+        for (int i = 0; i < colspan; i++) csArr.add(col + i);
+
         ArrayNode bbox = cell.putArray("bbox");
         bbox.add(left);
         bbox.add(top);
@@ -1066,6 +1117,254 @@ public class HancomAISchemaTransformerTest {
 
         SemanticHeading heading = (SemanticHeading) result.get(0).get(0);
         assertThat(heading.getCorrectSemanticScore()).isEqualTo(0.72);
+    }
+
+    // --- Task D: Array rowspan/colspan and crop-to-page bbox conversion ---
+
+    @Test
+    void arrayRowspan_parsedCorrectly() {
+        // rowspan [1, 2] → startRow=1, rowspan=2
+        // colspan [0] → startCol=0, colspan=1
+        // This cell spans rows 1 and 2, column 0 only
+        ObjectNode cell = objectMapper.createObjectNode();
+        cell.put("cell_id", 3);
+        ArrayNode rs = cell.putArray("rowspan");
+        rs.add(1); rs.add(2);
+        ArrayNode cs = cell.putArray("colspan");
+        cs.add(0);
+        ArrayNode bbox = cell.putArray("bbox");
+        bbox.add(21); bbox.add(126); bbox.add(143); bbox.add(237);
+
+        // Also need a cell at (0,0) to make a valid table
+        ObjectNode cell00 = objectMapper.createObjectNode();
+        cell00.put("cell_id", 0);
+        ArrayNode rs00 = cell00.putArray("rowspan");
+        rs00.add(0);
+        ArrayNode cs00 = cell00.putArray("colspan");
+        cs00.add(0);
+        ArrayNode bbox00 = cell00.putArray("bbox");
+        bbox00.add(21); bbox00.add(15); bbox00.add(143); bbox00.add(126);
+
+        // Build TSR entry
+        ObjectNode json = objectMapper.createObjectNode();
+        ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+        ArrayNode dlaPages = dlaOcr.addArray();
+        ObjectNode dlaPage = dlaPages.addObject();
+        dlaPage.put("page_number", 0);
+        dlaPage.put("image_height", 3508);
+        dlaPage.putArray("objects");
+
+        ArrayNode tsr = json.putArray("TABLE_STRUCTURE_RECOGNITION");
+        ObjectNode tableEntry = tsr.addObject();
+        tableEntry.put("page_number", 0);
+        ArrayNode dlaBbox = tableEntry.putArray("dla_bbox");
+        dlaBbox.add(183); dlaBbox.add(607); dlaBbox.add(1590); dlaBbox.add(1533);
+        ObjectNode tsrObj = tableEntry.putObject("tsr");
+        tsrObj.put("page_number", 0);
+        tsrObj.put("num_cells", 2);
+        ArrayNode tbbox = tsrObj.putArray("table_bbox");
+        tbbox.add(21); tbbox.add(13); tbbox.add(1349); tbbox.add(875);
+        ArrayNode cellsArray = tsrObj.putArray("cells");
+        cellsArray.add(cell00);
+        cellsArray.add(cell);
+
+        List<List<IObject>> result = transform(json);
+
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof TableBorder) {
+                table = (TableBorder) obj;
+                break;
+            }
+        }
+        assertThat(table).isNotNull();
+        // Table should have 3 rows (indices 0, 1, 2) and 1 column
+        assertThat(table.getNumberOfRows()).isEqualTo(3);
+        assertThat(table.getNumberOfColumns()).isEqualTo(1);
+
+        // Cell at (1, 0) should span 2 rows
+        TableBorderCell spanCell = table.getCell(1, 0);
+        assertThat(spanCell).isNotNull();
+        assertThat(spanCell.getRowSpan()).isEqualTo(2);
+        assertThat(spanCell.getColSpan()).isEqualTo(1);
+    }
+
+    @Test
+    void cropToPageBboxConversion_withKnownOffset() {
+        // DLA bbox (crop origin): [100, 200, 500, 600] in page pixels
+        // Cell bbox in crop coords: [10, 20, 90, 80]
+        // Expected page-level pixel coords: [110, 220, 190, 280]
+        // Expected PDF points: [110*0.24, pageH - 280*0.24, 190*0.24, pageH - 220*0.24]
+        double[] dlaBbox = {100, 200, 500, 600};
+        double[] tsrTableBbox = {0, 0, 400, 400};  // crop-relative
+
+        ObjectNode cell = objectMapper.createObjectNode();
+        cell.put("cell_id", 0);
+        ArrayNode rs = cell.putArray("rowspan");
+        rs.add(0);
+        ArrayNode cs = cell.putArray("colspan");
+        cs.add(0);
+        ArrayNode bbox = cell.putArray("bbox");
+        bbox.add(10); bbox.add(20); bbox.add(90); bbox.add(80);
+
+        ObjectNode json = createHancomAIJsonWithTableAndOffset(
+            new ObjectNode[]{},
+            dlaBbox,
+            tsrTableBbox,
+            new ObjectNode[]{cell}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof TableBorder) {
+                table = (TableBorder) obj;
+                break;
+            }
+        }
+        assertThat(table).isNotNull();
+
+        // Cell bbox should be converted from crop to page coords
+        TableBorderCell c = table.getCell(0, 0);
+        assertThat(c).isNotNull();
+        assertThat(c.getBoundingBox()).isNotNull();
+
+        // Page pixel coords: left=110, top=220, right=190, bottom=280
+        // PDF points: left=110*0.24=26.4, right=190*0.24=45.6
+        // topY = 842 - 220*0.24 = 842 - 52.8 = 789.2
+        // bottomY = 842 - 280*0.24 = 842 - 67.2 = 774.8
+        double pageHeight = 842.0;
+        double expectedLeft = 110.0 * 72.0 / 300.0;
+        double expectedRight = 190.0 * 72.0 / 300.0;
+        double expectedTopY = pageHeight - (220.0 * 72.0 / 300.0);
+        double expectedBottomY = pageHeight - (280.0 * 72.0 / 300.0);
+
+        assertThat(c.getBoundingBox().getLeftX()).isEqualTo(expectedLeft, org.assertj.core.api.Assertions.within(0.01));
+        assertThat(c.getBoundingBox().getRightX()).isEqualTo(expectedRight, org.assertj.core.api.Assertions.within(0.01));
+        assertThat(c.getBoundingBox().getTopY()).isEqualTo(expectedTopY, org.assertj.core.api.Assertions.within(0.01));
+        assertThat(c.getBoundingBox().getBottomY()).isEqualTo(expectedBottomY, org.assertj.core.api.Assertions.within(0.01));
+    }
+
+    @Test
+    void backwardCompat_integerRowspanColspan_stillWorks() {
+        // Test backward compatibility with integer rowspan/colspan format
+        ObjectNode cell = objectMapper.createObjectNode();
+        cell.put("row", 0);
+        cell.put("col", 0);
+        cell.put("rowspan", 2);
+        cell.put("colspan", 1);
+        cell.put("text", "Merged cell");
+        ArrayNode bbox = cell.putArray("bbox");
+        bbox.add(100); bbox.add(100); bbox.add(300); bbox.add(300);
+
+        ObjectNode cell2 = objectMapper.createObjectNode();
+        cell2.put("row", 0);
+        cell2.put("col", 1);
+        cell2.put("rowspan", 1);
+        cell2.put("colspan", 1);
+        cell2.put("text", "Normal cell");
+        ArrayNode bbox2 = cell2.putArray("bbox");
+        bbox2.add(300); bbox2.add(100); bbox2.add(500); bbox2.add(200);
+
+        double[] dlaBbox = {100, 100, 500, 300};
+
+        ObjectNode json = objectMapper.createObjectNode();
+        ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+        ArrayNode dlaPages = dlaOcr.addArray();
+        ObjectNode dlaPage = dlaPages.addObject();
+        dlaPage.put("page_number", 0);
+        dlaPage.put("image_height", 3508);
+        dlaPage.putArray("objects");
+
+        ArrayNode tsr = json.putArray("TABLE_STRUCTURE_RECOGNITION");
+        ObjectNode tableEntry = tsr.addObject();
+        tableEntry.put("page_number", 0);
+        ArrayNode dlaBboxArr = tableEntry.putArray("dla_bbox");
+        for (double v : dlaBbox) dlaBboxArr.add(v);
+        ObjectNode tsrObj = tableEntry.putObject("tsr");
+        tsrObj.put("page_number", 0);
+        tsrObj.put("num_cells", 2);
+        ArrayNode tbbox = tsrObj.putArray("table_bbox");
+        tbbox.add(0); tbbox.add(0); tbbox.add(400); tbbox.add(200);
+        ArrayNode cellsArray = tsrObj.putArray("cells");
+        cellsArray.add(cell);
+        cellsArray.add(cell2);
+
+        List<List<IObject>> result = transform(json);
+
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof TableBorder) {
+                table = (TableBorder) obj;
+                break;
+            }
+        }
+        assertThat(table).isNotNull();
+        assertThat(table.getNumberOfRows()).isEqualTo(2);
+        assertThat(table.getNumberOfColumns()).isEqualTo(2);
+
+        TableBorderCell mergedCell = table.getCell(0, 0);
+        assertThat(mergedCell).isNotNull();
+        assertThat(mergedCell.getRowSpan()).isEqualTo(2);
+        assertThat(mergedCell.getColSpan()).isEqualTo(1);
+    }
+
+    @Test
+    void multipleTablesPerPage_allProduced() {
+        // Two tables on the same page
+        ObjectNode json = objectMapper.createObjectNode();
+        ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+        ArrayNode dlaPages = dlaOcr.addArray();
+        ObjectNode dlaPage = dlaPages.addObject();
+        dlaPage.put("page_number", 0);
+        dlaPage.put("image_height", 3508);
+        dlaPage.putArray("objects");
+
+        ArrayNode tsr = json.putArray("TABLE_STRUCTURE_RECOGNITION");
+
+        // Table 1
+        ObjectNode entry1 = tsr.addObject();
+        entry1.put("page_number", 0);
+        entry1.put("object_id", 1);
+        ArrayNode dlaBbox1 = entry1.putArray("dla_bbox");
+        dlaBbox1.add(100); dlaBbox1.add(100); dlaBbox1.add(500); dlaBbox1.add(300);
+        ObjectNode tsr1 = entry1.putObject("tsr");
+        tsr1.put("page_number", 0);
+        tsr1.put("num_cells", 1);
+        ArrayNode tbbox1 = tsr1.putArray("table_bbox");
+        tbbox1.add(0); tbbox1.add(0); tbbox1.add(400); tbbox1.add(200);
+        ArrayNode cells1 = tsr1.putArray("cells");
+        ObjectNode c1 = cells1.addObject();
+        c1.put("cell_id", 0);
+        ArrayNode rs1 = c1.putArray("rowspan"); rs1.add(0);
+        ArrayNode cs1 = c1.putArray("colspan"); cs1.add(0);
+        ArrayNode b1 = c1.putArray("bbox");
+        b1.add(0); b1.add(0); b1.add(400); b1.add(200);
+
+        // Table 2
+        ObjectNode entry2 = tsr.addObject();
+        entry2.put("page_number", 0);
+        entry2.put("object_id", 2);
+        ArrayNode dlaBbox2 = entry2.putArray("dla_bbox");
+        dlaBbox2.add(100); dlaBbox2.add(500); dlaBbox2.add(500); dlaBbox2.add(700);
+        ObjectNode tsr2 = entry2.putObject("tsr");
+        tsr2.put("page_number", 0);
+        tsr2.put("num_cells", 1);
+        ArrayNode tbbox2 = tsr2.putArray("table_bbox");
+        tbbox2.add(0); tbbox2.add(0); tbbox2.add(400); tbbox2.add(200);
+        ArrayNode cells2 = tsr2.putArray("cells");
+        ObjectNode c2 = cells2.addObject();
+        c2.put("cell_id", 0);
+        ArrayNode rs2 = c2.putArray("rowspan"); rs2.add(0);
+        ArrayNode cs2 = c2.putArray("colspan"); cs2.add(0);
+        ArrayNode b2 = c2.putArray("bbox");
+        b2.add(0); b2.add(0); b2.add(400); b2.add(200);
+
+        List<List<IObject>> result = transform(json);
+
+        long tableCount = result.get(0).stream().filter(o -> o instanceof TableBorder).count();
+        assertThat(tableCount).isEqualTo(2);
     }
 
     @Test

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -24,6 +24,9 @@ import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.SemanticHeading;
+import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
+import org.verapdf.wcag.algorithms.entities.lists.ListItem;
+import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 
 import java.util.HashMap;
 import java.util.List;
@@ -310,6 +313,157 @@ public class HancomAISchemaTransformerTest {
         assertThat(tiny.getHeadingLevel()).isEqualTo(4);       // shortest → H4
 
         // No skipping: levels are 2, 3, 4 (no gap)
+    }
+
+    // --- List grouping (label 3) ---
+
+    @Test
+    void consecutiveLabel3_groupedIntoSinglePDFList() {
+        ObjectNode json = createHancomAIJson(
+            createObject(3, "First item", 100, 100, 500, 130),
+            createObject(3, "Second item", 100, 150, 500, 180),
+            createObject(3, "Third item", 100, 200, 500, 230)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        assertThat(result.get(0).get(0)).isInstanceOf(PDFList.class);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getListItems()).hasSize(3);
+        assertThat(list.getListItems().get(0).getFirstLine().getValue()).isEqualTo("First item");
+        assertThat(list.getListItems().get(1).getFirstLine().getValue()).isEqualTo("Second item");
+        assertThat(list.getListItems().get(2).getFirstLine().getValue()).isEqualTo("Third item");
+    }
+
+    @Test
+    void nonLabel3_breaksListIntoSeparateInstances() {
+        ObjectNode json = createHancomAIJson(
+            createObject(3, "Item A", 100, 100, 500, 130),
+            createObject(3, "Item B", 100, 150, 500, 180),
+            createObject(2, "A paragraph", 100, 200, 500, 230),   // label 2 breaks the run
+            createObject(3, "Item C", 100, 250, 500, 280),
+            createObject(3, "Item D", 100, 300, 500, 330)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(3);  // PDFList, paragraph, PDFList
+        assertThat(result.get(0).get(0)).isInstanceOf(PDFList.class);
+        assertThat(result.get(0).get(1)).isInstanceOf(SemanticParagraph.class);
+        assertThat(result.get(0).get(2)).isInstanceOf(PDFList.class);
+
+        PDFList list1 = (PDFList) result.get(0).get(0);
+        PDFList list2 = (PDFList) result.get(0).get(2);
+        assertThat(list1.getListItems()).hasSize(2);
+        assertThat(list2.getListItems()).hasSize(2);
+    }
+
+    @Test
+    void singleLabel3_stillWrappedInPDFList() {
+        ObjectNode json = createHancomAIJson(
+            createObject(3, "Solo item", 100, 100, 500, 130)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        assertThat(result.get(0).get(0)).isInstanceOf(PDFList.class);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getListItems()).hasSize(1);
+    }
+
+    @Test
+    void bulletPrefix_setsLabelLength() {
+        ObjectNode json = createHancomAIJson(
+            createObject(3, "\u2022 Bullet item", 100, 100, 500, 130),  // bullet char + space = 2
+            createObject(3, "1. Numbered item", 100, 150, 500, 180),    // "1. " = 3
+            createObject(3, "a) Letter item", 100, 200, 500, 230)       // "a) " = 3
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getListItems()).hasSize(3);
+        assertThat(list.getListItems().get(0).getLabelLength()).isEqualTo(2);
+        assertThat(list.getListItems().get(1).getLabelLength()).isEqualTo(3);
+        assertThat(list.getListItems().get(2).getLabelLength()).isEqualTo(3);
+    }
+
+    @Test
+    void noBulletPrefix_labelLengthZero() {
+        ObjectNode json = createHancomAIJson(
+            createObject(3, "Plain text item", 100, 100, 500, 130)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getListItems().get(0).getLabelLength()).isEqualTo(0);
+    }
+
+    @Test
+    void dashBulletPrefix_setsLabelLength() {
+        ObjectNode json = createHancomAIJson(
+            createObject(3, "- Dash item", 100, 100, 500, 130),
+            createObject(3, "\u2013 En-dash item", 100, 150, 500, 180),
+            createObject(3, "\u2014 Em-dash item", 100, 200, 500, 230)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getListItems().get(0).getLabelLength()).isEqualTo(2);  // "- "
+        assertThat(list.getListItems().get(1).getLabelLength()).isEqualTo(2);  // "\u2013 "
+        assertThat(list.getListItems().get(2).getLabelLength()).isEqualTo(2);  // "\u2014 "
+    }
+
+    @Test
+    void pdfList_hasBoundingBoxUnion() {
+        ObjectNode json = createHancomAIJson(
+            createObject(3, "Item 1", 100, 100, 500, 130),
+            createObject(3, "Item 2", 80, 150, 520, 180)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getBoundingBox()).isNotNull();
+        // Union bbox should encompass both items
+        // After coordinate conversion: leftX should be min(100, 80)*0.24 = 19.2
+        // rightX should be max(500, 520)*0.24 = 124.8
+        assertThat(list.getBoundingBox().getLeftX()).isLessThanOrEqualTo(
+            list.getListItems().get(0).getBoundingBox().getLeftX());
+        assertThat(list.getBoundingBox().getRightX()).isGreaterThanOrEqualTo(
+            list.getListItems().get(1).getBoundingBox().getRightX());
+    }
+
+    @Test
+    void pdfList_hasRecognizedStructureId() {
+        ObjectNode json = createHancomAIJson(
+            createObject(3, "Item", 100, 100, 500, 130)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getRecognizedStructureId()).isNotNull();
+    }
+
+    @Test
+    void multiDigitNumberBullet_setsLabelLength() {
+        ObjectNode json = createHancomAIJson(
+            createObject(3, "12. Twelfth item", 100, 100, 500, 130),
+            createObject(3, "3) Third item", 100, 150, 500, 180)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getListItems().get(0).getLabelLength()).isEqualTo(4);  // "12. "
+        assertThat(list.getListItems().get(1).getLabelLength()).isEqualTo(3);  // "3) "
     }
 
     // --- Helper methods ---

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -21,8 +21,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
 import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.SemanticCaption;
 import org.verapdf.wcag.algorithms.entities.SemanticHeading;
 import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
 import org.verapdf.wcag.algorithms.entities.lists.ListItem;
@@ -750,6 +752,71 @@ public class HancomAISchemaTransformerTest {
 
         // Words should be sorted: First (higher) then Second (lower)
         assertThat(getCellText(table, 0, 0)).isEqualTo("First Second");
+    }
+
+    // --- Task 5: Caption mapping (label 8 and 11) ---
+
+    @Test
+    void caption_tableName_becomesSemanticCaption() {
+        // label 8 (TableName) → SemanticCaption
+        ObjectNode json = createHancomAIJson(
+            createObject(8, "Table 1: Revenue", 100, 300, 500, 330)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        assertThat(result.get(0).get(0)).isInstanceOf(SemanticCaption.class);
+        SemanticCaption caption = (SemanticCaption) result.get(0).get(0);
+        assertThat(caption.getValue()).isEqualTo("Table 1: Revenue");
+    }
+
+    @Test
+    void caption_figureName_becomesSemanticCaption() {
+        // label 11 (FigureName) → SemanticCaption
+        ObjectNode json = createHancomAIJson(
+            createObject(11, "Figure 3: Architecture", 100, 400, 500, 430)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        assertThat(result.get(0).get(0)).isInstanceOf(SemanticCaption.class);
+        SemanticCaption caption = (SemanticCaption) result.get(0).get(0);
+        assertThat(caption.getValue()).isEqualTo("Figure 3: Architecture");
+    }
+
+    @Test
+    void caption_linkedToNearestFloat() {
+        // label 8 near a table → linkedContentId matches table's recognizedStructureId
+        // Table at pixel [100, 100, 500, 300], caption label 8 at [100, 310, 500, 340]
+        // Also a figure far away at [100, 800, 500, 1000]
+        ObjectNode[] dlaObjects = {
+            createObject(8, "Table 1: Data", 100, 310, 500, 340),
+            createObject(9, "", 100, 800, 500, 1000)
+        };
+
+        ObjectNode tsrCell = createTsrCell(0, 0, 1, 1, "cell", 100, 100, 500, 300);
+        double[] tableBbox = {100, 100, 500, 300};
+        ObjectNode json = createHancomAIJsonWithTable(
+            dlaObjects,
+            tableBbox,
+            new ObjectNode[]{tsrCell}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        // Find caption and table
+        SemanticCaption caption = null;
+        TableBorder table = null;
+        for (IObject obj : result.get(0)) {
+            if (obj instanceof SemanticCaption) caption = (SemanticCaption) obj;
+            if (obj instanceof TableBorder) table = (TableBorder) obj;
+        }
+
+        assertThat(caption).isNotNull();
+        assertThat(table).isNotNull();
+        assertThat(caption.getLinkedContentId()).isEqualTo(table.getRecognizedStructureId());
     }
 
     @Test

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -837,6 +837,82 @@ public class HancomAISchemaTransformerTest {
         assertThat(footnote.getValue()).isEqualTo("1. See reference [3].");
     }
 
+    // --- Task 7: Regionlist (label 7) → Table/List ---
+
+    @Test
+    void regionlist_withTsrOverlap_returnsNull() {
+        // label 7 with overlapping TSR → null (table handled separately by transformTablePage)
+        // DLA object at [100, 100, 500, 300] (label 7), TSR table covers same area
+        ObjectNode regionObj = createObject(7, "Table data here", 100, 100, 500, 300);
+
+        ObjectNode tsrCell = createTsrCell(0, 0, 1, 1, "cell", 100, 100, 500, 300);
+        double[] tableBbox = {100, 100, 500, 300};
+        ObjectNode json = createHancomAIJsonWithTable(
+            new ObjectNode[]{regionObj},
+            tableBbox,
+            new ObjectNode[]{tsrCell}
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        // label 7 region should be skipped (null), only the TSR table should appear
+        for (IObject obj : result.get(0)) {
+            // No PDFList or SemanticParagraph from label 7 — only the TableBorder from TSR
+            assertThat(obj).isNotInstanceOf(PDFList.class);
+            assertThat(obj).isNotInstanceOf(SemanticParagraph.class);
+        }
+        // TSR table should still be present
+        assertThat(result.get(0).stream().anyMatch(o -> o instanceof TableBorder)).isTrue();
+    }
+
+    @Test
+    void regionlist_withoutTsr_becomesList() {
+        // label 7 without any TSR data → PDFList from newline-split text
+        ObjectNode json = createHancomAIJson(
+            createObject(7, "First line\nSecond line\nThird line", 100, 100, 500, 200)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        assertThat(result.get(0).get(0)).isInstanceOf(PDFList.class);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getListItems()).hasSize(3);
+        assertThat(list.getListItems().get(0).getFirstLine().getValue()).isEqualTo("First line");
+        assertThat(list.getListItems().get(1).getFirstLine().getValue()).isEqualTo("Second line");
+        assertThat(list.getListItems().get(2).getFirstLine().getValue()).isEqualTo("Third line");
+    }
+
+    @Test
+    void regionlist_withoutTsr_singleLine_becomesSingleItemList() {
+        // label 7 with single line text → PDFList with one item
+        ObjectNode json = createHancomAIJson(
+            createObject(7, "Solo table text", 100, 100, 500, 130)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        assertThat(result.get(0).get(0)).isInstanceOf(PDFList.class);
+
+        PDFList list = (PDFList) result.get(0).get(0);
+        assertThat(list.getListItems()).hasSize(1);
+        assertThat(list.getListItems().get(0).getFirstLine().getValue()).isEqualTo("Solo table text");
+    }
+
+    @Test
+    void regionlist_withoutTsr_emptyText_returnsNull() {
+        // label 7 with empty text → null
+        ObjectNode json = createHancomAIJson(
+            createObject(7, "", 100, 100, 500, 200)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).isEmpty();
+    }
+
     @Test
     void tableCellText_pageHeaderFooterWords_excluded() {
         // Words with label 14 (page header), 15 (page footer), 17 (page number) should not

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -813,7 +813,7 @@ public class HancomAISchemaTransformerTest {
         // Also a figure far away at [100, 800, 500, 1000]
         ObjectNode[] dlaObjects = {
             createObject(8, "Table 1: Data", 100, 310, 500, 340),
-            createObject(9, "", 100, 800, 500, 1000)
+            createObject(10, "", 100, 800, 500, 1000)
         };
 
         ObjectNode tsrCell = createTsrCell(0, 0, 1, 1, "cell", 100, 100, 500, 300);
@@ -992,6 +992,35 @@ public class HancomAISchemaTransformerTest {
         // Default strategy should be table-first
         HancomAISchemaTransformer freshTransformer = new HancomAISchemaTransformer();
         assertThat(freshTransformer.getRegionlistStrategy()).isEqualTo(HybridConfig.REGIONLIST_TABLE_FIRST);
+    }
+
+    // --- Label 9 (Table) handled by TSR, returns null from transformObject ---
+
+    @Test
+    void label9_table_returnsNull() {
+        // label 9 = Table → handled by transformTablePage(), transformObject returns null
+        ObjectNode json = createHancomAIJson(
+            createObject(9, "Some table text", 100, 100, 500, 300)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).isEmpty();
+    }
+
+    // --- Label 10 (Figure) creates SemanticPicture ---
+
+    @Test
+    void label10_figure_createsPicture() {
+        // label 10 = Figure → SemanticPicture
+        ObjectNode json = createHancomAIJson(
+            createObject(10, "", 100, 100, 500, 400)
+        );
+
+        List<List<IObject>> result = transform(json);
+
+        assertThat(result.get(0)).hasSize(1);
+        assertThat(result.get(0).get(0)).isInstanceOf(SemanticPicture.class);
     }
 
     // --- Task 8: confidence → correctSemanticScore ---

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/MemoryPageImageCacheTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/MemoryPageImageCacheTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemoryPageImageCacheTest {
+
+    private static BufferedImage createTestImage() {
+        return new BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB);
+    }
+
+    @Test
+    void getOrFetch_storesAndReturns() throws IOException {
+        try (MemoryPageImageCache cache = new MemoryPageImageCache()) {
+            AtomicInteger fetchCount = new AtomicInteger(0);
+            BufferedImage img = cache.getOrFetch(0, idx -> {
+                fetchCount.incrementAndGet();
+                return createTestImage();
+            });
+
+            assertNotNull(img);
+            assertEquals(1, fetchCount.get());
+
+            // Second call should use cached value, not call fetcher
+            BufferedImage img2 = cache.getOrFetch(0, idx -> {
+                fetchCount.incrementAndGet();
+                return createTestImage();
+            });
+
+            assertNotNull(img2);
+            assertSame(img, img2, "Should return same cached instance");
+            assertEquals(1, fetchCount.get(), "Fetcher should not be called again");
+        }
+    }
+
+    @Test
+    void evict_removesEntry() throws IOException {
+        try (MemoryPageImageCache cache = new MemoryPageImageCache()) {
+            AtomicInteger fetchCount = new AtomicInteger(0);
+
+            cache.getOrFetch(0, idx -> {
+                fetchCount.incrementAndGet();
+                return createTestImage();
+            });
+            assertEquals(1, fetchCount.get());
+
+            cache.evict(0);
+
+            // After eviction, fetcher should be called again
+            cache.getOrFetch(0, idx -> {
+                fetchCount.incrementAndGet();
+                return createTestImage();
+            });
+            assertEquals(2, fetchCount.get(), "Fetcher should be called again after eviction");
+        }
+    }
+
+    @Test
+    void evict_nonExistentPage_noError() throws IOException {
+        try (MemoryPageImageCache cache = new MemoryPageImageCache()) {
+            assertDoesNotThrow(() -> cache.evict(99));
+        }
+    }
+
+    @Test
+    void close_clearsAllEntries() throws IOException {
+        MemoryPageImageCache cache = new MemoryPageImageCache();
+        AtomicInteger fetchCount = new AtomicInteger(0);
+
+        cache.getOrFetch(0, idx -> { fetchCount.incrementAndGet(); return createTestImage(); });
+        cache.getOrFetch(1, idx -> { fetchCount.incrementAndGet(); return createTestImage(); });
+        assertEquals(2, fetchCount.get());
+
+        cache.close();
+
+        // After close, fetcher should be called again for both pages
+        cache.getOrFetch(0, idx -> { fetchCount.incrementAndGet(); return createTestImage(); });
+        cache.getOrFetch(1, idx -> { fetchCount.incrementAndGet(); return createTestImage(); });
+        assertEquals(4, fetchCount.get(), "Fetcher should be called again after close");
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/OcrStrategyTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/OcrStrategyTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
+import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for OCR strategy option (HybridConfig) and OCR word data exposure
+ * (HancomAISchemaTransformer.getOcrWordsByPage).
+ */
+public class OcrStrategyTest {
+
+    @Nested
+    class HybridConfigOcrStrategy {
+
+        @Test
+        void defaultOcrStrategy_isOff() {
+            HybridConfig config = new HybridConfig();
+            assertThat(config.getOcrStrategy()).isEqualTo(HybridConfig.OCR_OFF);
+        }
+
+        @Test
+        void setOcrStrategy_auto() {
+            HybridConfig config = new HybridConfig();
+            config.setOcrStrategy(HybridConfig.OCR_AUTO);
+            assertThat(config.getOcrStrategy()).isEqualTo("auto");
+            assertThat(config.isOcrAuto()).isTrue();
+            assertThat(config.isOcrForce()).isFalse();
+        }
+
+        @Test
+        void setOcrStrategy_force() {
+            HybridConfig config = new HybridConfig();
+            config.setOcrStrategy(HybridConfig.OCR_FORCE);
+            assertThat(config.getOcrStrategy()).isEqualTo("force");
+            assertThat(config.isOcrForce()).isTrue();
+            assertThat(config.isOcrAuto()).isFalse();
+        }
+
+        @Test
+        void setOcrStrategy_off() {
+            HybridConfig config = new HybridConfig();
+            config.setOcrStrategy(HybridConfig.OCR_AUTO);
+            config.setOcrStrategy(HybridConfig.OCR_OFF);
+            assertThat(config.getOcrStrategy()).isEqualTo("off");
+            assertThat(config.isOcrAuto()).isFalse();
+            assertThat(config.isOcrForce()).isFalse();
+        }
+
+        @Test
+        void constants_haveExpectedValues() {
+            assertThat(HybridConfig.OCR_OFF).isEqualTo("off");
+            assertThat(HybridConfig.OCR_AUTO).isEqualTo("auto");
+            assertThat(HybridConfig.OCR_FORCE).isEqualTo("force");
+        }
+    }
+
+    @Nested
+    class TransformerOcrWordsByPage {
+
+        private HancomAISchemaTransformer transformer;
+        private ObjectMapper objectMapper;
+
+        @BeforeEach
+        void setUp() {
+            transformer = new HancomAISchemaTransformer();
+            objectMapper = new ObjectMapper();
+            StaticLayoutContainers.setCurrentContentId(1L);
+        }
+
+        @Test
+        void ocrWordsByPage_populatedAfterTransform() {
+            // Create a page with two DLA+OCR paragraph objects
+            ObjectNode json = objectMapper.createObjectNode();
+            ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+            ArrayNode pages = dlaOcr.addArray();
+            ObjectNode page = pages.addObject();
+            page.put("page_number", 0);
+            page.put("image_height", 3508);
+            ArrayNode objects = page.putArray("objects");
+
+            // Paragraph object with words array
+            ObjectNode obj = objects.addObject();
+            obj.put("label", 2);
+            obj.put("ocrtext", "Hello World");
+            ArrayNode bbox = obj.putArray("bbox");
+            bbox.add(100); bbox.add(100); bbox.add(500); bbox.add(130);
+            ArrayNode words = obj.putArray("words");
+            ObjectNode w1 = words.addObject();
+            w1.put("text", "Hello");
+            ArrayNode wb1 = w1.putArray("bbox");
+            wb1.add(100); wb1.add(100); wb1.add(200); wb1.add(130);
+            ObjectNode w2 = words.addObject();
+            w2.put("text", "World");
+            ArrayNode wb2 = w2.putArray("bbox");
+            wb2.add(250); wb2.add(100); wb2.add(500); wb2.add(130);
+
+            Map<Integer, Double> pageHeights = new HashMap<>();
+            pageHeights.put(1, 842.0);
+
+            HybridResponse response = new HybridResponse("", json, Collections.emptyMap());
+            transformer.transform(response, pageHeights);
+
+            Map<Integer, List<OcrWordInfo>> ocrWords = transformer.getOcrWordsByPage();
+            assertThat(ocrWords).isNotNull();
+            assertThat(ocrWords).containsKey(0);
+            assertThat(ocrWords.get(0)).hasSize(2);
+            assertThat(ocrWords.get(0).get(0).getText()).isEqualTo("Hello");
+            assertThat(ocrWords.get(0).get(1).getText()).isEqualTo("World");
+        }
+
+        @Test
+        void ocrWordsByPage_fallbackToObjectLevel_whenNoWordsArray() {
+            // Object without words array → falls back to object-level ocrtext + bbox
+            ObjectNode json = objectMapper.createObjectNode();
+            ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+            ArrayNode pages = dlaOcr.addArray();
+            ObjectNode page = pages.addObject();
+            page.put("page_number", 0);
+            page.put("image_height", 3508);
+            ArrayNode objects = page.putArray("objects");
+
+            ObjectNode obj = objects.addObject();
+            obj.put("label", 2);
+            obj.put("ocrtext", "Whole paragraph");
+            ArrayNode bbox = obj.putArray("bbox");
+            bbox.add(100); bbox.add(100); bbox.add(500); bbox.add(130);
+
+            Map<Integer, Double> pageHeights = new HashMap<>();
+            pageHeights.put(1, 842.0);
+
+            HybridResponse response = new HybridResponse("", json, Collections.emptyMap());
+            transformer.transform(response, pageHeights);
+
+            Map<Integer, List<OcrWordInfo>> ocrWords = transformer.getOcrWordsByPage();
+            assertThat(ocrWords).containsKey(0);
+            assertThat(ocrWords.get(0)).hasSize(1);
+            assertThat(ocrWords.get(0).get(0).getText()).isEqualTo("Whole paragraph");
+        }
+
+        @Test
+        void ocrWordsByPage_excludesFurnitureLabels() {
+            // Labels 14, 15, 17 should be excluded from OCR words
+            ObjectNode json = objectMapper.createObjectNode();
+            ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+            ArrayNode pages = dlaOcr.addArray();
+            ObjectNode page = pages.addObject();
+            page.put("page_number", 0);
+            page.put("image_height", 3508);
+            ArrayNode objects = page.putArray("objects");
+
+            // Header (label 14) - should be excluded
+            ObjectNode header = objects.addObject();
+            header.put("label", 14);
+            header.put("ocrtext", "Page Header");
+            ArrayNode hbbox = header.putArray("bbox");
+            hbbox.add(100); hbbox.add(10); hbbox.add(500); hbbox.add(30);
+
+            // Actual content (label 2) - should be included
+            ObjectNode content = objects.addObject();
+            content.put("label", 2);
+            content.put("ocrtext", "Content");
+            ArrayNode cbbox = content.putArray("bbox");
+            cbbox.add(100); cbbox.add(100); cbbox.add(500); cbbox.add(130);
+
+            Map<Integer, Double> pageHeights = new HashMap<>();
+            pageHeights.put(1, 842.0);
+
+            HybridResponse response = new HybridResponse("", json, Collections.emptyMap());
+            transformer.transform(response, pageHeights);
+
+            Map<Integer, List<OcrWordInfo>> ocrWords = transformer.getOcrWordsByPage();
+            assertThat(ocrWords.get(0)).hasSize(1);
+            assertThat(ocrWords.get(0).get(0).getText()).isEqualTo("Content");
+        }
+
+        @Test
+        void ocrWordsByPage_clearedBetweenTransformCalls() {
+            // First transform
+            ObjectNode json1 = createSimpleJson("First");
+            HybridResponse response1 = new HybridResponse("", json1, Collections.emptyMap());
+            Map<Integer, Double> pageHeights = new HashMap<>();
+            pageHeights.put(1, 842.0);
+            transformer.transform(response1, pageHeights);
+            assertThat(transformer.getOcrWordsByPage().get(0)).hasSize(1);
+
+            // Second transform should replace previous data
+            ObjectNode json2 = createSimpleJson("Second");
+            HybridResponse response2 = new HybridResponse("", json2, Collections.emptyMap());
+            transformer.transform(response2, pageHeights);
+            assertThat(transformer.getOcrWordsByPage().get(0)).hasSize(1);
+            assertThat(transformer.getOcrWordsByPage().get(0).get(0).getText()).isEqualTo("Second");
+        }
+
+        @Test
+        void ocrWordsByPage_wordInfoHasBbox() {
+            ObjectNode json = objectMapper.createObjectNode();
+            ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+            ArrayNode pages = dlaOcr.addArray();
+            ObjectNode page = pages.addObject();
+            page.put("page_number", 0);
+            page.put("image_height", 3508);
+            ArrayNode objects = page.putArray("objects");
+
+            ObjectNode obj = objects.addObject();
+            obj.put("label", 2);
+            obj.put("ocrtext", "Test");
+            ArrayNode bbox = obj.putArray("bbox");
+            bbox.add(100); bbox.add(200); bbox.add(300); bbox.add(250);
+
+            Map<Integer, Double> pageHeights = new HashMap<>();
+            pageHeights.put(1, 842.0);
+
+            HybridResponse response = new HybridResponse("", json, Collections.emptyMap());
+            transformer.transform(response, pageHeights);
+
+            OcrWordInfo word = transformer.getOcrWordsByPage().get(0).get(0);
+            assertThat(word.getBbox()).isNotNull();
+            // Verify bbox was converted from pixel to PDF points
+            // left = 100 * 72/300 = 24.0, right = 300 * 72/300 = 72.0
+            assertThat(word.getBbox().getLeftX()).isCloseTo(24.0, org.assertj.core.api.Assertions.within(0.01));
+            assertThat(word.getBbox().getRightX()).isCloseTo(72.0, org.assertj.core.api.Assertions.within(0.01));
+        }
+
+        private ObjectNode createSimpleJson(String text) {
+            ObjectNode json = objectMapper.createObjectNode();
+            ArrayNode dlaOcr = json.putArray("DOCUMENT_LAYOUT_WITH_OCR");
+            ArrayNode pages = dlaOcr.addArray();
+            ObjectNode page = pages.addObject();
+            page.put("page_number", 0);
+            page.put("image_height", 3508);
+            ArrayNode objects = page.putArray("objects");
+            ObjectNode obj = objects.addObject();
+            obj.put("label", 2);
+            obj.put("ocrtext", text);
+            ArrayNode bbox = obj.putArray("bbox");
+            bbox.add(100); bbox.add(100); bbox.add(500); bbox.add(130);
+            return json;
+        }
+    }
+
+    @Nested
+    class HybridSchemaTransformerDefault {
+
+        @Test
+        void defaultGetOcrWordsByPage_returnsEmptyMap() {
+            // The interface default should return empty map
+            HybridSchemaTransformer transformer = new HybridSchemaTransformer() {
+                @Override
+                public List<List<IObject>> transform(HybridResponse response, Map<Integer, Double> pageHeights) {
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public List<IObject> transformPage(int pageNumber, com.fasterxml.jackson.databind.JsonNode pageContent, double pageHeight) {
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public String getBackendType() {
+                    return "test";
+                }
+            };
+
+            assertThat(transformer.getOcrWordsByPage()).isEmpty();
+        }
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/OcrStrategyTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/OcrStrategyTest.java
@@ -44,9 +44,9 @@ public class OcrStrategyTest {
     class HybridConfigOcrStrategy {
 
         @Test
-        void defaultOcrStrategy_isOff() {
+        void defaultOcrStrategy_isAuto() {
             HybridConfig config = new HybridConfig();
-            assertThat(config.getOcrStrategy()).isEqualTo(HybridConfig.OCR_OFF);
+            assertThat(config.getOcrStrategy()).isEqualTo(HybridConfig.OCR_AUTO);
         }
 
         @Test

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/OcrStrategyTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/OcrStrategyTest.java
@@ -98,6 +98,12 @@ public class OcrStrategyTest {
             StaticLayoutContainers.setCurrentContentId(1L);
         }
 
+        @org.junit.jupiter.api.AfterEach
+        void tearDown() {
+            // Reset shared static state so later tests don't inherit our content IDs.
+            StaticLayoutContainers.setCurrentContentId(1L);
+        }
+
         @Test
         void ocrWordsByPage_populatedAfterTransform() {
             // Create a page with two DLA+OCR paragraph objects

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/TextSimilarityTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/TextSimilarityTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TextSimilarityTest {
+
+    @Test
+    void identical_strings_return_1() {
+        assertEquals(1.0, TextSimilarity.similarity("hello", "hello"));
+    }
+
+    @Test
+    void completely_different_return_low() {
+        assertTrue(TextSimilarity.similarity("abc", "xyz") < 0.5);
+    }
+
+    @Test
+    void corrupted_unicode_detected() {
+        assertFalse(TextSimilarity.trustStream(",QWURGXFWLRQ", "Introduction", 0.5));
+    }
+
+    @Test
+    void similar_strings_trust_stream() {
+        assertTrue(TextSimilarity.trustStream("Introduction to Biology", "Introduction to Biology", 0.5));
+    }
+
+    @Test
+    void minor_ocr_error_still_trusts_stream() {
+        assertTrue(TextSimilarity.trustStream("Introduction", "Introductlon", 0.5));
+    }
+
+    @Test
+    void null_stream_returns_false() {
+        assertFalse(TextSimilarity.trustStream(null, "text", 0.5));
+    }
+
+    @Test
+    void null_ocr_returns_true() {
+        assertTrue(TextSimilarity.trustStream("text", null, 0.5));
+    }
+
+    @Test
+    void empty_stream_returns_false() {
+        assertFalse(TextSimilarity.trustStream("", "text", 0.5));
+    }
+
+    @Test
+    void both_null_returns_zero_similarity() {
+        assertEquals(0.0, TextSimilarity.similarity(null, null));
+    }
+
+    @Test
+    void both_empty_strings_are_identical() {
+        assertEquals(1.0, TextSimilarity.similarity("", ""));
+    }
+
+    @Test
+    void one_empty_one_nonempty_returns_zero() {
+        assertEquals(0.0, TextSimilarity.similarity("", "hello"));
+        assertEquals(0.0, TextSimilarity.similarity("hello", ""));
+    }
+
+    @Test
+    void default_threshold_is_0_5() {
+        assertEquals(0.5, TextSimilarity.DEFAULT_THRESHOLD);
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/json/serializers/ElementMetadataSerializerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/json/serializers/ElementMetadataSerializerTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.json.serializers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opendataloader.pdf.hybrid.ElementMetadata;
+import org.verapdf.wcag.algorithms.entities.SemanticHeading;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ElementMetadataSerializerTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(SemanticHeading.class, new HeadingSerializer(SemanticHeading.class));
+        module.addSerializer(Double.class, new DoubleSerializer(Double.class));
+        objectMapper.registerModule(module);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SerializerUtil.clearElementMetadata();
+    }
+
+    private SemanticHeading createHeading(long id) {
+        SemanticHeading heading = new SemanticHeading();
+        heading.setBoundingBox(new BoundingBox(0, 0, 0, 100, 100));
+        heading.setRecognizedStructureId(id);
+        heading.setHeadingLevel(2);
+        return heading;
+    }
+
+    @Test
+    void testMetadataWrittenWhenPresent() throws JsonProcessingException {
+        long id = 42L;
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        metadata.put(id, new ElementMetadata()
+                .setConfidence(0.85)
+                .setSourceLabel(3));
+        SerializerUtil.setElementMetadata(metadata);
+
+        SemanticHeading heading = createHeading(id);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertTrue(json.contains("\"confidence\":0.85"), "Should contain confidence field");
+        assertTrue(json.contains("\"source label\":3"), "Should contain source label field");
+    }
+
+    @Test
+    void testNoMetadataFieldsWhenMapEmpty() throws JsonProcessingException {
+        // No metadata set — backward compat
+        SemanticHeading heading = createHeading(42L);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertFalse(json.contains("\"confidence\""), "Should not contain confidence without metadata");
+        assertFalse(json.contains("\"source label\""), "Should not contain source label without metadata");
+    }
+
+    @Test
+    void testConfidenceOmittedWhenDefault() throws JsonProcessingException {
+        long id = 10L;
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        metadata.put(id, new ElementMetadata()
+                .setConfidence(1.0)
+                .setSourceLabel(5));
+        SerializerUtil.setElementMetadata(metadata);
+
+        SemanticHeading heading = createHeading(id);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertFalse(json.contains("\"confidence\""), "confidence=1.0 should be omitted");
+        assertTrue(json.contains("\"source label\":5"), "source label should still appear");
+    }
+
+    @Test
+    void testSourceLabelOmittedWhenNegative() throws JsonProcessingException {
+        long id = 11L;
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        metadata.put(id, new ElementMetadata()
+                .setConfidence(0.5)
+                .setSourceLabel(-1));
+        SerializerUtil.setElementMetadata(metadata);
+
+        SemanticHeading heading = createHeading(id);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertTrue(json.contains("\"confidence\":0.5"));
+        assertFalse(json.contains("\"source label\""), "sourceLabel=-1 should be omitted");
+    }
+
+    @Test
+    void testHeadingInferenceMetadata() throws JsonProcessingException {
+        long id = 20L;
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        metadata.put(id, new ElementMetadata()
+                .setHeadingInferenceMethod("bbox-height")
+                .setBboxHeightPx(24.5));
+        SerializerUtil.setElementMetadata(metadata);
+
+        SemanticHeading heading = createHeading(id);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertTrue(json.contains("\"heading inference\""), "Should contain heading inference block");
+        assertTrue(json.contains("\"method\":\"bbox-height\""));
+        assertTrue(json.contains("\"bbox height px\":24.5"));
+    }
+
+    @Test
+    void testTsrMetadata() throws JsonProcessingException {
+        long id = 30L;
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        ElementMetadata.TsrMetadata tsr = new ElementMetadata.TsrMetadata()
+                .setNumCells(12)
+                .setHtml("<table><tr><td>a</td></tr></table>")
+                .setRunTimeMs(150);
+        metadata.put(id, new ElementMetadata().setTsr(tsr));
+        SerializerUtil.setElementMetadata(metadata);
+
+        SemanticHeading heading = createHeading(id);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertTrue(json.contains("\"tsr\""));
+        assertTrue(json.contains("\"num cells\":12"));
+        assertTrue(json.contains("\"html\""));
+        assertTrue(json.contains("\"run time ms\":150"));
+    }
+
+    @Test
+    void testCaptionMetadata() throws JsonProcessingException {
+        long id = 40L;
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        ElementMetadata.CaptionMetadata caption = new ElementMetadata.CaptionMetadata()
+                .setText("Figure 1: Example")
+                .setLanguage("en")
+                .setRunTimeMs(200);
+        metadata.put(id, new ElementMetadata().setCaption(caption));
+        SerializerUtil.setElementMetadata(metadata);
+
+        SemanticHeading heading = createHeading(id);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertTrue(json.contains("\"caption\""));
+        assertTrue(json.contains("\"text\":\"Figure 1: Example\""));
+        assertTrue(json.contains("\"language\":\"en\""));
+        assertTrue(json.contains("\"run time ms\":200"));
+    }
+
+    @Test
+    void testRegionlistResolutionMetadata() throws JsonProcessingException {
+        long id = 50L;
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        ElementMetadata.RegionlistResolution rl = new ElementMetadata.RegionlistResolution()
+                .setStrategy("table-first")
+                .setTsrAttempted(true)
+                .setTsrResult("success");
+        metadata.put(id, new ElementMetadata().setRegionlistResolution(rl));
+        SerializerUtil.setElementMetadata(metadata);
+
+        SemanticHeading heading = createHeading(id);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertTrue(json.contains("\"regionlist resolution\""));
+        assertTrue(json.contains("\"strategy\":\"table-first\""));
+        assertTrue(json.contains("\"tsr attempted\":true"));
+        assertTrue(json.contains("\"tsr result\":\"success\""));
+    }
+
+    @Test
+    void testWordMatchMetadata() throws JsonProcessingException {
+        long id = 60L;
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        metadata.put(id, new ElementMetadata()
+                .setWordMatchMethod("bbox-intersection")
+                .setMatchedWordCount(15));
+        SerializerUtil.setElementMetadata(metadata);
+
+        SemanticHeading heading = createHeading(id);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertTrue(json.contains("\"word match\""));
+        assertTrue(json.contains("\"method\":\"bbox-intersection\""));
+        assertTrue(json.contains("\"matched words\":15"));
+    }
+
+    @Test
+    void testNoMetadataForUnknownId() throws JsonProcessingException {
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        metadata.put(99L, new ElementMetadata().setConfidence(0.5));
+        SerializerUtil.setElementMetadata(metadata);
+
+        SemanticHeading heading = createHeading(1L); // different ID
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertFalse(json.contains("\"confidence\""), "Should not write metadata for unmatched ID");
+    }
+
+    @Test
+    void testClearElementMetadataRemovesState() throws JsonProcessingException {
+        long id = 42L;
+        Map<Long, ElementMetadata> metadata = new HashMap<>();
+        metadata.put(id, new ElementMetadata().setConfidence(0.5));
+        SerializerUtil.setElementMetadata(metadata);
+        SerializerUtil.clearElementMetadata();
+
+        SemanticHeading heading = createHeading(id);
+        String json = objectMapper.writeValueAsString(heading);
+
+        assertFalse(json.contains("\"confidence\""), "After clear, metadata should not be written");
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
@@ -18,9 +18,11 @@ package org.opendataloader.pdf.processors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.hybrid.HancomAISchemaTransformer;
 import org.opendataloader.pdf.hybrid.HybridClient.HybridRequest;
 import org.opendataloader.pdf.hybrid.HybridClient.OutputFormat;
 import org.opendataloader.pdf.hybrid.HybridConfig;
+import org.opendataloader.pdf.hybrid.HybridSchemaTransformer;
 import org.opendataloader.pdf.hybrid.TriageProcessor.TriageDecision;
 import org.opendataloader.pdf.hybrid.TriageProcessor.TriageResult;
 import org.opendataloader.pdf.hybrid.TriageProcessor.TriageSignals;
@@ -350,6 +352,29 @@ public class HybridDocumentProcessorTest {
         // docling uses same URL as docling-fast
         Assertions.assertEquals(HybridConfig.DOCLING_FAST_DEFAULT_URL, config.getEffectiveUrl("docling"));
         Assertions.assertEquals(HybridConfig.DOCLING_FAST_DEFAULT_URL, config.getEffectiveUrl("docling-fast"));
+    }
+
+    @Test
+    public void testHancomAIBackendEnabled() {
+        Config config = new Config();
+        config.setHybrid("hancom-ai");
+
+        Assertions.assertTrue(config.isHybridEnabled());
+        Assertions.assertEquals("hancom-ai", config.getHybrid());
+    }
+
+    @Test
+    public void testCreateTransformerReturnsHancomAISchemaTransformer() throws Exception {
+        Config config = new Config();
+        config.setHybrid("hancom-ai");
+
+        // createTransformer is private static — use reflection to verify it returns the correct type
+        java.lang.reflect.Method method = HybridDocumentProcessor.class.getDeclaredMethod("createTransformer", Config.class);
+        method.setAccessible(true);
+        HybridSchemaTransformer transformer = (HybridSchemaTransformer) method.invoke(null, config);
+
+        Assertions.assertNotNull(transformer);
+        Assertions.assertInstanceOf(HancomAISchemaTransformer.class, transformer);
     }
 
     // ===== Backend Chunk Splitting Tests =====


### PR DESCRIPTION
## Objective
Two user-visible problems on the helium branch:

1. **Hybrid AI backend is docling-only.** Users who have the Hancom AI HOCR SDK cannot use it — the pipeline has no hancom-ai backend wiring, no DLA/TSR/OCR routing, and no way to pass picture-captioning or page images to the model.
2. **PDF/UA-2 remediation pass rate is low.** When users run `--conformance ua2,wtpdf-accessibility` on a 200-PDF benchmark, 90 out of 200 documents fail veraPDF. Failures cluster on rules the remediator is expected to handle (list numbering, link destinations, annotation Contents, namespace declarations).

## Approach
**Hancom AI backend.** Add `hancom-ai` as a first-class hybrid backend alongside `docling-fast`. The transformer maps the Hancom AI DLA label set to OpenDataLoader semantic types (Table, List, FootNote, Caption, headings H2-H6), intersects TSR cell content with DLA+OCR word bboxes for real table-cell text, and attaches `ElementMetadata` sidecars that carry per-element provenance (text source: stream/ocr/ocr-fallback, DLA confidence, region resolution) through to the JSON output. OCR has an `auto` mode that compares stream-extracted vs OCR text with a similarity threshold to decide which to trust per region. A `PageImageCache` (memory or disk) avoids re-rendering pages for crop-based TSR.

**PDF/UA-2 remediation.** Fix the remediator's emitted structure so it satisfies veraPDF's ISO 14289-2 rules, targeting the clauses that fail in the benchmark:
- `8.2.5.25.1` — fall back to `/Ordered` ListNumbering when a list has Lbl but no explicit numbering type.
- `8.8.1` / `8.8.2` — convert Link-annotation named destinations to structure destinations.
- `8.9.4.2.1` — keep Link annotation `Contents` and its struct `Alt` identical (write `/Alt` as UTF-16 hex for non-ASCII), strip Private Use Area code points from Figure `/Alt`.
- `8.2.4.1` — attach the PDF 2.0 namespace to FENote struct elements.
- Table structure — wrap rows in THead/TBody, fill span-covered cells to suppress empty placeholders for Acrobat compatibility.

**Why this shape.** Hancom AI is a drop-in alternative backend, so it plugs into the existing HybridDocumentProcessor registry rather than forking the pipeline. The pdfua2 fixes are individually small, each clause-scoped, so regressions are isolated. ElementMetadata is a sidecar (not a field on IObject) to avoid touching the core entity schema.

## Evidence
Ran the 200-PDF benchmark (`opendataloader-pdfua/scripts/mock_server/pdfs`, downstream consumer of this branch) with and without the pdfua2 fixes, and verified Hancom AI backend end-to-end against the Hancom AI mock server.

### PDF/UA-2 + WTPDF Accessibility conformance (200 PDFs)

| Scenario | Expected | Actual |
|----------|----------|--------|
| Before pdfua2 fixes | — | **110 pass / 90 fail** |
| After pdfua2 fixes (this branch) | large pass-rate lift | **199 pass / 1 fail** |
| Remaining failure | one clause left for follow-up | `8.4.5.5.1.1` (font program embedding, 1 doc) |

Per-rule reduction on the failing 90 documents:
| veraPDF rule | Before | After |
|--------------|--------|-------|
| `8.2.5.25.1` (List ListNumbering) | 33 docs | 0 |
| `8.8.1` (structure destinations) | 27 docs | 0 |
| `8.9.4.2.1` (annotation Contents ↔ Alt) | 24 docs | 0 |
| `8.2.4.1` (struct namespace) | 16 docs | 0 |
| `8.8.2` (structure destinations) | 12 docs | 0 |

### Hancom AI hybrid backend

| Scenario | Expected | Actual |
|----------|----------|--------|
| `--hybrid hancom-ai --hybrid-url http://localhost:18008` | pipeline reaches mock server, returns per-element metadata | 200/200 documents processed, `hybridTimings.DOCUMENT_LAYOUT_WITH_OCR` populated per document |
| JSON output | `_metadata.hybrid` block + per-element text-source annotations | `_metadata.hybrid.mode=live`, `text_source` in {`stream`, `ocr`, `ocr-fallback`} per element |
| Crop-based TSR | table cells carry real content (not empty placeholders) | Cells populated from DLA+OCR word-bbox intersection; Adobe Acrobat renders table without empty cell artifacts |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Hancom AI hybrid backend with OCR/layout enrichment, TSR, image captioning, async convert, and optional disk- or memory-backed page-image caching.

* **Enhancements**
  * Outputs now include per-element hybrid metadata (confidence, source, TSR/caption/regionlist, text-source/similarity), improved heading/footnote handling, stricter image alt-text sanitization, table/list handling refinements, and configurable OCR/regionlist/image-cache options.

* **Documentation**
  * Added a local Hancom AI mock-server implementation plan and smoke-test procedure.

* **Tests**
  * Extensive unit/integration tests for transformer behavior, caches, metadata serialization, request-ID formats, and OCR strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->