### PR TITLE
feat(cli): make per-page parallelism opt-in via --threads (default 1)

### DIFF
--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
@@ -140,6 +140,13 @@ public class CLIOptions {
     private static final String TO_STDOUT_LONG_OPTION = "to-stdout";
     private static final String TO_STDOUT_DESC = "Write output to stdout instead of file (single format only)";
 
+    // ===== Threads =====
+    private static final String THREADS_LONG_OPTION = "threads";
+    private static final String THREADS_DESC = "Number of worker threads for per-page processing. "
+            + "Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; "
+            + "output may vary slightly on some PDFs. Capped at the number of available CPU cores. "
+            + "Applies to the native Java pipeline only; ignored in --hybrid mode";
+
     // ===== Export Options (internal) =====
     public static final String EXPORT_OPTIONS_LONG_OPTION = "export-options";
 
@@ -188,6 +195,7 @@ public class CLIOptions {
             new OptionDefinition(HYBRID_TIMEOUT_LONG_OPTION, null, "string", "0", HYBRID_TIMEOUT_DESC, true),
             new OptionDefinition(HYBRID_FALLBACK_LONG_OPTION, null, "boolean", false, HYBRID_FALLBACK_DESC, true),
             new OptionDefinition(TO_STDOUT_LONG_OPTION, null, "boolean", false, TO_STDOUT_DESC, true),
+            new OptionDefinition(THREADS_LONG_OPTION, null, "string", "1", THREADS_DESC, true),
             new OptionDefinition(EXPORT_OPTIONS_LONG_OPTION, null, "boolean", null, null, false),
 
             // Legacy options (not exported, for backward compatibility)
@@ -273,7 +281,34 @@ public class CLIOptions {
         applyImageOptions(config, commandLine);
         applyPagesOption(config, commandLine);
         applyHybridOptions(config, commandLine);
+        applyThreadsOption(config, commandLine);
+        config.normalize();
         return config;
+    }
+
+    private static void applyThreadsOption(Config config, CommandLine commandLine) {
+        if (!commandLine.hasOption(THREADS_LONG_OPTION)) {
+            return;
+        }
+        String value = commandLine.getOptionValue(THREADS_LONG_OPTION);
+        int requested;
+        try {
+            requested = Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    String.format("Option --threads requires an integer >= 1, got '%s'", value));
+        }
+        if (requested < 1) {
+            throw new IllegalArgumentException(
+                    String.format("Option --threads requires an integer >= 1, got %d", requested));
+        }
+        config.setThreads(requested);
+        int applied = config.getThreads();
+        if (applied < requested) {
+            System.err.println(String.format(
+                    "Warning: --threads=%d exceeds available CPU cores; capped to %d.",
+                    requested, applied));
+        }
     }
 
     private static void applyImageOptions(Config config, CommandLine commandLine) {

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIOptions.java
@@ -140,6 +140,13 @@ public class CLIOptions {
     private static final String TO_STDOUT_LONG_OPTION = "to-stdout";
     private static final String TO_STDOUT_DESC = "Write output to stdout instead of file (single format only)";
 
+    // ===== Threads =====
+    private static final String THREADS_LONG_OPTION = "threads";
+    private static final String THREADS_DESC = "Number of worker threads for per-page processing. "
+            + "Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; "
+            + "output may vary slightly on some PDFs. Capped at the number of available CPU cores. "
+            + "Applies to the native Java pipeline only; ignored in --hybrid mode";
+
     // ===== Export Options (internal) =====
     public static final String EXPORT_OPTIONS_LONG_OPTION = "export-options";
 
@@ -188,6 +195,7 @@ public class CLIOptions {
             new OptionDefinition(HYBRID_TIMEOUT_LONG_OPTION, null, "string", "0", HYBRID_TIMEOUT_DESC, true),
             new OptionDefinition(HYBRID_FALLBACK_LONG_OPTION, null, "boolean", false, HYBRID_FALLBACK_DESC, true),
             new OptionDefinition(TO_STDOUT_LONG_OPTION, null, "boolean", false, TO_STDOUT_DESC, true),
+            new OptionDefinition(THREADS_LONG_OPTION, null, "string", "1", THREADS_DESC, true),
             new OptionDefinition(EXPORT_OPTIONS_LONG_OPTION, null, "boolean", null, null, false),
 
             // Legacy options (not exported, for backward compatibility)
@@ -273,7 +281,32 @@ public class CLIOptions {
         applyImageOptions(config, commandLine);
         applyPagesOption(config, commandLine);
         applyHybridOptions(config, commandLine);
+        applyThreadsOption(config, commandLine);
+        config.normalize();
         return config;
+    }
+
+    private static void applyThreadsOption(Config config, CommandLine commandLine) {
+        if (!commandLine.hasOption(THREADS_LONG_OPTION)) {
+            return;
+        }
+        String value = commandLine.getOptionValue(THREADS_LONG_OPTION);
+        int threads;
+        try {
+            threads = Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    String.format("Option --threads requires an integer >= 1, got '%s'", value));
+        }
+        if (threads < 1) {
+            throw new IllegalArgumentException(
+                    String.format("Option --threads requires an integer >= 1, got %d", threads));
+        }
+        int maxThreads = Runtime.getRuntime().availableProcessors();
+        if (threads > maxThreads) {
+            threads = maxThreads;
+        }
+        config.setThreads(threads);
     }
 
     private static void applyImageOptions(Config config, CommandLine commandLine) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -20,6 +20,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.opendataloader.pdf.hybrid.HybridConfig;
 
@@ -28,6 +30,8 @@ import org.opendataloader.pdf.hybrid.HybridConfig;
  * Use this class to specify output formats, text processing options, and other settings.
  */
 public class Config {
+    private static final Logger LOGGER = Logger.getLogger(Config.class.getCanonicalName());
+
     /** Reading order option: no sorting, keeps PDF COS object order. */
     public static final String READING_ORDER_OFF = "off";
     /** Reading order option: XY-Cut++ algorithm for layout-aware sorting. */
@@ -877,6 +881,19 @@ public class Config {
         this.outputStdout = outputStdout;
     }
 
+    private int threads = 1;
+
+    public int getThreads() {
+        return threads;
+    }
+
+    public void setThreads(int threads) {
+        if (threads < 1) {
+            throw new IllegalArgumentException("threads must be >= 1, got " + threads);
+        }
+        this.threads = Math.min(threads, Runtime.getRuntime().availableProcessors());
+    }
+
     /**
      * Returns true if any output format requires structured content
      * (reading order, heading levels, list detection, etc.).
@@ -884,6 +901,22 @@ public class Config {
      */
     public boolean needsStructuredProcessing() {
         return isGenerateMarkdown() || isGenerateHtml() || isGenerateJSON() || isGeneratePDF();
+    }
+
+    /**
+     * Resolves conflicts between individually valid option values.
+     * Call once after all setters, before passing the Config to a processor.
+     * Currently: in hybrid mode, forces {@code threads} to 1 because the hybrid
+     * pipeline runs sequentially regardless of this value.
+     */
+    public void normalize() {
+        if (isHybridEnabled() && threads > 1) {
+            LOGGER.log(Level.WARNING,
+                    "--threads={0} ignored in hybrid mode (forcing threads=1); "
+                            + "the hybrid pipeline processes pages sequentially",
+                    threads);
+            threads = 1;
+        }
     }
 
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -20,6 +20,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.opendataloader.pdf.hybrid.HybridConfig;
 
@@ -28,6 +30,8 @@ import org.opendataloader.pdf.hybrid.HybridConfig;
  * Use this class to specify output formats, text processing options, and other settings.
  */
 public class Config {
+    private static final Logger LOGGER = Logger.getLogger(Config.class.getCanonicalName());
+
     /** Reading order option: no sorting, keeps PDF COS object order. */
     public static final String READING_ORDER_OFF = "off";
     /** Reading order option: XY-Cut++ algorithm for layout-aware sorting. */
@@ -877,6 +881,19 @@ public class Config {
         this.outputStdout = outputStdout;
     }
 
+    private int threads = 1;
+
+    public int getThreads() {
+        return threads;
+    }
+
+    public void setThreads(int threads) {
+        if (threads < 1) {
+            throw new IllegalArgumentException("threads must be >= 1, got " + threads);
+        }
+        this.threads = threads;
+    }
+
     /**
      * Returns true if any output format requires structured content
      * (reading order, heading levels, list detection, etc.).
@@ -884,6 +901,22 @@ public class Config {
      */
     public boolean needsStructuredProcessing() {
         return isGenerateMarkdown() || isGenerateHtml() || isGenerateJSON() || isGeneratePDF();
+    }
+
+    /**
+     * Resolves conflicts between individually valid option values.
+     * Call once after all setters, before passing the Config to a processor.
+     * Currently: in hybrid mode, forces {@code threads} to 1 because the hybrid
+     * pipeline runs sequentially regardless of this value.
+     */
+    public void normalize() {
+        if (isHybridEnabled() && threads > 1) {
+            LOGGER.log(Level.WARNING,
+                    "--threads={0} ignored in hybrid mode (forcing threads=1); "
+                            + "the hybrid pipeline processes pages sequentially",
+                    threads);
+            threads = 1;
+        }
     }
 
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -226,7 +226,7 @@ public class DocumentProcessor {
             pageArtifacts[i] = document.getArtifacts(i);
         }
 
-        int parallelism = Runtime.getRuntime().availableProcessors();
+        int parallelism = config.getThreads();
         ForkJoinPool pool = new ForkJoinPool(parallelism);
         LOGGER.log(Level.INFO, "Processing {0} pages with {1} threads", new Object[]{totalPages, parallelism});
 
@@ -651,9 +651,15 @@ public class DocumentProcessor {
 
         // xycut: XY-Cut++ sorting (per-page, stateless — safe to parallelize)
         if (Config.READING_ORDER_XYCUT.equals(readingOrder)) {
-            IntStream.range(0, StaticContainers.getDocument().getNumberOfPages()).parallel().forEach(pageNumber ->
-                contents.set(pageNumber, XYCutPlusPlusSorter.sort(contents.get(pageNumber)))
-            );
+            int totalPages = StaticContainers.getDocument().getNumberOfPages();
+            IntStream pages = IntStream.range(0, totalPages);
+            if (config.getThreads() > 1) {
+                pages.parallel().forEach(pageNumber ->
+                    contents.set(pageNumber, XYCutPlusPlusSorter.sort(contents.get(pageNumber))));
+            } else {
+                pages.forEach(pageNumber ->
+                    contents.set(pageNumber, XYCutPlusPlusSorter.sort(contents.get(pageNumber))));
+            }
             return;
         }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -226,7 +226,7 @@ public class DocumentProcessor {
             pageArtifacts[i] = document.getArtifacts(i);
         }
 
-        int parallelism = Runtime.getRuntime().availableProcessors();
+        int parallelism = config.getThreads();
         ForkJoinPool pool = new ForkJoinPool(parallelism);
         LOGGER.log(Level.INFO, "Processing {0} pages with {1} threads", new Object[]{totalPages, parallelism});
 

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -33,4 +33,5 @@ export function registerCliOptions(program: Command): void {
   program.option('--hybrid-timeout <value>', 'Hybrid backend request timeout in milliseconds (0 = no timeout). Default: 0');
   program.option('--hybrid-fallback', 'Opt in to Java fallback on hybrid backend error (default: disabled)');
   program.option('--to-stdout', 'Write output to stdout instead of file (single format only)');
+  program.option('--threads <value>', 'Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode');
 }

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -57,6 +57,8 @@ export interface ConvertOptions {
   hybridFallback?: boolean;
   /** Write output to stdout instead of file (single format only) */
   toStdout?: boolean;
+  /** Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode */
+  threads?: string;
 }
 
 /**
@@ -89,6 +91,7 @@ export interface CliOptions {
   hybridTimeout?: string;
   hybridFallback?: boolean;
   toStdout?: boolean;
+  threads?: string;
 }
 
 /**
@@ -174,6 +177,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.toStdout) {
     convertOptions.toStdout = true;
+  }
+  if (cliOptions.threads) {
+    convertOptions.threads = cliOptions.threads;
   }
 
   return convertOptions;
@@ -274,6 +280,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.toStdout) {
     args.push('--to-stdout');
+  }
+  if (options.threads) {
+    args.push('--threads', options.threads);
   }
 
   return args;

--- a/options.json
+++ b/options.json
@@ -207,6 +207,14 @@
       "required": false,
       "default": false,
       "description": "Write output to stdout instead of file (single format only)"
+    },
+    {
+      "name": "threads",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": "1",
+      "description": "Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode"
     }
   ]
 }

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -243,6 +243,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "default": False,
         "description": "Write output to stdout instead of file (single format only)",
     },
+    {
+        "name": "threads",
+        "python_name": "threads",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": "1",
+        "description": "Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode",
+    },
 ]
 
 

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -37,6 +37,7 @@ def convert(
     hybrid_timeout: Optional[str] = None,
     hybrid_fallback: bool = False,
     to_stdout: bool = False,
+    threads: Optional[str] = None,
 ) -> None:
     """
     Convert PDF(s) into the requested output format(s).
@@ -69,6 +70,7 @@ def convert(
         hybrid_timeout: Hybrid backend request timeout in milliseconds (0 = no timeout). Default: 0
         hybrid_fallback: Opt in to Java fallback on hybrid backend error (default: disabled)
         to_stdout: Write output to stdout instead of file (single format only)
+        threads: Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode
     """
     args: List[str] = []
 
@@ -138,5 +140,7 @@ def convert(
         args.append("--hybrid-fallback")
     if to_stdout:
         args.append("--to-stdout")
+    if threads:
+        args.extend(["--threads", threads])
 
     run_jar(args, quiet)


### PR DESCRIPTION
## Objective
On some PDFs, default-option runs fail intermittently after per-page parallel processing was enabled (bc52918e). The same class of failure is documented in [#264](https://github.com/opendataloader-project/opendataloader-pdf/issues/264), which concluded per-page parallelism is **not viable with the current upstream veraPDF/PDFBox state**. Without a knob to turn parallelism off, users have no workaround.

Refs [opendataloader-project/opendataloader-pdf#264](https://github.com/opendataloader-project/opendataloader-pdf/issues/264)

## Approach
Make sequential the default and expose parallelism as an opt-in experimental flag. Upstream thread-safety is outside this repo's control, so the stance is to let users choose when to trade stability for throughput.

- New `--threads N` (default `1`, capped at `availableProcessors()`).
- `DocumentProcessor` reads `config.getThreads()` instead of hardcoding `availableProcessors()` — reverts the effective default to sequential while keeping the parallel code path available.
- `Config.normalize()` forces `threads=1` and warns when `--hybrid` is set, because `HybridDocumentProcessor`'s Java path is already sequential by design (honoring `--threads` there would mislead).
- Option description is neutral: "stable" default, "experimental" for `>1`, notes output may vary slightly on some PDFs.
- `npm run sync` regenerated `options.json`, Python/Node bindings, and MDX docs.

## Evidence
Built with mvn (54/54 tests pass), ran the CLI against a sample PDF under each scenario and inspected stderr/log lines on a 10-core host:

| Scenario | Expected | Actual |
|----------|----------|--------|
| no `--threads` | 1 worker, no warning | `Processing N pages with 1 threads` |
| `--threads 4` | 4 workers, no warning | `Processing N pages with 4 threads` |
| `--threads 4 --hybrid docling-fast` | warning + force 1 | `--threads=4 ignored in hybrid mode (forcing threads=1); the hybrid pipeline processes pages sequentially` |
| `--hybrid docling-fast` (default threads) | silent | no threads-related log |
| `--threads 0` / `--threads abc` | reject with usage | `Option --threads requires an integer >= 1, got '0'` / `'abc'` |
| `--threads 99999` | cap at 10 (host cores) | runs with 10 workers |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --threads CLI option to control per-page worker parallelism (default 1 = sequential).
  * Values >1 enable experimental parallel page processing; per-page work uses parallelism only when threads >1.
  * Thread usage is capped to available CPU cores; a warning is shown if the effective count is lower than requested.
  * Option is ignored when running in hybrid mode.

* **Documentation**
  * Updated CLI and API docs to describe threads behavior and caveats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->