### PR TITLE
fix(deps): pin veraPDF and jackson-databind to fixed versions in published POM

### DIFF
--- a/java/opendataloader-pdf-core/pom.xml
+++ b/java/opendataloader-pdf-core/pom.xml
@@ -62,6 +62,22 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.verapdf</groupId>
+            <artifactId>wcag-algorithms</artifactId>
+            <version>${verapdf.wcag.algs.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.12.0</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,7 +58,9 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <verapdf.version>[1.31.0,1.32.0-RC)</verapdf.version>
+        <verapdf.version>1.31.54</verapdf.version>
+        <verapdf.wcag.algs.version>1.31.18</verapdf.wcag.algs.version>
+        <jackson.databind.version>2.21.1</jackson.databind.version>
         <junit.jupiter.version>5.14.3</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>
         <commons.cli.version>1.11.0</commons.cli.version>
@@ -82,6 +84,22 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.verapdf</groupId>
+                <artifactId>wcag-algorithms</artifactId>
+                <version>${verapdf.wcag.algs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.databind.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>


### PR DESCRIPTION
## Objective

Downstream consumers of `opendataloader-pdf-core:2.3.0` (e.g. `studio-api`) hit intermittent dependency-resolution failures on a clean Maven cache: VS Code Java/Maven import fails, sometimes with NPE in the resolver. The published POM declares veraPDF deps as a version range (`[1.31.0,1.32.0-RC)`) and bundles the `vera-dev` snapshot repository, so every clean consumer build has to walk `maven-metadata.xml` from vera-dev to pick a "latest matching" version — non-deterministic and network-fragile.

Reproduction (consumer side):

```bash
./mvnw -Dmaven.repo.local=/tmp/m2-clean -U -pl <module-using-core> -am -DskipTests compile
```

## Approach

Pin all veraPDF coordinates and `jackson-databind` to **fixed versions** in the published POM so consumer Maven can request the POM directly without a metadata range walk.

Three coordinated pins, in order of necessity:

1. **`verapdf.version` → `1.31.54`** — replaces the range. Matches what the range was resolving to today. Affects `validation-model` and `wcag-validation` direct deps.
2. **`verapdf.wcag.algs.version` → `1.31.18`** (new property + new direct dep). Upstream `validation 1.31.54`'s POM declares `wcag-algorithms` as a *separate* range `[1.31.0,1.32.0-RC)`, so pinning only `verapdf.version` still leaves a transitive range walk. Adding `wcag-algorithms` as a direct dep at the fixed version short-circuits that via Maven's nearest-wins rule. The property name matches upstream's `verapdf.wcag.algs.version` for cross-referencing.
3. **`jackson.databind.version` → `2.21.1`** (new property + new direct dep). Adding `wcag-algorithms` at depth 2 would otherwise win nearest-wins over `validation-model → core → jackson-databind 2.21.1` at depth 4, silently downgrading jackson to **2.15.0** (the version `wcag-algorithms 1.31.18` declares) — that's roughly 3 years of jackson CVEs we'd ship as a regression. Pinning jackson-databind at `2.21.1` directly preserves the pre-fix effective version.

Belt-and-suspenders:

- The same three pins are also added to parent `<dependencyManagement>` for our own build's collection-stage hardening (`flatten-maven-plugin` `oss` mode strips management from the published POM, so this protects only our build, not consumers — but it makes the parent POM internally consistent).
- `<exclusion>` for `org.jacoco:jacoco-maven-plugin` on `wcag-algorithms` (both in the direct dep and in the management entry). The `wcag-algorithms 1.31.18` POM declares jacoco-maven-plugin as a **compile-scope** dependency, leaking a Maven plugin onto the consumer's runtime classpath. The duplicated exclusion guards the published POM and any future refactor of the management/direct duplication.

The `vera-dev` repository **stays** in the published POM — transitive verapdf jars (`parser`, `pdf-model`, `core`, `verapdf-xmp-core`, `metadata-fixer`) only exist there, not on Maven Central. Removing the repo would break consumer downloads. Eliminating that dependency requires either upstream veraPDF publishing to Central or vendoring; out of scope for this PR.

Other consciously-accepted tradeoff: consumers no longer auto-pick veraPDF / jackson patch releases. We trade auto-patch absorption for resolution determinism — which is what the bug report asks for.

## Evidence

A fake consumer project (`/tmp/fake-consumer` depending on `opendataloader-pdf-core`) was used with a clean Maven cache to simulate the user's reported scenario. `mvn dependency:tree` was the primary witness; `mvn clean test` and `mvn package` the secondary.

| Scenario | Expected | Actual |
|----------|----------|--------|
| Consumer cold-cache resolve, range version | non-deterministic; metadata fetched, multiple wcag-algorithms POMs probed | 9+ wcag-algorithms POMs fetched (1.31.1…1.31.10), `validation-model`/`wcag-validation` metadata.xml fetched against vera-dev |
| Consumer cold-cache resolve, this PR | deterministic; direct POM lookup at fixed version | All veraPDF coords resolve to fixed versions (validation-model 1.31.54, wcag-validation 1.31.54, wcag-algorithms 1.31.18, parser 1.31.17, pdf-model 1.31.3, core 1.31.10, metadata-fixer 1.31.54, verapdf-xmp-core 1.31.10) |
| Jackson resolved version, this PR | 2.21.1 (no regression) | `jackson-databind 2.21.1`; verbose tree shows `jackson-databind 2.15.0 omitted for conflict with 2.21.1` |
| `jacoco-maven-plugin` on compile classpath | absent | absent (verified via `dependency:tree` and `mvn dependency:list -DincludeScope=compile`) |
| `mvn clean test` (core) | pass | 554 / 554 tests pass |
| `mvn package` (cli) | pass | BUILD SUCCESS |
| Published `.flattened-pom.xml` | direct deps with fixed versions | 5 direct deps all fixed: validation-model 1.31.54, wcag-validation 1.31.54, wcag-algorithms 1.31.18 (+ jacoco exclusion), jackson-databind 2.21.1, okhttp 4.12.0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven parent POM configuration with pinned versions for critical dependencies to ensure improved build stability, consistency, and long-term maintainability across all releases
  * Extended core PDF loader module dependencies by adding new libraries that enable enhanced document validation capabilities and improved JSON data processing features
  * Implemented centralized dependency version management and alignment to maintain consistency across all project modules and prevent version-related conflicts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->