### PR TITLE
Fix rules 8.9.2.2-1 and 8.9.2.2-2

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -359,7 +359,7 @@ public class AutoTaggingProcessor {
         if (isPDF2_0) {
             Long f = annotation.getIntegerKey(ASAtom.F);
             //PDF/UA-2 rules 8.9.2.2-1, 8.9.2.2-2
-            if (f != null && (((f & 1) != 0) || (((f & 32) != 0) && (f & 256) != 256))) {
+            if (f != null && ((f & 1) != 0 || ((f & 32) != 0 && (f & 256) == 0))) {
                 return false;
             }
             ASAtom subtype = annotation.getSubtype();
@@ -367,7 +367,7 @@ public class AutoTaggingProcessor {
             if (ASAtom.SOUND.equals(subtype) || ASAtom.MOVIE.equals(subtype) || ASAtom.POPUP.equals(subtype)) {
                 return false;
             }
-            //PDF/UA-2 rules 8.10.1-1, 8.9.2.4.13-1, 8.9.2.4.16-1, 8.9.2.3-1, 8.2.5.20-1,
+            //PDF/UA-2 rules 8.10.1-1, 8.9.2.4.13-1, 8.9.2.4.16-1, 8.9.2.3-1, 8.2.5.20-1
             return (ASAtom.WIDGET.equals(subtype) && boundingBox.getHeight() != 0 && boundingBox.getWidth() != 0)
                 || ASAtom.WATERMARK.equals(subtype) || annotation.isMarkup() || ASAtom.LINK.equals(subtype);
         } else {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -362,11 +362,14 @@ public class AutoTaggingProcessor {
             if (f != null && (((f & 1) != 0) || (((f & 32) != 0) && (f & 256) != 256))) {
                 return false;
             }
+            ASAtom subtype = annotation.getSubtype();
+            //PDF/UA-2 8.9.2.4.11-1, 8.9.2.4.11-2, 8.9.2.4.9-1
+            if (ASAtom.SOUND.equals(subtype) || ASAtom.MOVIE.equals(subtype) || ASAtom.POPUP.equals(subtype)) {
+                return false;
+            }
             //PDF/UA-2 rules 8.10.1-1, 8.9.2.4.13-1, 8.9.2.4.16-1, 8.9.2.3-1, 8.2.5.20-1,
-            //8.9.2.4.11-1, 8.9.2.4.11-2, 8.9.2.4.9-1
-            return (ASAtom.WIDGET.equals(annotation.getSubtype()) && boundingBox.getHeight() != 0 && boundingBox.getWidth() != 0)
-                || ASAtom.WATERMARK.equals(annotation.getSubtype()) || annotation.isMarkup() || ASAtom.LINK.equals(annotation.getSubtype())
-                || (!ASAtom.SOUND.equals(annotation.getSubtype()) && !ASAtom.MOVIE.equals(annotation.getSubtype()) && !ASAtom.POPUP.equals(annotation.getSubtype()));
+            return (ASAtom.WIDGET.equals(subtype) && boundingBox.getHeight() != 0 && boundingBox.getWidth() != 0)
+                || ASAtom.WATERMARK.equals(subtype) || annotation.isMarkup() || ASAtom.LINK.equals(subtype);
         } else {
             //PDF/UA-1 rules 7.18.1-1, 7.18.4-1, 7.18.5-1
             return !ASAtom.PRINTER_MARK.equals(annotation.getSubtype()) &&

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -352,15 +352,21 @@ public class AutoTaggingProcessor {
     }
 
     private static boolean needToAddAnnotationToStructTree(PDAnnotation annotation, PDPage page, BoundingBox boundingBox) {
+        //PDF/UA-1 rule 7.18.2-1 / PDF/UA-2 rule 8.9.2.4.15-1
+        if (ASAtom.TRAP_NET.equals(annotation.getSubtype())) {
+            return false;
+        }
         if (isPDF2_0) {
             Long f = annotation.getIntegerKey(ASAtom.F);
             //PDF/UA-2 rules 8.9.2.2-1, 8.9.2.2-2
-            if (f != null && (((f & 1) == 0) || (f & 32) == 0 || (f & 256) == 256)) {
+            if (f != null && (((f & 1) != 0) || (((f & 32) != 0) && (f & 256) != 256))) {
                 return false;
             }
-            //PDF/UA-2 rules 8.10.1-1, 8.9.2.4.13-1, 8.9.2.4.16-1, 8.9.2.3-1, 8.2.5.20-1
+            //PDF/UA-2 rules 8.10.1-1, 8.9.2.4.13-1, 8.9.2.4.16-1, 8.9.2.3-1, 8.2.5.20-1,
+            //8.9.2.4.11-1, 8.9.2.4.11-2, 8.9.2.4.9-1
             return (ASAtom.WIDGET.equals(annotation.getSubtype()) && boundingBox.getHeight() != 0 && boundingBox.getWidth() != 0)
-                || ASAtom.WATERMARK.equals(annotation.getSubtype()) || annotation.isMarkup() || ASAtom.LINK.equals(annotation.getSubtype());
+                || ASAtom.WATERMARK.equals(annotation.getSubtype()) || annotation.isMarkup() || ASAtom.LINK.equals(annotation.getSubtype())
+                || (!ASAtom.SOUND.equals(annotation.getSubtype()) && !ASAtom.MOVIE.equals(annotation.getSubtype()) && !ASAtom.POPUP.equals(annotation.getSubtype()));
         } else {
             //PDF/UA-1 rules 7.18.1-1, 7.18.4-1, 7.18.5-1
             return !ASAtom.PRINTER_MARK.equals(annotation.getSubtype()) &&


### PR DESCRIPTION
Add rules
PDF/UA-1 7.18.2-1
PDF/UA-2 8.9.2.4.11-1
8.9.2.4.15-1
8.9.2.4.11-2
8.9.2.4.9-1

<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF 2.0 annotation processing for more accurate document structure generation.
  * Explicitly excludes certain transient or multimedia annotations (e.g., popup, sound, movie, trap-net) from structure evaluation.
  * Refined flag-based eligibility rules for annotations in PDF 2.0 to reduce false positives while preserving PDF 1.x behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->