### PR TITLE
fix(runner): use utf-8 encoding for subprocess I/O on Windows

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
@@ -26,7 +26,7 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
                     capture_output=True,
                     text=True,
                     check=True,
-                    encoding=locale.getpreferredencoding(False),
+                    encoding="utf-8",
                 )
                 return result.stdout
 
@@ -36,11 +36,11 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
-                encoding=locale.getpreferredencoding(False),
+                encoding="utf-8",
             ) as process:
                 output_lines: List[str] = []
                 for line in process.stdout:
-                    sys.stdout.write(line)
+                    sys.stdout.buffer.write(line.encode("utf-8", errors="replace"))
                     output_lines.append(line)
 
                 return_code = process.wait()

--- a/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
@@ -1,7 +1,6 @@
 """
 Low-level JAR runner for opendataloader-pdf.
 """
-import locale
 import subprocess
 import sys
 import importlib.resources as resources
@@ -27,6 +26,7 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
                     text=True,
                     check=True,
                     encoding="utf-8",
+                    errors="replace",
                 )
                 return result.stdout
 
@@ -37,10 +37,15 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
                 stderr=subprocess.STDOUT,
                 text=True,
                 encoding="utf-8",
+                errors="replace",
             ) as process:
                 output_lines: List[str] = []
                 for line in process.stdout:
-                    sys.stdout.buffer.write(line.encode("utf-8", errors="replace"))
+                    if hasattr(sys.stdout, "buffer"):
+                        sys.stdout.buffer.write(line.encode("utf-8", errors="replace"))
+                        sys.stdout.buffer.flush()
+                    else:
+                        sys.stdout.write(line)
                     output_lines.append(line)
 
                 return_code = process.wait()


### PR DESCRIPTION
## Objective
On Korean Windows (and other non-UTF-8 Windows locales), running `opendataloader-pdf` fails immediately with:
```
UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in position 130: illegal multibyte sequence
```
The JAR outputs UTF-8, but the Python wrapper reads it using the system locale encoding (`cp949`).

## Approach
Replace `locale.getpreferredencoding(False)` with a hard-coded `"utf-8"` in both call sites:
- `subprocess.run` (quiet mode, line 29)
- `subprocess.Popen` (streaming mode, line 39)

The JAR always outputs UTF-8 regardless of OS locale, so tying the decoder to the system locale was always wrong. Also switch `sys.stdout.write(line)` to `sys.stdout.buffer.write(line.encode("utf-8", errors="replace"))` so the decoded text reaches the terminal correctly on Windows where stdout may also default to `cp949`.

This change is safe on Linux/macOS — those platforms already default to UTF-8, so the behavior is identical.

## Evidence
Verified source after patch:

| Check | Expected | Actual |
|-------|----------|--------|
| `encoding="utf-8"` occurrences | 2 (both call sites) | 2 |
| `locale.getpreferredencoding` occurrences | 0 (fully removed) | 0 |
| `stdout.buffer.write` occurrences | 1 | 1 |
| Before fix (cp949 Windows) | UnicodeDecodeError on byte 0xe2 | UnicodeDecodeError |
| After fix (cp949 Windows) | subprocess reads UTF-8 correctly | Correct (no decode error) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent UTF-8 encoding for both captured and live-streamed command output, improving handling of special and non-ASCII characters.
  * Live output now preserves replacement behavior on encoding errors while continuing to stream data in real time and collect output for error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->