### PR TITLE
cleanup: remove dead exception-handling paths from closePdfResources

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -75,28 +75,15 @@ public class DocumentProcessor {
      * - Clears static containers to remove lingering references
      * Should always be called in a finally block.
      */
-    private static void closePdfResources() throws Exception {
-        Exception closeFailure = null;
-        PDDocument document = StaticResources.getDocument();
-        if (document != null) {
-            try {
+    private static void closePdfResources() {
+        clearCleanupStep("PDDocument", () -> {
+            PDDocument document = StaticResources.getDocument();
+            if (document != null) {
                 document.close();
-            } catch (Exception e) {
-                closeFailure = e;
             }
-        }
+        });
+        clearCleanupStep("ContrastRatioConsumer", StaticLayoutContainers::closeContrastRatioConsumer);
 
-        try {
-            StaticLayoutContainers.closeContrastRatioConsumer();
-        } catch (Exception e) {
-            if (closeFailure != null) {
-                closeFailure.addSuppressed(e);
-            } else {
-                closeFailure = e;
-            }
-        }
-
-        // cleanup static containers
         clearCleanupStep("StaticResources", StaticResources::clear);
         clearCleanupStep("StaticContainers", () -> StaticContainers.updateContainers(null));
         clearCleanupStep(
@@ -107,10 +94,6 @@ public class DocumentProcessor {
         clearCleanupStep("StaticStorages", StaticStorages::clearAllContainers);
         clearCleanupStep("StaticCoreContainers", StaticCoreContainers::clearAllContainers);
         clearCleanupStep("StaticXmpCoreContainers", StaticXmpCoreContainers::clearAllContainers);
-
-        if (closeFailure != null) {
-            throw closeFailure;
-        }
     }
 
     /**
@@ -149,7 +132,6 @@ public class DocumentProcessor {
      * @throws IOException if unable to process the file
      */
     public static ProcessingResult processFileWithResult(String inputPdfName, Config config) throws IOException {
-        Throwable processingFailure = null;
         try {
             // Phase 1: Extract
             ExtractionResult extraction = extractContents(inputPdfName, config);
@@ -160,25 +142,11 @@ public class DocumentProcessor {
             long outputNs = System.nanoTime() - t0;
 
             return new ProcessingResult(extraction.getHybridTimings(), extraction.getExtractionNs(), outputNs);
-        } catch (IOException | RuntimeException | Error e) {
-            processingFailure = e;
-            throw e;
         } finally {
-            // Ensures resources are always released, even if processing throws an exception
-            try {
-                closePdfResources();
-            } catch (Exception closeException) {
-                LOGGER.log(Level.WARNING, "Error during PDF resource cleanup", closeException);
-                if (processingFailure != null) {
-                    processingFailure.addSuppressed(closeException);
-                } else {
-                    if (closeException instanceof IOException) {
-                        throw (IOException) closeException;
-                    } else {
-                        throw new IOException("Failed to close PDF resources", closeException);
-                    }
-                }
-            }
+            // Always release resources, even if processing threw. closePdfResources
+            // logs and swallows per-step failures so cleanup cannot mask the original
+            // processing exception.
+            closePdfResources();
         }
     }
 


### PR DESCRIPTION
## Objective
> "`closePdfResources` declares `throws Exception` and accumulates `closeFailure` from `document.close()` and `closeContrastRatioConsumer()`, but neither call can throw — both swallow exceptions internally with no `throws` clause. The matching catch in the caller's finally block is also unreachable."

#410 added `closePdfResources()` with defensive exception-handling around `PDDocument.close()` and `StaticLayoutContainers.closeContrastRatioConsumer()`. After the merge, a closer reading of the call graph (and `javap` on verapdf's `parser-1.31.14.jar`) showed:

- `PDDocument.close()` is declared `public void close()` with no `throws`. verapdf wraps `SeekableInputStream.close()` in its own try/catch internally.
- `StaticLayoutContainers.closeContrastRatioConsumer()` already wraps the underlying call in try/catch and only logs at WARNING.

So the accumulator (`closeFailure` capture, `addSuppressed`, conditional re-throw) and the matching try/catch in the caller's finally block were dead code in practice.

Fixes [opendataloader-project/opendataloader-pdf#470](https://github.com/opendataloader-project/opendataloader-pdf/issues/470)

## Approach
Route both close calls through the existing `clearCleanupStep` helper so they share the same per-step isolation as the static-container resets. The method now declares no `throws` and the caller's finally block collapses to a single line.

Behaviorally equivalent:
- Cleanup is still always invoked.
- Per-step isolation still prevents one failure from aborting the rest.
- Processing exceptions still surface unchanged. Cleanup can no longer mask them since it no longer throws.

## Evidence
Built locally and re-ran the file-lock smoke test from #408.

| Scenario | Expected | Actual |
|----------|----------|--------|
| `mvn -pl opendataloader-pdf-core -am test` | All pass, no regression | ✅ 566 tests, 0 failures, BUILD SUCCESS |
| `processFile()` then `lsof -p $PID` | Input PDF + tmp_pdf_file FDs released | ✅ neither FD present after `processFile` returned |
| `git diff --stat` | Net deletion (dead code removed) | ✅ -42 / +10 in DocumentProcessor.java |

The simplified `closePdfResources` retains all the user-visible behavior of #410 (file lock release, idempotent cleanup, isolated per-step failures) while removing exception-handling paths that cannot fire under any of the currently-imported verapdf versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF processing error handling to gracefully manage cleanup failures by logging warnings instead of propagating exceptions. This enhances reliability and prevents processing interruptions due to resource cleanup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->