### PR TITLE
Add nesting of Annotation within an Annot tag

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -29,7 +29,6 @@ import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
-import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.StreamInfo;
 
 import java.io.*;
@@ -241,10 +240,10 @@ public class AutoTaggingProcessor {
         COSObject seDocument = addStructElement(structTreeRoot, cosDocument, TaggedPDFConstants.DOCUMENT, null);
         Map<SemanticHeading, Integer> normalizedLevels = buildNormalizedHeadingLevels(contents);
         for (int pageNumber = 0; pageNumber < contents.size(); pageNumber++) {
-            processLinkAnnotations(document, cosDocument, pageNumber);
+            processAnnotations(document, cosDocument, pageNumber);
             List<IObject> pageContents = contents.get(pageNumber);
             addKids(pageContents, seDocument, cosDocument, normalizedLevels);
-            processLinkAnnotations(cosDocument, seDocument, pageNumber);
+            processAnnotations(cosDocument, seDocument, pageNumber);
         }
         return seDocument;
     }
@@ -352,7 +351,7 @@ public class AutoTaggingProcessor {
         return result;
     }
 
-    private static void processLinkAnnotations(PDDocument document, COSDocument cosDocument, int pageNumber) {
+    private static void processAnnotations(PDDocument document, COSDocument cosDocument, int pageNumber) {
         PDPage page = document.getPages().get(pageNumber);
         List<PDAnnotation> annotations = page.getAnnotations();
         if (annotations == null) return;
@@ -360,47 +359,54 @@ public class AutoTaggingProcessor {
         for (PDAnnotation annotation : annotations) {
             COSObject annotObj = annotation.getObject();
             if (annotObj == null || annotObj.empty()) continue;
-            if (!ASAtom.LINK.equals(annotation.getSubtype())) continue;
-            annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
-            // Get URI from action if available
-            String uriString = null;
-            try {
-                PDAction action = annotation.getA();
-                if (action != null && action.getObject() != null && ASAtom.URI.equals(action.getSubtype())) {
-                    uriString = action.getStringKey(ASAtom.URI);
-                }
-            } catch (Exception e) {
-                // ignore — URI not critical
+            //PDF/UA-1 rule 7.18.1-1
+            if (!isPDF2_0 && !ASAtom.LINK.equals(annotation.getSubtype()) &&
+                !ASAtom.PRINTER_MARK.equals(annotation.getSubtype()) && !ASAtom.PRINTER_MARK.equals(annotation.getSubtype()) &&
+                !PDAnnotation.isOutsideCropBox(page, annotation) && PDAnnotation.isVisibleAnnotation(annotation)) {
+                annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
             }
-            // Create Link struct element
-            // PDF/UA-2 clause 8.9.4.2.1 requires the annotation's Contents and the enclosing
-            // struct element's Alt to be identical when both are present. Prefer any existing
-            // Contents authored on the annotation (accessibility text the author already
-            // wrote), otherwise fall back to URI, then to "Link".
-            String existingContents = annotation.getContents();
-            // Build a single COSString object and use it for /Contents. Hex form
-            // (isHex=true) is required because UTF-16BE code units whose low
-            // byte is 0x5C would be misparsed as a backslash escape inside a
-            // PDF literal string, corrupting non-ASCII text. UTF-16 with BOM
-            // keeps readers from interpreting the string as PDFDocEncoding.
-            if (existingContents != null && !existingContents.isEmpty()) {
-                // Preserve the annotation's existing COSString reference when
-                // present — re-encoding would change literal/hex form and
-                // break the equality check.
-                COSObject contentsObj = annotObj.getKey(ASAtom.CONTENTS);
-                if (contentsObj == null || contentsObj.getType() != COSObjType.COS_STRING) {
-                    // Non-string /Contents (rare, e.g. indirect/array shape). Build a hex
-                    // UTF-16 COSString from the parsed text and write it back to /Contents
-                    // too so the annotation and /Alt remain byte-identical per §8.9.4.2.1.
+            if (ASAtom.LINK.equals(annotation.getSubtype())) {
+                annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
+                // Get URI from action if available
+                String uriString = null;
+                try {
+                    PDAction action = annotation.getA();
+                    if (action != null && action.getObject() != null && ASAtom.URI.equals(action.getSubtype())) {
+                        uriString = action.getStringKey(ASAtom.URI);
+                    }
+                } catch (Exception e) {
+                    // ignore — URI not critical
+                }
+                // Create Link struct element
+                // PDF/UA-2 clause 8.9.4.2.1 requires the annotation's Contents and the enclosing
+                // struct element's Alt to be identical when both are present. Prefer any existing
+                // Contents authored on the annotation (accessibility text the author already
+                // wrote), otherwise fall back to URI, then to "Link".
+                String existingContents = annotation.getContents();
+                // Build a single COSString object and use it for /Contents. Hex form
+                // (isHex=true) is required because UTF-16BE code units whose low
+                // byte is 0x5C would be misparsed as a backslash escape inside a
+                // PDF literal string, corrupting non-ASCII text. UTF-16 with BOM
+                // keeps readers from interpreting the string as PDFDocEncoding.
+                if (existingContents != null && !existingContents.isEmpty()) {
+                    // Preserve the annotation's existing COSString reference when
+                    // present — re-encoding would change literal/hex form and
+                    // break the equality check.
+                    COSObject contentsObj = annotObj.getKey(ASAtom.CONTENTS);
+                    if (contentsObj == null || contentsObj.getType() != COSObjType.COS_STRING) {
+                        // Non-string /Contents (rare, e.g. indirect/array shape). Build a hex
+                        // UTF-16 COSString from the parsed text and write it back to /Contents
+                        // too so the annotation and /Alt remain byte-identical per §8.9.4.2.1.
+                        COSObject linkTextObject = COSString.construct(
+                            existingContents.getBytes(StandardCharsets.UTF_16), true);
+                        annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
+                    }
+                } else {
+                    String altText = uriString != null ? uriString : "Link";
                     COSObject linkTextObject = COSString.construct(
-                        existingContents.getBytes(StandardCharsets.UTF_16), true);
+                        altText.getBytes(StandardCharsets.UTF_16), true);
                     annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
                 }
-            } else {
-                String altText = uriString != null ? uriString : "Link";
-                COSObject linkTextObject = COSString.construct(
-                    altText.getBytes(StandardCharsets.UTF_16), true);
-                annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
             }
             // Assign StructParent integer to annotation and register in parent tree
             int structParentInt = currentStructParent++;
@@ -419,16 +425,20 @@ public class AutoTaggingProcessor {
         }
     }
 
-    private static void processLinkAnnotations(COSDocument cosDocument, COSObject seDocument, int pageNumber) {
+    private static void processAnnotations(COSDocument cosDocument, COSObject seDocument, int pageNumber) {
         for (PDAnnotation annotation : annotationBBoxesMap.values()) {
-            createLinkStructElem(cosDocument, seDocument, annotation, null, pageNumber);
+            if (ASAtom.LINK.equals(annotation.getSubtype())) {
+                createAnnotationStructElem(cosDocument, seDocument, annotation, null, pageNumber, TaggedPDFConstants.LINK);
+            } else {
+                createAnnotationStructElem(cosDocument, seDocument, annotation, null, pageNumber, TaggedPDFConstants.ANNOT);
+            }
         }
         annotationBBoxesMap.clear();
     }
 
-    private static void createLinkStructElem(COSDocument cosDocument, COSObject parent, PDAnnotation annotation,
-                                             List<StreamInfo> streamInfos, int pageNumber) {
-        COSObject linkElem = addStructElement(parent, cosDocument, TaggedPDFConstants.LINK, pageNumber);
+    private static void createAnnotationStructElem(COSDocument cosDocument, COSObject parent, PDAnnotation annotation,
+                                                   List<StreamInfo> streamInfos, int pageNumber, String tag) {
+        COSObject linkElem = addStructElement(parent, cosDocument, tag, pageNumber);
         linkElem.setKey(ASAtom.ALT, annotation.getKey(ASAtom.CONTENTS));
         annotationStructParents.put(annotation.getIntegerKey(ASAtom.STRUCT_PARENT).intValue(), linkElem);
         // Create OBJR pointing to the annotation
@@ -878,8 +888,14 @@ public class AutoTaggingProcessor {
                             addMcidChildren(streamInfos, textNode.getPageNumber(), cosObject);
                             streamInfos.clear();
                         }
-                        createLinkStructElem(StaticResources.getDocument().getDocument(), cosObject, entry.getValue(),
-                            textChunk.getStreamInfos(), textNode.getPageNumber());
+                        if (ASAtom.LINK.equals(entry.getValue().getSubtype())) {
+                            createAnnotationStructElem(StaticResources.getDocument().getDocument(), cosObject, entry.getValue(),
+                                textChunk.getStreamInfos(), textNode.getPageNumber(), TaggedPDFConstants.LINK);
+                        } else {
+                            createAnnotationStructElem(StaticResources.getDocument().getDocument(), cosObject, entry.getValue(),
+                                textChunk.getStreamInfos(), textNode.getPageNumber(), TaggedPDFConstants.ANNOT);
+                        }
+
                     } else {
                         streamInfos.addAll(textChunk.getStreamInfos());
                     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -444,7 +444,7 @@ public class AutoTaggingProcessor {
         }
         COSObject structElement = addStructElement(parent, cosDocument, tag, pageNumber);
 
-        // Various PDF/UA riles require the annotation's Contents and the enclosing
+        // PDF/UA-2 rule 8.9.4.2-1 requires the annotation's Contents and the enclosing
         // struct element's Alt to be identical when both are present.
         COSObject contents = annotation.getKey(ASAtom.CONTENTS);
         if (contents != null && !contents.empty() && contents.getType() == COSObjType.COS_STRING) {
@@ -710,11 +710,12 @@ public class AutoTaggingProcessor {
     }
 
 
-    //PDF/UA-1 rule 7.3-1 / PDF/UA-2 rule 8.2.5.28.2-1
+
     private static COSObject createFigureStructElemReturning(ImageChunk image, COSObject parent, COSDocument cosDocument) {
         COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE, image.getPageNumber());
         double[] bbox = {image.getLeftX(), image.getBottomY(), image.getRightX(), image.getTopY()};
         addAttributeToStructElem(figureObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
+        //PDF/UA-1 rule 7.3-1 / PDF/UA-2 rule 8.2.5.28.2-1
         // Use enriched description if available, otherwise fallback "image N"
         String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
                 ? ((EnrichedImageChunk) image).sanitizeDescription()
@@ -734,11 +735,12 @@ public class AutoTaggingProcessor {
         return figureObject;
     }
 
-    //PDF/UA-1 rule 7.7-1
+
     private static void createFormulaStructElem(SemanticFormula formula, COSObject parent, COSDocument cosDocument) {
         COSObject formulaObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FORMULA, formula.getPageNumber());
         double[] bbox = {formula.getLeftX(), formula.getBottomY(), formula.getRightX(), formula.getTopY()};
         addAttributeToStructElem(formulaObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
+        //PDF/UA-1 rule 7.7-1
         String altText = formula.getLatex().isEmpty() ? "formula" : formula.getLatex();
         formulaObject.setKey(ASAtom.ALT,
                 COSString.construct(altText.getBytes(StandardCharsets.UTF_16), true));

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -359,13 +359,28 @@ public class AutoTaggingProcessor {
         for (PDAnnotation annotation : annotations) {
             COSObject annotObj = annotation.getObject();
             if (annotObj == null || annotObj.empty()) continue;
-            //PDF/UA-1 rule 7.18.1-1
-            if (!isPDF2_0 && !ASAtom.LINK.equals(annotation.getSubtype()) &&
-                !ASAtom.PRINTER_MARK.equals(annotation.getSubtype()) && !ASAtom.PRINTER_MARK.equals(annotation.getSubtype()) &&
-                !PDAnnotation.isOutsideCropBox(page, annotation) && PDAnnotation.isVisibleAnnotation(annotation)) {
-                annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
+
+            if (isPDF2_0) {
+                //PDF/UA-2 rules 8.10.1-1, 8.9.2.4.16-1, 8.9.2.3-1
+                if (ASAtom.WIDGET.equals(annotation.getSubtype()) || ASAtom.WATERMARK.equals(annotation.getSubtype()) ||
+                    annotation.isMarkup()) {
+                    annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
+                    pageChanged = assignStructParentToAnnotation(annotObj, cosDocument);
+                }
+            } else {
+                //PDF/UA-1 rules 7.18.1-1 + 7.18.4-1
+                if (!ASAtom.LINK.equals(annotation.getSubtype()) &&
+                    !ASAtom.PRINTER_MARK.equals(annotation.getSubtype()) &&
+                    !PDAnnotation.isOutsideCropBox(page, annotation) && PDAnnotation.isVisibleAnnotation(annotation)) {
+                    annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
+                    pageChanged = assignStructParentToAnnotation(annotObj, cosDocument);
+                }
             }
-            if (ASAtom.LINK.equals(annotation.getSubtype())) {
+            //PDF/UA-1 rule 7.18.5-1 / PDF/UA-2 rule 8.2.5.20-1
+            //TODO: check if artifact in PDF/UA-2
+            if ((ASAtom.LINK.equals(annotation.getSubtype()) && isPDF2_0) ||
+                (ASAtom.LINK.equals(annotation.getSubtype()) && !isPDF2_0 &&
+                    !PDAnnotation.isOutsideCropBox(page, annotation) && PDAnnotation.isVisibleAnnotation(annotation))) {
                 annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
                 // Get URI from action if available
                 String uriString = null;
@@ -407,12 +422,8 @@ public class AutoTaggingProcessor {
                         altText.getBytes(StandardCharsets.UTF_16), true);
                     annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
                 }
+                pageChanged = assignStructParentToAnnotation(annotObj, cosDocument);
             }
-            // Assign StructParent integer to annotation and register in parent tree
-            int structParentInt = currentStructParent++;
-            annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
-            cosDocument.addChangedObject(annotObj);
-            pageChanged = true;
         }
         // Flush the Annots array (may be an indirect object separate from the page)
         // so that direct-object annotation dicts inside it (StructParent + Contents) are saved.
@@ -425,19 +436,32 @@ public class AutoTaggingProcessor {
         }
     }
 
+    private static boolean assignStructParentToAnnotation(COSObject annotObj, COSDocument cosDocument) {
+        // Assign StructParent integer to annotation and register in parent tree
+        int structParentInt = currentStructParent++;
+        annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
+        cosDocument.addChangedObject(annotObj);
+        return true;
+    }
+
     private static void processAnnotations(COSDocument cosDocument, COSObject seDocument, int pageNumber) {
         for (PDAnnotation annotation : annotationBBoxesMap.values()) {
-            if (ASAtom.LINK.equals(annotation.getSubtype())) {
-                createAnnotationStructElem(cosDocument, seDocument, annotation, null, pageNumber, TaggedPDFConstants.LINK);
-            } else {
-                createAnnotationStructElem(cosDocument, seDocument, annotation, null, pageNumber, TaggedPDFConstants.ANNOT);
-            }
+            createAnnotationStructElem(cosDocument, seDocument, annotation, null, pageNumber);
         }
         annotationBBoxesMap.clear();
     }
 
     private static void createAnnotationStructElem(COSDocument cosDocument, COSObject parent, PDAnnotation annotation,
-                                                   List<StreamInfo> streamInfos, int pageNumber, String tag) {
+                                                   List<StreamInfo> streamInfos, int pageNumber) {
+
+        String tag;
+        if (ASAtom.LINK.equals(annotation.getSubtype())) {
+            tag = TaggedPDFConstants.LINK;
+        } else if (ASAtom.WIDGET.equals(annotation.getSubtype())) {
+            tag = TaggedPDFConstants.FORM;
+        } else {
+            tag = TaggedPDFConstants.ANNOT;
+        }
         COSObject linkElem = addStructElement(parent, cosDocument, tag, pageNumber);
         linkElem.setKey(ASAtom.ALT, annotation.getKey(ASAtom.CONTENTS));
         annotationStructParents.put(annotation.getIntegerKey(ASAtom.STRUCT_PARENT).intValue(), linkElem);
@@ -888,14 +912,8 @@ public class AutoTaggingProcessor {
                             addMcidChildren(streamInfos, textNode.getPageNumber(), cosObject);
                             streamInfos.clear();
                         }
-                        if (ASAtom.LINK.equals(entry.getValue().getSubtype())) {
-                            createAnnotationStructElem(StaticResources.getDocument().getDocument(), cosObject, entry.getValue(),
-                                textChunk.getStreamInfos(), textNode.getPageNumber(), TaggedPDFConstants.LINK);
-                        } else {
-                            createAnnotationStructElem(StaticResources.getDocument().getDocument(), cosObject, entry.getValue(),
-                                textChunk.getStreamInfos(), textNode.getPageNumber(), TaggedPDFConstants.ANNOT);
-                        }
-
+                        createAnnotationStructElem(StaticResources.getDocument().getDocument(), cosObject, entry.getValue(),
+                            textChunk.getStreamInfos(), textNode.getPageNumber());
                     } else {
                         streamInfos.addAll(textChunk.getStreamInfos());
                     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -370,19 +370,17 @@ public class AutoTaggingProcessor {
 
     private static void setAnnotationContents(PDAnnotation annotation, COSObject annotObj) {
         // Create Annotation struct element
-        // PDF/UA-2 clause 8.9.4.2.1 requires the annotation's Contents and the enclosing
+        // Various PDF/UA riles require the annotation's Contents and the enclosing
         // struct element's Alt to be identical when both are present. Prefer any existing
         // Contents authored on the annotation (accessibility text the author already
-        // wrote), otherwise fall back to URI, then to "Annotation".
+        // wrote), otherwise fall back to URI (for Link only), then to "Annotation".
         String existingContents = annotation.getContents();
 
-        // Preserve the annotation's existing COSString reference when
-        // present — re-encoding would change literal/hex form and
-        // break the equality check.
+        // Preserve the annotation's existing Contents when present
         if (existingContents == null || existingContents.isEmpty()) {
             String altText = null;
             // Get URI from action if available
-            if (ASAtom.LINK.equals(annotation.getSubtype())){
+            if (ASAtom.LINK.equals(annotation.getSubtype())) {
                 PDAction action = annotation.getA();
                 if (action != null && action.getObject() != null && ASAtom.URI.equals(action.getSubtype())) {
                     altText = action.getStringKey(ASAtom.URI);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -351,7 +351,7 @@ public class AutoTaggingProcessor {
         return result;
     }
 
-    private static boolean needToAddToStructTree(PDAnnotation annotation, PDPage page, BoundingBox boundingBox) {
+    private static boolean needToAddAnnotationToStructTree(PDAnnotation annotation, PDPage page, BoundingBox boundingBox) {
         if (isPDF2_0) {
             Long f = annotation.getIntegerKey(ASAtom.F);
             //PDF/UA-2 rules 8.9.2.2-1, 8.9.2.2-2
@@ -375,43 +375,25 @@ public class AutoTaggingProcessor {
         // Contents authored on the annotation (accessibility text the author already
         // wrote), otherwise fall back to URI, then to "Annotation".
         String existingContents = annotation.getContents();
-        // Build a single COSString object and use it for /Contents. Hex form
-        // (isHex=true) is required because UTF-16BE code units whose low
-        // byte is 0x5C would be misparsed as a backslash escape inside a
-        // PDF literal string, corrupting non-ASCII text. UTF-16 with BOM
-        // keeps readers from interpreting the string as PDFDocEncoding.
-        if (existingContents != null && !existingContents.isEmpty()) {
-            // Preserve the annotation's existing COSString reference when
-            // present — re-encoding would change literal/hex form and
-            // break the equality check.
-            COSObject contentsObj = annotObj.getKey(ASAtom.CONTENTS);
-            if (contentsObj == null || contentsObj.getType() != COSObjType.COS_STRING) {
-                // Non-string /Contents (rare, e.g. indirect/array shape). Build a hex
-                // UTF-16 COSString from the parsed text and write it back to /Contents
-                // too so the annotation and /Alt remain byte-identical per §8.9.4.2.1.
-                COSObject linkTextObject = COSString.construct(
-                    existingContents.getBytes(StandardCharsets.UTF_16), true);
-                annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
-            }
-        } else {
+
+        // Preserve the annotation's existing COSString reference when
+        // present — re-encoding would change literal/hex form and
+        // break the equality check.
+        if (existingContents == null || existingContents.isEmpty()) {
             String altText = null;
             // Get URI from action if available
             if (ASAtom.LINK.equals(annotation.getSubtype())){
-                try {
-                    PDAction action = annotation.getA();
-                    if (action != null && action.getObject() != null && ASAtom.URI.equals(action.getSubtype())) {
-                        altText = action.getStringKey(ASAtom.URI);
-                    }
-                } catch (Exception e) {
-                    // ignore — URI not critical
+                PDAction action = annotation.getA();
+                if (action != null && action.getObject() != null && ASAtom.URI.equals(action.getSubtype())) {
+                    altText = action.getStringKey(ASAtom.URI);
                 }
             }
             if (altText == null) {
                 altText = "Annotation";
             }
-            COSObject linkTextObject = COSString.construct(
+            COSObject textObject = COSString.construct(
                 altText.getBytes(StandardCharsets.UTF_16), true);
-            annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
+            annotObj.setKey(ASAtom.CONTENTS, textObject);
         }
     }
 
@@ -425,10 +407,14 @@ public class AutoTaggingProcessor {
             if (annotObj == null || annotObj.empty()) continue;
 
             BoundingBox boundingBox = new BoundingBox(page.getPageNumber(), annotation.getRect());
-            if (needToAddToStructTree(annotation, page, boundingBox)) {
+            if (needToAddAnnotationToStructTree(annotation, page, boundingBox)) {
                 annotationBBoxesMap.put(boundingBox, annotation);
                 setAnnotationContents(annotation, annotObj);
-                pageChanged = assignStructParentToAnnotation(annotObj, cosDocument);
+                // Assign StructParent integer to annotation and register in parent tree
+                int structParentInt = currentStructParent++;
+                annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
+                cosDocument.addChangedObject(annotObj);
+                pageChanged = true;
             }
         }
         // Flush the Annots array (may be an indirect object separate from the page)
@@ -440,14 +426,6 @@ public class AutoTaggingProcessor {
             }
             cosDocument.addChangedObject(page.getObject());
         }
-    }
-
-    private static boolean assignStructParentToAnnotation(COSObject annotObj, COSDocument cosDocument) {
-        // Assign StructParent integer to annotation and register in parent tree
-        int structParentInt = currentStructParent++;
-        annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
-        cosDocument.addChangedObject(annotObj);
-        return true;
     }
 
     private static void processAnnotations(COSDocument cosDocument, COSObject seDocument, int pageNumber) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -463,6 +463,10 @@ public class AutoTaggingProcessor {
             tag = TaggedPDFConstants.ANNOT;
         }
         COSObject linkElem = addStructElement(parent, cosDocument, tag, pageNumber);
+        COSObject contents = annotation.getKey(ASAtom.CONTENTS);
+        if (contents != null && !contents.empty() && contents.getType() == COSObjType.COS_STRING) {
+            linkElem.setKey(ASAtom.ALT, contents);
+        }
         linkElem.setKey(ASAtom.ALT, annotation.getKey(ASAtom.CONTENTS));
         annotationStructParents.put(annotation.getIntegerKey(ASAtom.STRUCT_PARENT).intValue(), linkElem);
         // Create OBJR pointing to the annotation

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -100,7 +100,7 @@ public class AutoTaggingProcessor {
         for (OperatorStreamKey operatorStreamKey : structParents.keySet()) {
             structParentsIntegers.put(operatorStreamKey, currentStructParent++);
         }
-        List<org.verapdf.pd.PDPage> rawPages = document.getPages();
+        List<PDPage> rawPages = document.getPages();
         for (int pageNumber = 0; pageNumber < rawPages.size(); pageNumber++) {
             PDPage page = rawPages.get(pageNumber);
             if (isPDF2_0) {
@@ -351,6 +351,70 @@ public class AutoTaggingProcessor {
         return result;
     }
 
+    private static boolean needToAddToStructTree(PDAnnotation annotation, PDPage page, BoundingBox boundingBox) {
+        if (isPDF2_0) {
+            Long f = annotation.getIntegerKey(ASAtom.F);
+            //PDF/UA-2 rules 8.9.2.2-1, 8.9.2.2-2
+            if (f != null && (((f & 1) == 0) || (f & 32) == 0 || (f & 256) == 256)) {
+                return false;
+            }
+            //PDF/UA-2 rules 8.10.1-1, 8.9.2.4.13-1, 8.9.2.4.16-1, 8.9.2.3-1, 8.2.5.20-1
+            return (ASAtom.WIDGET.equals(annotation.getSubtype()) && boundingBox.getHeight() != 0 && boundingBox.getWidth() != 0)
+                || ASAtom.WATERMARK.equals(annotation.getSubtype()) || annotation.isMarkup() || ASAtom.LINK.equals(annotation.getSubtype());
+        } else {
+            //PDF/UA-1 rules 7.18.1-1, 7.18.4-1, 7.18.5-1
+            return !ASAtom.PRINTER_MARK.equals(annotation.getSubtype()) &&
+                !PDAnnotation.isOutsideCropBox(page, annotation) && PDAnnotation.isVisibleAnnotation(annotation);
+        }
+    }
+
+    private static void setAnnotationContents(PDAnnotation annotation, COSObject annotObj) {
+        // Create Annotation struct element
+        // PDF/UA-2 clause 8.9.4.2.1 requires the annotation's Contents and the enclosing
+        // struct element's Alt to be identical when both are present. Prefer any existing
+        // Contents authored on the annotation (accessibility text the author already
+        // wrote), otherwise fall back to URI, then to "Annotation".
+        String existingContents = annotation.getContents();
+        // Build a single COSString object and use it for /Contents. Hex form
+        // (isHex=true) is required because UTF-16BE code units whose low
+        // byte is 0x5C would be misparsed as a backslash escape inside a
+        // PDF literal string, corrupting non-ASCII text. UTF-16 with BOM
+        // keeps readers from interpreting the string as PDFDocEncoding.
+        if (existingContents != null && !existingContents.isEmpty()) {
+            // Preserve the annotation's existing COSString reference when
+            // present — re-encoding would change literal/hex form and
+            // break the equality check.
+            COSObject contentsObj = annotObj.getKey(ASAtom.CONTENTS);
+            if (contentsObj == null || contentsObj.getType() != COSObjType.COS_STRING) {
+                // Non-string /Contents (rare, e.g. indirect/array shape). Build a hex
+                // UTF-16 COSString from the parsed text and write it back to /Contents
+                // too so the annotation and /Alt remain byte-identical per §8.9.4.2.1.
+                COSObject linkTextObject = COSString.construct(
+                    existingContents.getBytes(StandardCharsets.UTF_16), true);
+                annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
+            }
+        } else {
+            String altText = null;
+            // Get URI from action if available
+            if (ASAtom.LINK.equals(annotation.getSubtype())){
+                try {
+                    PDAction action = annotation.getA();
+                    if (action != null && action.getObject() != null && ASAtom.URI.equals(action.getSubtype())) {
+                        altText = action.getStringKey(ASAtom.URI);
+                    }
+                } catch (Exception e) {
+                    // ignore — URI not critical
+                }
+            }
+            if (altText == null) {
+                altText = "Annotation";
+            }
+            COSObject linkTextObject = COSString.construct(
+                altText.getBytes(StandardCharsets.UTF_16), true);
+            annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
+        }
+    }
+
     private static void processAnnotations(PDDocument document, COSDocument cosDocument, int pageNumber) {
         PDPage page = document.getPages().get(pageNumber);
         List<PDAnnotation> annotations = page.getAnnotations();
@@ -360,68 +424,10 @@ public class AutoTaggingProcessor {
             COSObject annotObj = annotation.getObject();
             if (annotObj == null || annotObj.empty()) continue;
 
-            if (isPDF2_0) {
-                //PDF/UA-2 rules 8.10.1-1, 8.9.2.4.16-1, 8.9.2.3-1
-                if (ASAtom.WIDGET.equals(annotation.getSubtype()) || ASAtom.WATERMARK.equals(annotation.getSubtype()) ||
-                    annotation.isMarkup()) {
-                    annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
-                    pageChanged = assignStructParentToAnnotation(annotObj, cosDocument);
-                }
-            } else {
-                //PDF/UA-1 rules 7.18.1-1 + 7.18.4-1
-                if (!ASAtom.LINK.equals(annotation.getSubtype()) &&
-                    !ASAtom.PRINTER_MARK.equals(annotation.getSubtype()) &&
-                    !PDAnnotation.isOutsideCropBox(page, annotation) && PDAnnotation.isVisibleAnnotation(annotation)) {
-                    annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
-                    pageChanged = assignStructParentToAnnotation(annotObj, cosDocument);
-                }
-            }
-            //PDF/UA-1 rule 7.18.5-1 / PDF/UA-2 rule 8.2.5.20-1
-            //TODO: check if artifact in PDF/UA-2
-            if ((ASAtom.LINK.equals(annotation.getSubtype()) && isPDF2_0) ||
-                (ASAtom.LINK.equals(annotation.getSubtype()) && !isPDF2_0 &&
-                    !PDAnnotation.isOutsideCropBox(page, annotation) && PDAnnotation.isVisibleAnnotation(annotation))) {
-                annotationBBoxesMap.put(new BoundingBox(page.getPageNumber(), annotation.getRect()), annotation);
-                // Get URI from action if available
-                String uriString = null;
-                try {
-                    PDAction action = annotation.getA();
-                    if (action != null && action.getObject() != null && ASAtom.URI.equals(action.getSubtype())) {
-                        uriString = action.getStringKey(ASAtom.URI);
-                    }
-                } catch (Exception e) {
-                    // ignore — URI not critical
-                }
-                // Create Link struct element
-                // PDF/UA-2 clause 8.9.4.2.1 requires the annotation's Contents and the enclosing
-                // struct element's Alt to be identical when both are present. Prefer any existing
-                // Contents authored on the annotation (accessibility text the author already
-                // wrote), otherwise fall back to URI, then to "Link".
-                String existingContents = annotation.getContents();
-                // Build a single COSString object and use it for /Contents. Hex form
-                // (isHex=true) is required because UTF-16BE code units whose low
-                // byte is 0x5C would be misparsed as a backslash escape inside a
-                // PDF literal string, corrupting non-ASCII text. UTF-16 with BOM
-                // keeps readers from interpreting the string as PDFDocEncoding.
-                if (existingContents != null && !existingContents.isEmpty()) {
-                    // Preserve the annotation's existing COSString reference when
-                    // present — re-encoding would change literal/hex form and
-                    // break the equality check.
-                    COSObject contentsObj = annotObj.getKey(ASAtom.CONTENTS);
-                    if (contentsObj == null || contentsObj.getType() != COSObjType.COS_STRING) {
-                        // Non-string /Contents (rare, e.g. indirect/array shape). Build a hex
-                        // UTF-16 COSString from the parsed text and write it back to /Contents
-                        // too so the annotation and /Alt remain byte-identical per §8.9.4.2.1.
-                        COSObject linkTextObject = COSString.construct(
-                            existingContents.getBytes(StandardCharsets.UTF_16), true);
-                        annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
-                    }
-                } else {
-                    String altText = uriString != null ? uriString : "Link";
-                    COSObject linkTextObject = COSString.construct(
-                        altText.getBytes(StandardCharsets.UTF_16), true);
-                    annotObj.setKey(ASAtom.CONTENTS, linkTextObject);
-                }
+            BoundingBox boundingBox = new BoundingBox(page.getPageNumber(), annotation.getRect());
+            if (needToAddToStructTree(annotation, page, boundingBox)) {
+                annotationBBoxesMap.put(boundingBox, annotation);
+                setAnnotationContents(annotation, annotObj);
                 pageChanged = assignStructParentToAnnotation(annotObj, cosDocument);
             }
         }
@@ -462,13 +468,12 @@ public class AutoTaggingProcessor {
         } else {
             tag = TaggedPDFConstants.ANNOT;
         }
-        COSObject linkElem = addStructElement(parent, cosDocument, tag, pageNumber);
+        COSObject structElement = addStructElement(parent, cosDocument, tag, pageNumber);
         COSObject contents = annotation.getKey(ASAtom.CONTENTS);
         if (contents != null && !contents.empty() && contents.getType() == COSObjType.COS_STRING) {
-            linkElem.setKey(ASAtom.ALT, contents);
+            structElement.setKey(ASAtom.ALT, contents);
         }
-        linkElem.setKey(ASAtom.ALT, annotation.getKey(ASAtom.CONTENTS));
-        annotationStructParents.put(annotation.getIntegerKey(ASAtom.STRUCT_PARENT).intValue(), linkElem);
+        annotationStructParents.put(annotation.getIntegerKey(ASAtom.STRUCT_PARENT).intValue(), structElement);
         // Create OBJR pointing to the annotation
         COSObject objr = COSDictionary.construct();
         objr.setKey(ASAtom.TYPE, COSName.construct(ASAtom.OBJR));
@@ -476,9 +481,9 @@ public class AutoTaggingProcessor {
         objr.setKey(ASAtom.PG, cosDocument.getPDDocument().getPages().get(pageNumber).getObject());
         COSObject kArray = COSArray.construct();
         kArray.add(objr);
-        linkElem.setKey(ASAtom.K, kArray);
+        structElement.setKey(ASAtom.K, kArray);
         if (streamInfos != null) {
-            addMcidChildren(streamInfos, pageNumber, linkElem);
+            addMcidChildren(streamInfos, pageNumber, structElement);
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -369,28 +369,22 @@ public class AutoTaggingProcessor {
     }
 
     private static void setAnnotationContents(PDAnnotation annotation, COSObject annotObj) {
-        // Create Annotation struct element
-        // Various PDF/UA riles require the annotation's Contents and the enclosing
-        // struct element's Alt to be identical when both are present. Prefer any existing
-        // Contents authored on the annotation (accessibility text the author already
-        // wrote), otherwise fall back to URI (for Link only), then to "Annotation".
         String existingContents = annotation.getContents();
-
         // Preserve the annotation's existing Contents when present
         if (existingContents == null || existingContents.isEmpty()) {
-            String altText = null;
+            String contentsText = null;
             // Get URI from action if available
             if (ASAtom.LINK.equals(annotation.getSubtype())) {
                 PDAction action = annotation.getA();
                 if (action != null && action.getObject() != null && ASAtom.URI.equals(action.getSubtype())) {
-                    altText = action.getStringKey(ASAtom.URI);
+                    contentsText = action.getStringKey(ASAtom.URI);
                 }
             }
-            if (altText == null) {
-                altText = "Annotation";
+            if (contentsText == null) {
+                contentsText = "Annotation";
             }
             COSObject textObject = COSString.construct(
-                altText.getBytes(StandardCharsets.UTF_16), true);
+                contentsText.getBytes(StandardCharsets.UTF_16), true);
             annotObj.setKey(ASAtom.CONTENTS, textObject);
         }
     }
@@ -445,6 +439,11 @@ public class AutoTaggingProcessor {
             tag = TaggedPDFConstants.ANNOT;
         }
         COSObject structElement = addStructElement(parent, cosDocument, tag, pageNumber);
+
+        // Various PDF/UA riles require the annotation's Contents and the enclosing
+        // struct element's Alt to be identical when both are present. Prefer any existing
+        // Contents authored on the annotation (accessibility text the author already
+        // wrote), otherwise fall back to URI (for Link only), then to "Annotation".
         COSObject contents = annotation.getKey(ASAtom.CONTENTS);
         if (contents != null && !contents.empty() && contents.getType() == COSObjType.COS_STRING) {
             structElement.setKey(ASAtom.ALT, contents);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -372,6 +372,9 @@ public class AutoTaggingProcessor {
         String existingContents = annotation.getContents();
         // Preserve the annotation's existing Contents when present
         if (existingContents == null || existingContents.isEmpty()) {
+            // Prefer any existing Contents authored on the annotation (accessibility
+            // text the author already wrote), otherwise fall back to URI (for Link only),
+            // then to "Annotation".
             String contentsText = null;
             // Get URI from action if available
             if (ASAtom.LINK.equals(annotation.getSubtype())) {
@@ -380,6 +383,7 @@ public class AutoTaggingProcessor {
                     contentsText = action.getStringKey(ASAtom.URI);
                 }
             }
+            //TODO Use AI to generate descriptions
             if (contentsText == null) {
                 contentsText = "Annotation";
             }
@@ -441,9 +445,7 @@ public class AutoTaggingProcessor {
         COSObject structElement = addStructElement(parent, cosDocument, tag, pageNumber);
 
         // Various PDF/UA riles require the annotation's Contents and the enclosing
-        // struct element's Alt to be identical when both are present. Prefer any existing
-        // Contents authored on the annotation (accessibility text the author already
-        // wrote), otherwise fall back to URI (for Link only), then to "Annotation".
+        // struct element's Alt to be identical when both are present.
         COSObject contents = annotation.getKey(ASAtom.CONTENTS);
         if (contents != null && !contents.empty() && contents.getType() == COSObjType.COS_STRING) {
             structElement.setKey(ASAtom.ALT, contents);
@@ -708,6 +710,7 @@ public class AutoTaggingProcessor {
     }
 
 
+    //PDF/UA-1 rule 7.3-1 / PDF/UA-2 rule 8.2.5.28.2-1
     private static COSObject createFigureStructElemReturning(ImageChunk image, COSObject parent, COSDocument cosDocument) {
         COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE, image.getPageNumber());
         double[] bbox = {image.getLeftX(), image.getBottomY(), image.getRightX(), image.getTopY()};
@@ -731,6 +734,7 @@ public class AutoTaggingProcessor {
         return figureObject;
     }
 
+    //PDF/UA-1 rule 7.7-1
     private static void createFormulaStructElem(SemanticFormula formula, COSObject parent, COSDocument cosDocument) {
         COSObject formulaObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FORMULA, formula.getPageNumber());
         double[] bbox = {formula.getLeftX(), formula.getBottomY(), formula.getRightX(), formula.getTopY()};

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,7 +58,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <verapdf.version>1.31.54</verapdf.version>
+        <verapdf.version>1.31.55</verapdf.version>
         <verapdf.wcag.algs.version>1.31.18</verapdf.wcag.algs.version>
         <jackson.databind.version>2.21.1</jackson.databind.version>
         <junit.jupiter.version>5.14.3</junit.jupiter.version>


### PR DESCRIPTION
PDF/UA-1 rule 7.18.1-1

<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader annotation support: widgets, links, markups and watermarks are recognized and tagged by subtype for improved accessibility.

* **Refactor**
  * Unified, subtype-aware annotation processing with PDF-version and page-visibility rules to create correct structural tags.

* **Bug Fixes**
  * Consistent Alt/Contents handling: string contents used for Alt, non-string contents normalized to ensure stable output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->