### PR TITLE
fix(node): split CLI streaming from library API to prevent stdout double-write

### DIFF
--- a/node/opendataloader-pdf/src/cli.ts
+++ b/node/opendataloader-pdf/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { Command, CommanderError } from 'commander';
-import { convert } from './index.js';
+import { _runForCli } from './index.js';
 import { CliOptions, buildConvertOptions } from './convert-options.generated.js';
 import { registerCliOptions } from './cli-options.generated.js';
 
@@ -56,13 +56,9 @@ async function main(): Promise<number> {
   const convertOptions = buildConvertOptions(cliOptions);
 
   try {
-    const output = await convert(inputPaths, convertOptions);
-    if (output && !convertOptions.quiet) {
-      process.stdout.write(output);
-      if (!output.endsWith('\n')) {
-        process.stdout.write('\n');
-      }
-    }
+    // _runForCli streams stdout/stderr to the parent process as they arrive;
+    // we deliberately do not re-print anything here. (Issue #398.)
+    await _runForCli(inputPaths, convertOptions);
     return 0;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/node/opendataloader-pdf/src/index.ts
+++ b/node/opendataloader-pdf/src/index.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
+import { StringDecoder } from 'string_decoder';
 import { fileURLToPath } from 'url';
 
 // Re-export types and utilities from auto-generated file
@@ -15,6 +16,11 @@ const __dirname = path.dirname(__filename);
 const JAR_NAME = 'opendataloader-pdf-cli.jar';
 
 interface JarExecutionOptions {
+  /**
+   * When true, forwards Java's stdout and stderr chunks to the parent
+   * process in real time as well as accumulating them. Used by the bundled
+   * CLI so long-running conversions show progress as it happens.
+   */
   streamOutput?: boolean;
 }
 
@@ -37,24 +43,55 @@ function executeJar(args: string[], executionOptions: JarExecutionOptions = {}):
 
     let stdout = '';
     let stderr = '';
+    // StringDecoder buffers incomplete multi-byte UTF-8 sequences across
+    // chunk boundaries — Buffer.toString() alone would emit replacement
+    // characters when, e.g., a 3-byte Korean codepoint splits across two
+    // 'data' events. One decoder per stream so they don't share state.
+    const stdoutDecoder = new StringDecoder('utf8');
+    const stderrDecoder = new StringDecoder('utf8');
 
-    javaProcess.stdout.on('data', (data) => {
-      const chunk = data.toString();
+    javaProcess.stdout.on('data', (data: Buffer) => {
+      const chunk = stdoutDecoder.write(data);
+      if (chunk.length === 0) return;
       if (streamOutput) {
+        // Stream-only: don't also accumulate, or a multi-hour conversion
+        // would buffer its entire (potentially gigabyte) stdout in memory
+        // for no consumer.
         process.stdout.write(chunk);
+      } else {
+        stdout += chunk;
       }
-      stdout += chunk;
     });
 
-    javaProcess.stderr.on('data', (data) => {
-      const chunk = data.toString();
+    javaProcess.stderr.on('data', (data: Buffer) => {
+      const chunk = stderrDecoder.write(data);
+      if (chunk.length === 0) return;
       if (streamOutput) {
         process.stderr.write(chunk);
       }
+      // stderr is always accumulated (progress logs are small and we need
+      // them for error messages on non-zero exit).
       stderr += chunk;
     });
 
     javaProcess.on('close', (code) => {
+      // Flush any trailing bytes the decoder is still holding (always emit
+      // them — if we drop them on error paths, error messages with non-ASCII
+      // characters lose their tail).
+      const stdoutTail = stdoutDecoder.end();
+      const stderrTail = stderrDecoder.end();
+      if (stdoutTail.length > 0) {
+        if (streamOutput) {
+          process.stdout.write(stdoutTail);
+        } else {
+          stdout += stdoutTail;
+        }
+      }
+      if (stderrTail.length > 0) {
+        if (streamOutput) process.stderr.write(stderrTail);
+        stderr += stderrTail;
+      }
+
       if (code === 0) {
         resolve(stdout);
       } else {
@@ -80,26 +117,58 @@ function executeJar(args: string[], executionOptions: JarExecutionOptions = {}):
   });
 }
 
-export function convert(
+function buildJarArgs(
   inputPaths: string | string[],
-  options: ConvertOptions = {},
-): Promise<string> {
+  options: ConvertOptions,
+): string[] | Error {
   const inputList = Array.isArray(inputPaths) ? inputPaths : [inputPaths];
   if (inputList.length === 0) {
-    return Promise.reject(new Error('At least one input path must be provided.'));
+    return new Error('At least one input path must be provided.');
   }
 
   for (const input of inputList) {
     if (!fs.existsSync(input)) {
-      return Promise.reject(new Error(`Input file or folder not found: ${input}`));
+      return new Error(`Input file or folder not found: ${input}`);
     }
   }
 
-  const args: string[] = [...inputList, ...buildArgs(options)];
+  return [...inputList, ...buildArgs(options)];
+}
 
-  return executeJar(args, {
-    streamOutput: !options.quiet,
-  });
+export function convert(
+  inputPaths: string | string[],
+  options: ConvertOptions = {},
+): Promise<string> {
+  const argsOrError = buildJarArgs(inputPaths, options);
+  if (argsOrError instanceof Error) {
+    return Promise.reject(argsOrError);
+  }
+  // Library API: never streams to the parent process. Returns the full stdout
+  // string so callers can do `const out = await convert(...)` without surprise
+  // side-effects on process.stdout / process.stderr.
+  return executeJar(argsOrError, { streamOutput: false });
+}
+
+/**
+ * Internal entry point used by the bundled CLI. Streams Java's stdout and
+ * stderr to the parent process in real time (so long-running conversions like
+ * hybrid mode show progress as it happens) and resolves without a stdout
+ * payload — preventing the caller from re-printing what was already streamed.
+ *
+ * Not part of the public API: do not import this from application code. Use
+ * {@link convert} instead.
+ *
+ * @internal
+ */
+export async function _runForCli(
+  inputPaths: string | string[],
+  options: ConvertOptions = {},
+): Promise<void> {
+  const argsOrError = buildJarArgs(inputPaths, options);
+  if (argsOrError instanceof Error) {
+    throw argsOrError;
+  }
+  await executeJar(argsOrError, { streamOutput: true });
 }
 
 /**

--- a/node/opendataloader-pdf/test/executeJar.unit.test.ts
+++ b/node/opendataloader-pdf/test/executeJar.unit.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for the JAR execution layer's stdout/stderr handling.
+ *
+ * These tests use a fake child process (no real Java) so we can deterministically
+ * assert the streaming/buffering contract:
+ *   - convert() — library API: never writes to process.stdout, returns full stdout
+ *   - _runForCli() — CLI helper: streams stdout/stderr to the parent in real time,
+ *     does not return the stdout payload (the caller must not re-print it)
+ *
+ * Issue #398 reproducer: a long-running conversion (think hybrid mode, 1h+) must
+ * surface progress via stderr without the CLI double-printing the result on close.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock child_process so we control spawn() entirely (no real Java process).
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+// Mock fs so JAR-file-exists and input-file-exists checks always pass.
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
+import { spawn } from 'child_process';
+import { convert, _runForCli } from '../src/index';
+
+class FakeProcess extends EventEmitter {
+  stdout = new EventEmitter() as EventEmitter & { pipe?: unknown };
+  stderr = new EventEmitter() as EventEmitter & { pipe?: unknown };
+}
+
+function makeFakeSpawn(): {
+  proc: FakeProcess;
+  spawnMock: ReturnType<typeof vi.fn>;
+} {
+  const proc = new FakeProcess();
+  const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>;
+  spawnMock.mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+  return { proc, spawnMock };
+}
+
+/** Yield to the microtask queue so Promise callbacks fire. */
+const tick = () => new Promise<void>((r) => setImmediate(r));
+
+describe('executeJar — library API (convert)', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('returns the full stdout string on success', async () => {
+    const { proc } = makeFakeSpawn();
+    const promise = convert('input.pdf', { quiet: true });
+
+    proc.stdout.emit('data', Buffer.from('Lorem '));
+    proc.stdout.emit('data', Buffer.from('ipsum dolor'));
+    proc.emit('close', 0);
+
+    await expect(promise).resolves.toBe('Lorem ipsum dolor');
+  });
+
+  it('does not write to process.stdout (no streaming side-effect)', async () => {
+    const { proc } = makeFakeSpawn();
+    const promise = convert('input.pdf', { quiet: true });
+
+    proc.stdout.emit('data', Buffer.from('result text'));
+    proc.emit('close', 0);
+
+    await promise;
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not write to process.stderr (no streaming side-effect)', async () => {
+    // Library callers should not have stderr leaked into their parent process.
+    // Java's --quiet silences stderr at the source for typical library use,
+    // but the contract holds even if Java emits to stderr.
+    const { proc } = makeFakeSpawn();
+    const promise = convert('input.pdf', { quiet: true });
+
+    proc.stderr.emit('data', Buffer.from('정보: progress'));
+    proc.stdout.emit('data', Buffer.from('result'));
+    proc.emit('close', 0);
+
+    await promise;
+
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects with stderr in the error message on non-zero exit', async () => {
+    const { proc } = makeFakeSpawn();
+    const promise = convert('input.pdf', { quiet: true });
+
+    proc.stderr.emit('data', Buffer.from('Java stack trace'));
+    proc.emit('close', 1);
+
+    await expect(promise).rejects.toThrow(/exited with code 1/);
+    await expect(promise).rejects.toThrow(/Java stack trace/);
+  });
+
+  it('reassembles multi-byte UTF-8 codepoints split across chunks', async () => {
+    // Java's progress logs are localized; '정' = 0xEC 0xA0 0x95 (3 bytes).
+    // If the OS hands us this codepoint split across two 'data' events, a
+    // naive Buffer.toString() emits two replacement characters. Streaming
+    // is meant to be byte-faithful to what Java printed, so we must
+    // reassemble across the boundary.
+    const { proc } = makeFakeSpawn();
+    const promise = convert('input.pdf', { quiet: true });
+
+    proc.stdout.emit('data', Buffer.from([0xEC, 0xA0])); // first 2 bytes of '정'
+    proc.stdout.emit('data', Buffer.from([0x95]));        // last byte of '정'
+    proc.stdout.emit('data', Buffer.from('보', 'utf8'));  // a clean codepoint
+    proc.emit('close', 0);
+
+    await expect(promise).resolves.toBe('정보');
+  });
+});
+
+describe('executeJar — CLI helper (_runForCli)', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('streams stdout chunks to process.stdout in real time', async () => {
+    // The defining requirement for hybrid-mode-style long runs: the user must
+    // see output as it arrives, not buffered until the process closes.
+    const { proc } = makeFakeSpawn();
+    const promise = _runForCli(['input.pdf']);
+
+    proc.stdout.emit('data', Buffer.from('chunk1'));
+    await tick();
+    expect(stdoutSpy).toHaveBeenCalledWith('chunk1');
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+
+    proc.stdout.emit('data', Buffer.from('chunk2'));
+    await tick();
+    expect(stdoutSpy).toHaveBeenCalledTimes(2);
+
+    proc.emit('close', 0);
+    await promise;
+
+    // Critical: process.stdout was called exactly twice — once per chunk.
+    // No extra "final flush" call. That's how we avoid the #398 double-write.
+    expect(stdoutSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('streams stderr chunks to process.stderr in real time', async () => {
+    const { proc } = makeFakeSpawn();
+    const promise = _runForCli(['input.pdf']);
+
+    proc.stderr.emit('data', Buffer.from('정보: Number of pages: 14\n'));
+    await tick();
+    expect(stderrSpy).toHaveBeenCalledWith('정보: Number of pages: 14\n');
+
+    proc.stderr.emit('data', Buffer.from('정보: Processing 14 pages\n'));
+    await tick();
+    expect(stderrSpy).toHaveBeenCalledTimes(2);
+
+    proc.emit('close', 0);
+    await promise;
+  });
+
+  it('preserves true interleaving of stderr and stdout chunks as they arrive', async () => {
+    // Hybrid mode emits progress logs on stderr *throughout* the run, with
+    // result chunks landing on stdout in between. Both streams must reach the
+    // parent in arrival order without one buffering the other.
+    const { proc } = makeFakeSpawn();
+    const promise = _runForCli(['input.pdf']);
+
+    const calls: string[] = [];
+    stdoutSpy.mockImplementation(((chunk: Buffer) => {
+      calls.push('OUT:' + chunk.toString());
+      return true;
+    }) as never);
+    stderrSpy.mockImplementation(((chunk: Buffer) => {
+      calls.push('ERR:' + chunk.toString());
+      return true;
+    }) as never);
+
+    proc.stderr.emit('data', Buffer.from('progress 1'));
+    await tick();
+    proc.stdout.emit('data', Buffer.from('result A'));
+    await tick();
+    proc.stderr.emit('data', Buffer.from('progress 2'));
+    await tick();
+    proc.stdout.emit('data', Buffer.from('result B'));
+    await tick();
+    proc.emit('close', 0);
+    await promise;
+
+    expect(calls).toEqual([
+      'ERR:progress 1',
+      'OUT:result A',
+      'ERR:progress 2',
+      'OUT:result B',
+    ]);
+  });
+
+  it('resolves without returning the stdout payload (caller must not re-print)', async () => {
+    // _runForCli's contract: streaming has the side-effect, the resolved value
+    // carries no stdout text. This is what blocks the CLI from double-printing.
+    const { proc } = makeFakeSpawn();
+    const promise = _runForCli(['input.pdf']);
+
+    proc.stdout.emit('data', Buffer.from('result text'));
+    proc.emit('close', 0);
+
+    const resolved = await promise;
+
+    expect(resolved).toBeUndefined();
+  });
+
+  it('rejects with stderr in the error message on non-zero exit', async () => {
+    const { proc } = makeFakeSpawn();
+    const promise = _runForCli(['input.pdf']);
+
+    proc.stderr.emit('data', Buffer.from('boom'));
+    proc.emit('close', 2);
+
+    await expect(promise).rejects.toThrow(/exited with code 2/);
+    await expect(promise).rejects.toThrow(/boom/);
+  });
+
+  it('forwards multi-byte UTF-8 to process.stderr without splitting codepoints', async () => {
+    // Defining the streaming contract for non-ASCII progress logs. Without a
+    // StringDecoder, splitting '정' (0xEC 0xA0 0x95) across two chunks would
+    // emit two replacement characters to the user's terminal — exactly the
+    // failure mode the comment in index.ts warns about.
+    const { proc } = makeFakeSpawn();
+    const promise = _runForCli(['input.pdf']);
+
+    const forwarded: string[] = [];
+    stderrSpy.mockImplementation(((chunk: string) => {
+      forwarded.push(chunk);
+      return true;
+    }) as never);
+
+    proc.stderr.emit('data', Buffer.from([0xEC, 0xA0])); // partial '정'
+    await tick();
+    proc.stderr.emit('data', Buffer.from([0x95]));        // completes '정'
+    await tick();
+    proc.stderr.emit('data', Buffer.from('보', 'utf8'));
+    await tick();
+    proc.emit('close', 0);
+    await promise;
+
+    // No replacement characters anywhere in what the user saw.
+    const joined = forwarded.join('');
+    expect(joined).toBe('정보');
+    expect(joined).not.toContain('�');
+  });
+});
+

--- a/node/opendataloader-pdf/test/streaming.integration.test.ts
+++ b/node/opendataloader-pdf/test/streaming.integration.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration tests for the stdout/stderr streaming contract.
+ *
+ * Runs the bundled CLI as a real subprocess against a multi-page sample PDF.
+ * Asserts the user-facing behavior that mock unit tests cannot prove:
+ *   - CLI never double-prints stdout (regression test for #398)
+ *   - Java's progress logs reach the parent's stderr in real time, before the
+ *     stdout payload finishes — the property that makes hour-long hybrid runs
+ *     observable
+ *   - Library API does not leak Java's output to the parent's stdout
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawn, spawnSync } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const rootDir = path.resolve(__dirname, '..', '..', '..');
+const cliPath = path.resolve(__dirname, '..', 'dist', 'cli.js');
+const jarPath = path.resolve(__dirname, '..', 'lib', 'opendataloader-pdf-cli.jar');
+const samplePdf = path.join(rootDir, 'samples', 'pdf', '2408.02509v1.pdf');
+
+interface Capture {
+  stdout: string;
+  stderr: string;
+  /** Wall-clock ms (since process spawn) of each chunk we received. */
+  timeline: Array<{ stream: 'out' | 'err'; size: number; at: number }>;
+  exitCode: number | null;
+}
+
+function captureSubprocess(command: string, args: string[]): Promise<Capture> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args);
+    const start = Date.now();
+    const cap: Capture = { stdout: '', stderr: '', timeline: [], exitCode: null };
+
+    proc.stdout.on('data', (chunk: Buffer) => {
+      cap.stdout += chunk.toString();
+      cap.timeline.push({ stream: 'out', size: chunk.length, at: Date.now() - start });
+    });
+    proc.stderr.on('data', (chunk: Buffer) => {
+      cap.stderr += chunk.toString();
+      cap.timeline.push({ stream: 'err', size: chunk.length, at: Date.now() - start });
+    });
+    proc.on('close', (code) => {
+      cap.exitCode = code;
+      resolve(cap);
+    });
+    proc.on('error', reject);
+  });
+}
+
+const runCli = (args: string[]) => captureSubprocess('node', [cliPath, ...args]);
+const runJar = (args: string[]) => captureSubprocess('java', ['-jar', jarPath, ...args]);
+
+describe('CLI streaming contract', () => {
+  beforeAll(() => {
+    // Self-contained: build dist on demand so `pnpm test` works on a fresh
+    // checkout without a separate `pnpm build` step. The JAR has to come from
+    // the Maven build (it's not something Vitest should rebuild), so we still
+    // surface a clear error if it's missing.
+    if (!fs.existsSync(cliPath)) {
+      const result = spawnSync(
+        'pnpm',
+        ['exec', 'tsup', '--no-dts', 'src/index.ts', 'src/cli.ts',
+         '--format', 'esm,cjs', '--shims', '--out-dir', 'dist'],
+        { cwd: path.resolve(__dirname, '..'), stdio: 'inherit' },
+      );
+      if (result.status !== 0) {
+        throw new Error('Failed to build dist for streaming integration test');
+      }
+    }
+    if (!fs.existsSync(jarPath)) {
+      throw new Error(
+        `Bundled JAR not found at ${jarPath} — build the Java module first ` +
+        `(\`mvn package\` in java/, then \`pnpm run setup\` in this package).`,
+      );
+    }
+    if (!fs.existsSync(samplePdf)) {
+      throw new Error(`Sample PDF not found at ${samplePdf}`);
+    }
+  }, 60000);
+
+  it('prints --to-stdout output exactly once (regression for #398)', async () => {
+    // Ground truth: invoke the JAR directly with --quiet so stderr is empty
+    // and stdout carries only the result payload. The Node CLI must produce
+    // the same bytes — no more, no less. Comparing against the JAR rather
+    // than another Node-CLI run prevents a symmetric-mutation regression
+    // (e.g., trimming/appending in both code paths) from sneaking past.
+    const referenceCap = await runJar([samplePdf, '--quiet', '--format', 'text', '--to-stdout']);
+    expect(referenceCap.exitCode).toBe(0);
+    const referenceStdout = referenceCap.stdout;
+    expect(referenceStdout.length).toBeGreaterThan(1000);
+
+    const cap = await runCli([samplePdf, '--format', 'text', '--to-stdout']);
+    expect(cap.exitCode).toBe(0);
+
+    // Defining check: the no-flag Node CLI must produce the *exact same*
+    // stdout bytes as the JAR. Pre-fix this came out at 2x because of
+    // double-write. Length-only comparison would miss byte-substituting
+    // mutations of identical length, so we compare the full payload.
+    expect(cap.stdout).toBe(referenceStdout);
+  }, 60000);
+
+  it('forwards Java progress logs to stderr in real time before stdout completes', async () => {
+    const cap = await runCli([samplePdf, '--format', 'text', '--to-stdout']);
+    expect(cap.exitCode).toBe(0);
+
+    // Java emits a "Number of pages" line during preprocessing — long before
+    // text extraction finishes — to stderr.
+    expect(cap.stderr).toMatch(/Number of pages/);
+
+    // The property that makes long runs observable: at least one stderr chunk
+    // arrives before stdout finishes streaming. We compare *event indices*
+    // (arrival order in cap.timeline) rather than millisecond timestamps to
+    // stay deterministic — two events scheduled in the same tick will share
+    // an `at` value but always have distinct indices.
+    const firstErrIdx = cap.timeline.findIndex((e) => e.stream === 'err');
+    let lastOutIdx = -1;
+    for (let i = cap.timeline.length - 1; i >= 0; i--) {
+      if (cap.timeline[i].stream === 'out') {
+        lastOutIdx = i;
+        break;
+      }
+    }
+    expect(firstErrIdx).toBeGreaterThanOrEqual(0);
+    expect(lastOutIdx).toBeGreaterThanOrEqual(0);
+    expect(firstErrIdx).toBeLessThan(lastOutIdx);
+  }, 60000);
+
+  it('library convert() does not leak to the parent process stdio', async () => {
+    // Spawn a tiny Node script that imports convert() and calls it. We capture
+    // *that* process's stdio: convert() must not write to stdout/stderr itself.
+    // The import specifier is a file:// URL so the harness works on Windows
+    // (where path.resolve yields backslashes that ESM rejects).
+    const distIndexUrl = pathToFileURL(path.resolve(__dirname, '..', 'dist', 'index.js')).href;
+    const harness = `
+      import { convert } from '${distIndexUrl}';
+      const out = await convert(${JSON.stringify(samplePdf)}, {
+        format: ['text'], toStdout: true, quiet: true,
+      });
+      // One intended write at the end so we can distinguish "the marker"
+      // from any leakage caused by executeJar forwarding to process.stdout.
+      process.stdout.write('LEN=' + out.length + '\\n');
+    `;
+
+    // Place the harness in an isolated tmpdir — survives Ctrl-C / OOM cleanly
+    // (OS reaps tmpdir trees) instead of polluting the source tree.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'odl-pdf-issue398-'));
+    const tmpScript = path.join(tmpDir, 'harness.mjs');
+    fs.writeFileSync(tmpScript, harness);
+    try {
+      const cap = await captureSubprocess('node', [tmpScript]);
+      expect(cap.exitCode).toBe(0);
+      // The only line on stdout must be our LEN= marker. Anything else means
+      // executeJar leaked Java's stdout into the parent.
+      expect(cap.stdout.trim().split('\n')).toHaveLength(1);
+      expect(cap.stdout).toMatch(/^LEN=\d+\n$/);
+      expect(cap.stderr).toBe('');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 60000);
+});

--- a/node/opendataloader-pdf/tsconfig.json
+++ b/node/opendataloader-pdf/tsconfig.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "skipLibCheck": true,
     "strict": true,
+    "stripInternal": true,
     "types": ["node"],
     "ignoreDeprecations": "6.0"
   },


### PR DESCRIPTION
## Objective
CLI users running `opendataloader-pdf <file> --to-stdout` (or any invocation
without `--quiet`) see every output line printed twice. The cause: `executeJar()`
streams Java's stdout to `process.stdout` in real time *and* accumulates it
into the resolved string, then `cli.ts` prints that string a second time.

This PR supersedes #399 by @kuishou68, whose diagnosis was correct and whose
original fix is preserved as the basis of this change. We took it over because
(a) #399's approach made `convert()` (the library API) regress to returning an
empty string when `quiet` was undefined — flagged in CodeRabbit's second review
and unaddressed for ~12 days — and (b) we wanted to land regression coverage at
the same time so this class of bug stops recurring.

Fixes [opendataloader-project/opendataloader-pdf#398](https://github.com/opendataloader-project/opendataloader-pdf/issues/398)
Closes [opendataloader-project/opendataloader-pdf#399](https://github.com/opendataloader-project/opendataloader-pdf/pull/399)

## Approach
Separate concerns at the layer boundary so that streaming (a CLI-only need) and
the resolved string (a library-only need) never compete for the same return
channel.

- `convert()` (library API) is pinned to `streamOutput: false`. It always
  returns the full stdout string and never touches the parent process's stdio.
  No `quiet`-dependent return shape, no surprise side-effects.
- `_runForCli()` (internal helper, used only by the bundled CLI) is pinned to
  `streamOutput: true`. It forwards Java's stdout and stderr to the parent
  process in real time and resolves to `void`, so the CLI cannot re-print what
  was already streamed.
- `cli.ts` calls `_runForCli()` and never touches the resolved value.

Java's progress logs continue to surface on stderr in real time — the property
that makes long hybrid-mode runs observable.

Test infrastructure was added because we kept rediscovering the same class of
bug by hand:
- `executeJar.unit.test.ts` (9 tests) — mocks `child_process.spawn` and asserts
  the streaming/buffering contract deterministically (no real Java needed).
- `streaming.integration.test.ts` (3 tests) — runs the bundled CLI as a real
  subprocess against a multi-page sample PDF and asserts the user-facing
  behavior: no double-write, stderr arrives before stdout completes, library
  call doesn't leak to the parent's stdio.

## Evidence
Manual verification on the bundled CLI plus full vitest run:

| Scenario | Expected | Actual |
|----------|----------|--------|
| CLI, no `--quiet`, `--to-stdout` (1-page PDF) | 459 bytes (single copy) | 459 bytes |
| CLI, no `--quiet`, `--to-stdout` (14-page PDF) | 63006 bytes (single copy) | 63006 bytes |
| 14-page CLI: stderr progress logs | streamed before stdout | 28 stderr lines, "Number of pages" present |
| Library: `convert(path, { quiet: true })` returns | full stdout string | 459 bytes |
| Library: `convert(path, { quiet: undefined })` returns | full stdout string | 459 bytes |
| Library: side-effect on `process.stdout` | none | none |
| Library: side-effect on `process.stderr` | none | none |
| `vitest --run` | all pass | 30/30 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated CLI output duplication so conversion results no longer print twice.

* **Improvements**
  * Real-time forwarding of conversion stdout/stderr without duplicating payloads.
  * Library conversion now returns full subprocess output and avoids writing subprocess stdout to the parent process.
  * Improved UTF‑8 handling across chunked output and clearer exit/error reporting.
  * Build now strips internal declarations from emitted artifacts.

* **Tests**
  * Added unit and integration tests for streaming, interleaved stdout/stderr, and UTF‑8 correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->