### PR TITLE
fix(markdown): wrap image link destinations in angle brackets to handle unsafe filename chars

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -150,6 +150,39 @@ public class MarkdownGenerator implements Closeable {
         }
     }
 
+    /**
+     * Wraps an image relative path as a CommonMark angle-bracket link destination
+     * (`<...>`). The bare form `(my paper.png)` is terminated by the first space or
+     * unbalanced parenthesis, so paths inheriting filenames with spaces, parens, or
+     * brackets break in renderers (#405). The angle-bracket form is the
+     * spec-recommended way to embed such paths and lets the on-disk path stay
+     * byte-identical to the rendered link, which preserves user intent for both the
+     * default `<stem>_images/` directory and any `--image-dir` value.
+     *
+     * Only `<`, `>`, and `\` are reserved inside the angle-bracket form; escape
+     * those with a backslash. Newlines have no representable form in a link
+     * destination — replace them with spaces so the destination stays well-formed.
+     */
+    static String formatMarkdownLinkDestination(String path) {
+        if (path == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder(path.length() + 2);
+        sb.append('<');
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '<' || c == '>' || c == '\\') {
+                sb.append('\\').append(c);
+            } else if (c == '\n' || c == '\r') {
+                sb.append(' ');
+            } else {
+                sb.append(c);
+            }
+        }
+        sb.append('>');
+        return sb.toString();
+    }
+
     protected void writeImage(ImageChunk image) {
         try {
             String absolutePath = String.format(MarkdownSyntax.IMAGE_FILE_NAME_FORMAT, StaticLayoutContainers.getImagesDirectory(), File.separator, image.getIndex(), imageFormat);
@@ -164,7 +197,7 @@ public class MarkdownGenerator implements Closeable {
                         LOGGER.log(Level.WARNING, "Failed to convert image to Base64: {0}", absolutePath);
                     }
                 } else {
-                    imageSource = relativePath;
+                    imageSource = formatMarkdownLinkDestination(relativePath);
                 }
                 if (imageSource != null) {
                     String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
@@ -198,7 +231,7 @@ public class MarkdownGenerator implements Closeable {
                         LOGGER.log(Level.WARNING, "Failed to convert image to Base64: {0}", absolutePath);
                     }
                 } else {
-                    imageSource = relativePath;
+                    imageSource = formatMarkdownLinkDestination(relativePath);
                 }
                 if (imageSource != null) {
                     String altText = picture.hasDescription()

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/ImageDirIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/ImageDirIntegrationTest.java
@@ -157,4 +157,99 @@ class ImageDirIntegrationTest {
                     "Markdown should reference custom image directory");
         }
     }
+
+    /**
+     * Regression test for #405: when the input filename contains characters that
+     * have special meaning in CommonMark link destinations (spaces, parens, etc.),
+     * the on-disk directory keeps the original filename and the rendered Markdown
+     * link wraps the destination in angle brackets per CommonMark §6.4 so it stays
+     * a single, parseable token.
+     */
+    @Test
+    void testDefaultImageDir_markdownLinkUsesAngleBracketDestination() throws Exception {
+        File samplePdf = new File(SAMPLE_PDF_WITH_IMAGES);
+        if (!samplePdf.exists()) {
+            System.out.println("Skipping test: Sample PDF not found");
+            return;
+        }
+
+        // Copy the sample PDF under a filename containing CommonMark-reserved chars.
+        String unsafeStem = "my paper (draft) [v2]";
+        Path renamed = tempDir.resolve(unsafeStem + ".pdf");
+        Files.copy(samplePdf.toPath(), renamed);
+
+        Path outputDir = tempDir.resolve("output");
+
+        Config config = new Config();
+        config.setOutputFolder(outputDir.toString());
+        config.setImageOutput(Config.IMAGE_OUTPUT_EXTERNAL);
+        config.setGenerateJSON(false);
+        config.setAddImageToMarkdown(true);
+
+        DocumentProcessor.processFile(renamed.toAbsolutePath().toString(), config);
+
+        // The on-disk image directory keeps the original filename — we don't rewrite
+        // user input. The rendered destination uses the angle-bracket form.
+        Path imageDir = outputDir.resolve(unsafeStem + "_images");
+        assertTrue(Files.exists(imageDir),
+                "On-disk image directory should keep the original filename");
+
+        Path mdOutput = outputDir.resolve(unsafeStem + ".md");
+        assertTrue(Files.exists(mdOutput), "Markdown output should exist");
+
+        String mdContent = Files.readString(mdOutput);
+        assertTrue(mdContent.contains("!["),
+                "Test precondition: sample must produce markdown image syntax");
+
+        // Inside `<...>` the path stays byte-identical to the on-disk directory.
+        String expectedDestination = "<" + unsafeStem + "_images/imageFile";
+        assertTrue(mdContent.contains(expectedDestination),
+                "Markdown link should wrap the path in angle brackets; expected '" + expectedDestination + "'");
+        // The raw unwrapped form must NOT appear inside a link destination — that
+        // is the exact bug #405 reports.
+        assertFalse(mdContent.contains("(" + unsafeStem + "_images/"),
+                "Raw unwrapped directory name must not appear as a Markdown link destination");
+    }
+
+    /**
+     * #405 reproduces equally through the `--image-dir` path. A user-provided
+     * directory name with spaces or parens lands verbatim on disk (we respect the
+     * user's input) and the Markdown link wraps it in angle brackets.
+     */
+    @Test
+    void testCustomImageDir_markdownLinkUsesAngleBracketDestination() throws Exception {
+        File samplePdf = new File(SAMPLE_PDF_WITH_IMAGES);
+        if (!samplePdf.exists()) {
+            System.out.println("Skipping test: Sample PDF not found");
+            return;
+        }
+
+        Path customImageDir = tempDir.resolve("my pictures (v2)");
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setImageDir(customImageDir.toString());
+        config.setImageOutput(Config.IMAGE_OUTPUT_EXTERNAL);
+        config.setGenerateJSON(false);
+        config.setAddImageToMarkdown(true);
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        // On-disk directory keeps the user-provided name verbatim.
+        assertTrue(Files.exists(customImageDir),
+                "Custom image directory should keep the user-provided name");
+
+        Path mdOutput = tempDir.resolve(SAMPLE_PDF_BASENAME + ".md");
+        assertTrue(Files.exists(mdOutput), "Markdown output should exist");
+
+        String mdContent = Files.readString(mdOutput);
+        assertTrue(mdContent.contains("!["),
+                "Test precondition: sample must produce markdown image syntax");
+
+        String expectedDestination = "<my pictures (v2)/imageFile";
+        assertTrue(mdContent.contains(expectedDestination),
+                "Markdown link should wrap the custom dir in angle brackets; expected '" + expectedDestination + "'");
+        assertFalse(mdContent.contains("(my pictures (v2)/"),
+                "Raw unwrapped custom-dir name must not appear as a Markdown link destination");
+    }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
@@ -105,4 +105,79 @@ public class MarkdownGeneratorTest {
         sb.append(MarkdownSyntax.SPACE);
         return sb.toString();
     }
+
+    // ----- formatMarkdownLinkDestination (#405) -----
+
+    @Test
+    void testFormatLinkDestination_wrapsSafePathsInAngleBrackets() {
+        // Even paths with no reserved chars get wrapped — uniform output is easier
+        // to reason about than "sometimes bare, sometimes angle-bracketed".
+        assertEquals("<imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("imageFile1.png"));
+        assertEquals("<output/sub.dir/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("output/sub.dir/imageFile1.png"));
+    }
+
+    @Test
+    void testFormatLinkDestination_keepsSpacesVerbatim() {
+        // The whole point: inside `<...>`, spaces are legal per CommonMark §6.4.
+        assertEquals("<my paper_images/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("my paper_images/imageFile1.png"));
+    }
+
+    @Test
+    void testFormatLinkDestination_keepsParensAndBracketsVerbatim() {
+        assertEquals("<draft (v2) [rc]/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("draft (v2) [rc]/imageFile1.png"));
+    }
+
+    @Test
+    void testFormatLinkDestination_keepsApostropheAndDoubleQuoteVerbatim() {
+        // Common real-world filename — `John's "draft".pdf`.
+        assertEquals("<John's \"draft\"_images/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("John's \"draft\"_images/imageFile1.png"));
+    }
+
+    @Test
+    void testFormatLinkDestination_keepsPercentAndHashVerbatim() {
+        // No percent-decoding happens inside `<...>`, so a literal `%` or `#`
+        // in a directory name renders correctly without double-encoding.
+        assertEquals("<100% (final)#1/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("100% (final)#1/imageFile1.png"));
+    }
+
+    @Test
+    void testFormatLinkDestination_escapesAngleBracketsInPath() {
+        // `<` and `>` inside the destination must be backslash-escaped — they
+        // would otherwise terminate the angle-bracket form prematurely.
+        assertEquals("<a\\<b\\>c/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("a<b>c/imageFile1.png"));
+    }
+
+    @Test
+    void testFormatLinkDestination_escapesBackslashInPath() {
+        // Backslash itself must be escaped to round-trip cleanly.
+        assertEquals("<a\\\\b/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("a\\b/imageFile1.png"));
+    }
+
+    @Test
+    void testFormatLinkDestination_replacesNewlinesWithSpaces() {
+        // Newlines have no representable form in a link destination per spec.
+        assertEquals("<a b/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("a\nb/imageFile1.png"));
+        assertEquals("<a b/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("a\rb/imageFile1.png"));
+    }
+
+    @Test
+    void testFormatLinkDestination_passesThroughNonAscii() {
+        assertEquals("<문서/imageFile1.png>",
+                MarkdownGenerator.formatMarkdownLinkDestination("문서/imageFile1.png"));
+    }
+
+    @Test
+    void testFormatLinkDestination_handlesNull() {
+        assertNull(MarkdownGenerator.formatMarkdownLinkDestination(null));
+    }
 }


### PR DESCRIPTION
## Objective
> "When the input PDF filename contains spaces, the extracted markdown references images via a relative path that inherits that filename — also containing spaces. Most markdown renderers stop parsing the path at the first space, so images fail to load silently."

A user processing `my paper.pdf` (or any filename with spaces, parens, brackets, etc.) gets a Markdown file where every image link silently fails to render in VS Code, GitHub, and similar viewers. The same class of bug also reproduces through `--image-dir "my pictures"`, where the user's explicit path is well-formed on disk but breaks in the rendered Markdown.

Fixes [opendataloader-project/opendataloader-pdf#405](https://github.com/opendataloader-project/opendataloader-pdf/issues/405)

## Approach
Wrap the relative path in the CommonMark angle-bracket link-destination form (`<...>`) at the Markdown emit site (`writeImage` / `writePicture` in `MarkdownGenerator`), instead of rewriting the on-disk directory name.

Why this layer and this form:
- **Angle-bracket is the spec-recommended way.** CommonMark §6.4 explicitly admits the angle-bracket form for destinations containing spaces, parens, brackets, etc. The bare form `(...)` would terminate at the first reserved character. Only `<`, `>`, and `\` need escaping inside `<...>`, and we backslash-escape those; newlines have no representable form and are replaced with spaces.
- **The on-disk path stays byte-identical to the rendered link.** This preserves user intent for both the default `<stem>_images/` directory and any `--image-dir` value, and lets users locate their images on disk by reading the link.
- **JSON `source` fields are left raw.** Downstream consumers treat that field as a filesystem path; encoding or wrapping would break their lookups. Different sublanguage, different escape rules.
- **HTML output is left unchanged.** Quoted attribute values legally accept spaces/parens/brackets and the user agent handles `src` URL encoding when the page is rendered. Verified end-to-end with a local HTTP server.

## Evidence
Built the CLI locally and ran the full repro path on three scenarios. Also re-ran the full core test suite (566 tests) to confirm no regression.

| Scenario | Expected | Actual |
|----------|----------|--------|
| `my paper.pdf` (default dir, before fix) | Image link contains literal space → renderer truncates | `![image 1](my paper_images/imageFile1.png)` — broken in VS Code/GitHub |
| `my paper.pdf` (default dir, after fix) | On-disk dir verbatim; MD link in angle brackets | On-disk `my paper_images/`, MD link `![image 1](<my paper_images/imageFile1.png>)` ✅ |
| `draft (v2) [rc].pdf` (after fix) | Parens & brackets verbatim inside `<...>` | MD link `![image 1](<draft (v2) [rc]_images/imageFile1.png>)` ✅ |
| `--image-dir "my pictures (v2)"` (after fix) | User's path verbatim on disk; MD link in angle brackets | On-disk `my pictures (v2)/`, MD link `<my pictures (v2)/imageFile1.png>` ✅ |
| JSON `source` field (after fix) | Raw filesystem path (no wrapping) | `"source" : "my paper_images/imageFile1.png"` ✅ |
| `mvn -pl opendataloader-pdf-core -am test` | All pass | 566 tests, 0 failures, BUILD SUCCESS ✅ |

Unit tests in `MarkdownGeneratorTest` cover the helper directly: safe paths still get wrapped (uniform output), spaces / parens / brackets / apostrophes / quotes / literal `%` / `#` all pass through verbatim inside `<...>`, literal `<` / `>` / `\` in the path get backslash-escaped, newlines collapse to spaces, non-ASCII passes through, null returns null. Integration tests in `ImageDirIntegrationTest` exercise the full pipeline end-to-end for both default and `--image-dir` paths with reserved characters.

## Notes
- Supersedes #411, which took the alternative approach of rewriting the on-disk directory name. That approach silently mutates explicit user input via `--image-dir` (a CLI hygiene violation) and reproduces the same bug class through the custom-dir door.
- An earlier revision of this PR percent-encoded the link instead of using the angle-bracket form. The angle-bracket form is the CommonMark spec's intended idiom for this case, keeps the on-disk path byte-identical to the link, and avoids cross-format encoding considerations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown image link destinations are now formatted safely: special characters (including <, >, backslashes), spaces and newlines are normalized/escaped and wrapped in angle brackets so links render reliably.

* **Tests**
  * Added integration and unit tests validating Markdown image-link formatting for paths with reserved characters and newline variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->