### PR TITLE
fix(node): suppress duplicated stderr re-print on Java subprocess exit

### DIFF
--- a/node/opendataloader-pdf/src/cli.ts
+++ b/node/opendataloader-pdf/src/cli.ts
@@ -61,8 +61,17 @@ async function main(): Promise<number> {
     await _runForCli(inputPaths, convertOptions);
     return 0;
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(message);
+    // Subprocess-exit errors are already on the user's terminal via the live
+    // stderr stream — re-printing would duplicate output and risk leaking
+    // anything sensitive Java logged (e.g. a --password value echoed by an
+    // underlying library). Wrapper-side failures (JAR not found, java not in
+    // PATH, bad input path) still need to be surfaced.
+    const isJavaExit =
+      err instanceof Error && (err as Error & { isJavaExit?: boolean }).isJavaExit === true;
+    if (!isJavaExit) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(message);
+    }
     return 1;
   }
 }

--- a/node/opendataloader-pdf/src/index.ts
+++ b/node/opendataloader-pdf/src/index.ts
@@ -99,6 +99,11 @@ function executeJar(args: string[], executionOptions: JarExecutionOptions = {}):
         const error = new Error(
           `The opendataloader-pdf CLI exited with code ${code}.\n\n${errorOutput}`,
         );
+        // Tag so the CLI can suppress re-printing this message — Java's
+        // stderr was already streamed live to the parent in CLI mode, and
+        // re-printing risks leaking anything sensitive Java logged
+        // (e.g. a --password value echoed by an underlying library).
+        (error as Error & { isJavaExit?: boolean }).isJavaExit = true;
         reject(error);
       }
     });

--- a/node/opendataloader-pdf/test/executeJar.unit.test.ts
+++ b/node/opendataloader-pdf/test/executeJar.unit.test.ts
@@ -110,6 +110,19 @@ describe('executeJar — library API (convert)', () => {
     await expect(promise).rejects.toThrow(/Java stack trace/);
   });
 
+  it('tags the rejection with isJavaExit so the CLI can suppress re-printing', async () => {
+    // The CLI relies on this tag to avoid duplicating stderr that was already
+    // streamed live (and to avoid re-surfacing anything sensitive Java logged).
+    // Library callers can ignore the tag — message and behavior are unchanged.
+    const { proc } = makeFakeSpawn();
+    const promise = convert('input.pdf', { quiet: true });
+
+    proc.stderr.emit('data', Buffer.from('Bad password: hunter2'));
+    proc.emit('close', 1);
+
+    await expect(promise).rejects.toMatchObject({ isJavaExit: true });
+  });
+
   it('reassembles multi-byte UTF-8 codepoints split across chunks', async () => {
     // Java's progress logs are localized; '정' = 0xEC 0xA0 0x95 (3 bytes).
     // If the OS hands us this codepoint split across two 'data' events, a


### PR DESCRIPTION
## Objective
When the Java subprocess exits non-zero, the Node CLI prints its stderr a second time on top of what was already streamed live during the run. CodeQL flags that duplicated print as a **high-severity** clear-text-logging issue ([alert #31](https://github.com/opendataloader-project/opendataloader-pdf/security/code-scanning/31)): if a downstream PDF library ever echoes the user's `--password` value in an error message, the wrapper rebroadcasts it through `console.error`. The duplicated print also undoes part of the #398 streaming fix on the stderr side.

Fixes [opendataloader-project/opendataloader-pdf code-scanning #31](https://github.com/opendataloader-project/opendataloader-pdf/security/code-scanning/31)

## Approach
Tag the close-handler rejection in `index.ts` with an `isJavaExit` flag and have the CLI skip its final `console.error(message)` when that flag is set. The user has already seen Java's stderr via the live stream (CLI mode forwards `process.stderr.write(chunk)` per chunk), so re-printing only duplicates output and re-surfaces anything sensitive Java may have logged.

Two design properties worth noting:
- **Library API is untouched.** `convert()` callers still receive the same `Error` with the same `message`, the same `name`, and `instanceof Error` still holds. The optional `isJavaExit` property is invisible to anyone who doesn't look for it.
- **Wrapper-side failures are not suppressed.** Errors from JAR-not-found, java-not-in-PATH, or input-path validation never get the tag, so they keep being surfaced — those are paths where the user has seen *nothing* yet.

This PR is scoped to the duplicated-print problem only. The deeper question — that PDF passwords have user/owner semantics, that `--password` is global across multi-input batches when document credentials are inherently per-file, and that permission bits are a separate axis — needs a coherent redesign and will be handled in a follow-up design issue, not retrofitted here.

## Evidence
Added one unit test asserting the close-handler rejection carries `isJavaExit: true`, and re-ran the full suite to confirm the library API contract is unchanged.

| Scenario | Expected | Actual |
|----------|----------|--------|
| Java exits non-zero | rejection has `isJavaExit: true` | `isJavaExit: true` |
| Library `Error.message` on non-zero exit | unchanged | unchanged — all 32 prior tests still pass |
| Wrapper-side error (e.g. missing input file) | `console.error` still fires | confirmed: tag not set, message printed |

```
Test Files  5 passed (5)
     Tests  33 passed (33)   (32 existing + 1 new)
```

`pnpm run lint` clean. Diff is +29/-2 across 3 files.

## Note on CodeQL `js/clear-text-logging`

CodeQL still flags the remaining `console.error(message)` inside the catch (now at `cli.ts:73`) under the same rule — its taint tracker follows `process.argv` → spawn args → subprocess error → `console.error` and cannot tell that the only branch reaching this print is wrapper-side errors (JAR-not-found, java-not-in-PATH, input-path validation), none of which embed the `--password` value in their message text. The new alert instance will be dismissed as a false positive after merge; the underlying source — the password traveling through argv at all — is part of the broader password-handling redesign and will not be addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)