### PR TITLE
feat(api): add OutputWriter for two-phase extraction-then-output flow

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OutputWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/OutputWriter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.api;
+
+import org.opendataloader.pdf.processors.DocumentProcessor;
+import org.opendataloader.pdf.processors.ExtractionResult;
+
+import java.io.IOException;
+
+/**
+ * Writes configured output files (JSON, Markdown, HTML, PDF, text, images,
+ * tagged PDF) from a pre-computed {@link ExtractionResult}.
+ *
+ * <p>Use this when you have already run extraction once (e.g. via
+ * {@link AutoTagger#tag(String, ExtractionResult)}) and want to emit file
+ * outputs from that same result without re-extracting.
+ *
+ * <p>Typical two-phase usage:
+ * <pre>{@code
+ * Config config = new Config();
+ * config.setOutputFolder("/out");
+ * config.setGenerateJSON(true);
+ * config.setGenerateMarkdown(true);
+ *
+ * // Phase 1: extract once
+ * ExtractionResult extraction =
+ *     org.opendataloader.pdf.processors.DocumentProcessor.extractContents(
+ *         "input.pdf", config);
+ *
+ * // Phase 2a: write output files
+ * OutputWriter.writeOutputs("input.pdf", extraction, config);
+ *
+ * // Phase 2b: tag in-memory and reuse the same extraction
+ * try (TaggingResult tagged = AutoTagger.tag("input.pdf", extraction)) {
+ *     // ... use tagged.getDocument()
+ * }
+ * }</pre>
+ *
+ * <p>For the single-call extraction-and-output pipeline, use
+ * {@link OpenDataLoaderPDF#processFile} instead.
+ */
+public final class OutputWriter {
+
+    private OutputWriter() {
+    }
+
+    /**
+     * Writes the output files configured on {@code config} (e.g.
+     * {@code generateJSON}, {@code generateMarkdown}, {@code generateHtml},
+     * {@code generatePDF}, {@code generateTaggedPDF}, {@code generateText})
+     * using the supplied pre-computed extraction.
+     *
+     * <p>This method does <em>not</em> re-run extraction. Output behaviour is
+     * identical to {@link OpenDataLoaderPDF#processFile} for the same
+     * {@link Config}, including stdout mode, image directory resolution, and
+     * tagged-PDF generation.
+     *
+     * @param inputPdfName path to the input PDF file (used for filename derivation
+     *                     and tagged-PDF / annotated-PDF re-saves; not re-parsed)
+     * @param extraction   pre-computed extraction result (from
+     *                     {@code DocumentProcessor.extractContents})
+     * @param config       configuration controlling which output formats to emit
+     * @throws IOException if writing any output file fails
+     */
+    public static void writeOutputs(String inputPdfName, ExtractionResult extraction, Config config)
+            throws IOException {
+        DocumentProcessor.generateOutputs(inputPdfName, extraction.getContents(), config,
+                extraction.getElementMetadata());
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -383,7 +383,20 @@ public class DocumentProcessor {
         return pagesToProcess == null || pagesToProcess.contains(pageNumber);
     }
 
-    private static void generateOutputs(String inputPdfName, List<List<IObject>> contents, Config config,
+    /**
+     * Writes the configured output files (JSON/MD/HTML/PDF/Text/images/tagged PDF)
+     * from already-extracted contents.
+     *
+     * <p><strong>Internal API. Do not call directly.</strong> This method is
+     * {@code public} only so the {@link org.opendataloader.pdf.api.OutputWriter}
+     * facade in the {@code api} package can delegate to it. The signature
+     * (notably the {@code List<List<IObject>>} and
+     * {@code Map<Long, ElementMetadata>} parameters) is an implementation
+     * detail and may change in any release. External callers must use
+     * {@link org.opendataloader.pdf.api.OutputWriter#writeOutputs}, which is
+     * the stable public API.
+     */
+    public static void generateOutputs(String inputPdfName, List<List<IObject>> contents, Config config,
                                            Map<Long, ElementMetadata> elementMetadata) throws IOException {
         // Stdout mode: write primary format to stdout, skip file I/O
         if (config.isOutputStdout()) {


### PR DESCRIPTION
## Summary

- New public class `org.opendataloader.pdf.api.OutputWriter` with `writeOutputs(inputPdf, ExtractionResult, Config)` so callers that already ran extraction can emit JSON/MD/HTML/PDF/text/images/tagged-PDF outputs from that same `ExtractionResult` without re-parsing the PDF.
- `DocumentProcessor.generateOutputs` promoted from `private` to `public static` so the new `api.OutputWriter` facade can delegate to it. Javadoc explicitly marks it as internal — callers must use `api.OutputWriter`.

This is **purely additive** — no existing public API changed. The single-call `processFile` pipeline behaves identically to before.

## Why

Downstream consumers (e.g. `opendataloader-pdfua`) need both file outputs (JSON/MD/HTML) and an in-memory tagged document from the same input. Previously this required two extraction passes (`processFile` for outputs + `AutoTagger.tag` for the tagged doc), which doubled wall time and any hybrid backend calls. With `OutputWriter` and the existing `AutoTagger.tag(String, ExtractionResult)` overload, a downstream pipeline can extract once and feed both sinks.

## API surface

```java
// Phase 1: extract once
ExtractionResult extraction =
    DocumentProcessor.extractContents("input.pdf", config);

// Phase 2a: emit configured output files
OutputWriter.writeOutputs("input.pdf", extraction, config);

// Phase 2b: tag in-memory from the same extraction
try (TaggingResult tagged = AutoTagger.tag("input.pdf", extraction)) {
    // ...
}
```

## Test plan

- [x] `mvn test -pl opendataloader-pdf-core` — 554/0/0 pass, no test changes required
- [x] `mvn install -DskipTests` succeeds (javadoc plugin happy)
- [x] Used by a follow-up `opendataloader-pdfua` PR (link in comments after open) which switches to the new two-phase flow and verifies extraction runs exactly once via a dedicated regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new output writer API that separates extraction and output generation into two phases. Extract content once, then generate multiple output formats from the same extraction without re-processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->