### PR TITLE
refactor(core): move CLIOptions to core api.cli package

### DIFF
--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -18,6 +18,7 @@ package org.opendataloader.pdf.cli;
 import org.apache.commons.cli.*;
 import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.api.OpenDataLoaderPDF;
+import org.opendataloader.pdf.api.cli.CLIOptions;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
 
 import java.io.File;

--- a/java/opendataloader-pdf-core/pom.xml
+++ b/java/opendataloader-pdf-core/pom.xml
@@ -78,6 +78,10 @@
             <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.12.0</version>

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -33,15 +33,33 @@ import java.util.stream.Collectors;
 /**
  * Adapter that maps Apache Commons CLI options to {@link Config} / {@link HybridConfig}.
  *
- * <p><b>Stable API for downstream tools (e.g. opendataloader-pdfua):</b>
+ * <p><b>Stable API for downstream tools</b> (e.g. opendataloader-pdfua) — these four
+ * members are the supported integration surface and will not break compatibly:
  * <ul>
- *   <li>{@link #defineOptions()}</li>
- *   <li>{@link #addAllTo(Options)}</li>
- *   <li>{@link #applyAllTo(Config, CommandLine)}</li>
- *   <li>{@link #FOLDER_OPTION}</li>
+ *   <li>{@link #defineOptions()} — get a fully populated {@code Options} instance</li>
+ *   <li>{@link #addAllTo(Options)} — add core options into an externally-built {@code Options}</li>
+ *   <li>{@link #applyAllTo(Config, CommandLine)} — populate a {@code Config} from a parsed line</li>
+ *   <li>{@link #FOLDER_OPTION} — short option name for {@code --output-dir}</li>
  * </ul>
- * Other public members exist for internal use by the CLI module and the option-export
- * tooling. They may change between minor releases.
+ *
+ * <p><b>Everything else is internal.</b> The numerous other public {@code static} members
+ * (option-name constants, helpers like {@code createConfigFromCommandLine},
+ * {@code exportOptionsAsJson}) exist for the CLI module ({@code CLIMain}) and the
+ * options-export tooling that drives Node/Python binding generation. Their visibility
+ * is {@code public} only for cross-package access within this codebase; they are
+ * <i>not</i> part of the supported API and may be renamed, moved, or removed in any
+ * release. Downstream consumers depending on them do so at their own risk.
+ *
+ * <p>Pdfua's usage pattern (build your own {@code Options}, add core's, parse, then
+ * populate {@code Config}):
+ * <pre>{@code
+ *   Options options = new Options();
+ *   options.addOption(...);              // your tool-specific options
+ *   CLIOptions.addAllTo(options);        // add core's options
+ *   CommandLine cmd = parser.parse(options, args);
+ *   Config core = new Config();
+ *   CLIOptions.applyAllTo(core, cmd);
+ * }</pre>
  */
 public class CLIOptions {
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.opendataloader.pdf.cli;
+package org.opendataloader.pdf.api.cli;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -30,6 +30,19 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Adapter that maps Apache Commons CLI options to {@link Config} / {@link HybridConfig}.
+ *
+ * <p><b>Stable API for downstream tools (e.g. opendataloader-pdfua):</b>
+ * <ul>
+ *   <li>{@link #defineOptions()}</li>
+ *   <li>{@link #addAllTo(Options)}</li>
+ *   <li>{@link #applyAllTo(Config, CommandLine)}</li>
+ *   <li>{@link #FOLDER_OPTION}</li>
+ * </ul>
+ * Other public members exist for internal use by the CLI module and the option-export
+ * tooling. They may change between minor releases.
+ */
 public class CLIOptions {
 
     // ===== Output Directory =====

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsContentSafetyTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsContentSafetyTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.opendataloader.pdf.cli;
+package org.opendataloader.pdf.api.cli;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.opendataloader.pdf.cli;
+package org.opendataloader.pdf.api.cli;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsTest.java
@@ -639,4 +639,29 @@ class CLIOptionsTest {
         // downstream-only is not consumed by applyAllTo — that is the caller's job.
         assertEquals("value", cmd.getOptionValue("downstream-only"));
     }
+
+    @Test
+    void testAddAllTo_preservesPreexistingDownstreamOptions() {
+        Options ext = new Options();
+        ext.addOption(null, "ua-foo", true, "Pdfua-specific option");
+        ext.addOption(null, "ua-bar", false, "Pdfua-specific flag");
+        CLIOptions.addAllTo(ext);
+
+        assertTrue(ext.hasOption("ua-foo"));
+        assertTrue(ext.hasOption("ua-bar"));
+        assertTrue(ext.hasOption("hybrid"));
+        assertTrue(ext.hasOption("threads"));
+    }
+
+    @Test
+    void testAddAllTo_calledTwice_isIdempotent() {
+        Options ext = new Options();
+        CLIOptions.addAllTo(ext);
+        int afterFirst = ext.getOptions().size();
+        // commons-cli's Options.addOption silently replaces by long-name, so calling
+        // addAllTo twice does not throw and does not duplicate. Pin this so a future
+        // commons-cli upgrade that changes the behavior surfaces here.
+        CLIOptions.addAllTo(ext);
+        assertEquals(afterFirst, ext.getOptions().size());
+    }
 }


### PR DESCRIPTION
## Objective
Downstream tools (e.g. [opendataloader-pdfua](https://github.com/opendataloader-project/opendataloader-pdfua)) need CLI option parsing — turning a `commons-cli` `CommandLine` into a populated `Config`/`HybridConfig`. To get that, they had to depend on `opendataloader-pdf-cli`, which is **not published to Maven Central**. The result: every downstream build forces a manual `cd opendataloader-pdf/java && mvn install -DskipTests` first. New contributors hit this immediately.

## Approach
Move `CLIOptions` into core under `org.opendataloader.pdf.api.cli`. Downstream tools then depend only on `opendataloader-pdf-core` (which **is** on Central). The `cli` module keeps its identity as the executable artifact: `CLIMain` stays where it is and gains a single import line to the new package. The shaded fat jar layout, `Main-Class` manifest, and `--export-options` output are all unchanged — meaning the Node and Python wrappers, IDE run config, CI workflows, and `options.json`-driven binding generators do not need to be touched.

The class Javadoc documents which four members are stable for downstream use (`defineOptions`, `addAllTo`, `applyAllTo`, `FOLDER_OPTION`); other public members exist for the cli module's own use and may change.

## Evidence
Built + tested both modules, ran the wrapper test suites against the freshly-built jar, and verified `--export-options` output is byte-identical to the existing `options.json`:

| Scenario | Expected | Actual |
|----------|----------|--------|
| `mvn test` in `opendataloader-pdf-core` | All pass (incl. moved `CLIOptionsTest`, `CLIOptionsContentSafetyTest`) | **634/634** pass |
| `mvn test` in `opendataloader-pdf-cli` | All pass (`CLIMainTest` still works against new package) | **5/5** pass |
| `npm test` in `node/opendataloader-pdf` (vitest, integration tests run real jar) | All pass | **32/32** pass |
| `pytest` in `python/opendataloader-pdf` (`test_cli_options.py` + `test_convert_integration.py`) | All pass | **13/13** pass |
| `java -jar opendataloader-pdf-cli-0.0.0.jar --export-options` | byte-identical to existing `options.json` | `diff` empty, `wc -c` identical (7828 bytes) |
| Shaded jar `Main-Class` manifest | `org.opendataloader.pdf.cli.CLIMain` (unchanged) | confirmed via `unzip -p` |
| Shaded jar contents | New package present alongside CLIMain | `org/opendataloader/pdf/api/cli/CLIOptions.class` confirmed inside fat jar |

Companion PR on opendataloader-pdfua removes its `opendataloader-pdf-cli` dependency and updates its single import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API documentation for CLI options, clarifying stability guarantees for downstream tools.

* **Dependencies**
  * Added Apache Commons CLI library to support command-line argument parsing.

* **Refactor**
  * Relocated CLI options into a stable API namespace.

* **Tests**
  * Updated tests to match the namespace change and improve coverage for option merging and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->