### PR TITLE
fix: cap image rendering resolution to prevent OOM on large pages

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -90,6 +90,7 @@ public class Config {
     private final HybridConfig hybridConfig = new HybridConfig();
     private boolean includeHeaderFooter = false;
     private boolean detectStrikethrough = false;
+    private float imageResolution = 2000.0f;
 
     /** Table detection method: default (border-based detection). */
     public static final String TABLE_METHOD_DEFAULT = "default";
@@ -869,6 +870,30 @@ public class Config {
 
     public void setDetectStrikethrough(boolean detectStrikethrough) {
         this.detectStrikethrough = detectStrikethrough;
+    }
+
+    /**
+     * Gets the maximum pixel size for the longest axis when rendering pages for image extraction.
+     * Lower values reduce memory usage at the cost of image resolution.
+     *
+     * @return The maximum pixel size on the longest axis (default: 2000).
+     */
+    public float getImageResolution() {
+        return imageResolution;
+    }
+
+    /**
+     * Sets the maximum pixel size for the longest axis when rendering pages for image extraction.
+     *
+     * @param imageResolution The maximum pixel size (must be > 0).
+     * @throws IllegalArgumentException if the value is not positive.
+     */
+    public void setImageResolution(float imageResolution) {
+        if (imageResolution <= 0) {
+            throw new IllegalArgumentException(
+                String.format("imageResolution must be > 0, got %s", imageResolution));
+        }
+        this.imageResolution = imageResolution;
     }
 
     private boolean outputStdout = false;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -134,6 +134,9 @@ public class CLIOptions {
     private static final String IMAGE_DIR_LONG_OPTION = "image-dir";
     private static final String IMAGE_DIR_DESC = "Directory for extracted images";
 
+    private static final String IMAGE_RESOLUTION_LONG_OPTION = "image-resolution";
+    private static final String IMAGE_RESOLUTION_DESC = "Max pixel size for the longest axis when rendering pages for image extraction. Lower values reduce memory usage. Default: 2000";
+
     // ===== Pages =====
     private static final String PAGES_LONG_OPTION = "pages";
     private static final String PAGES_DESC = "Pages to extract (e.g., \"1,3,5-7\"). Default: all pages";
@@ -245,6 +248,7 @@ public class CLIOptions {
             new OptionDefinition(IMAGE_OUTPUT_LONG_OPTION, null, "string", "external", IMAGE_OUTPUT_DESC, true),
             new OptionDefinition(IMAGE_FORMAT_LONG_OPTION, null, "string", "png", IMAGE_FORMAT_DESC, true),
             new OptionDefinition(IMAGE_DIR_LONG_OPTION, null, "string", null, IMAGE_DIR_DESC, true),
+            new OptionDefinition(IMAGE_RESOLUTION_LONG_OPTION, null, "string", "2000", IMAGE_RESOLUTION_DESC, true),
             new OptionDefinition(PAGES_LONG_OPTION, null, "string", null, PAGES_DESC, true),
             new OptionDefinition(INCLUDE_HEADER_FOOTER_LONG_OPTION, null, "boolean", false,
                     INCLUDE_HEADER_FOOTER_DESC, true),
@@ -377,6 +381,7 @@ public class CLIOptions {
         applyFormatOption(config, commandLine);
         applyTableMethodOption(config, commandLine);
         applyImageOptions(config, commandLine);
+        applyImageResolutionOption(config, commandLine);
         applyPagesOption(config, commandLine);
         applyHybridOptions(config, commandLine);
         applyThreadsOption(config, commandLine);
@@ -440,6 +445,29 @@ public class CLIOptions {
         if (commandLine.hasOption(IMAGE_DIR_LONG_OPTION)) {
             config.setImageDir(commandLine.getOptionValue(IMAGE_DIR_LONG_OPTION));
         }
+    }
+
+    private static void applyImageResolutionOption(Config config, CommandLine commandLine) {
+        if (!commandLine.hasOption(IMAGE_RESOLUTION_LONG_OPTION)) {
+            return;
+        }
+        String value = commandLine.getOptionValue(IMAGE_RESOLUTION_LONG_OPTION);
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Option --image-resolution requires a positive number");
+        }
+        float resolution;
+        try {
+            resolution = Float.parseFloat(value.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    String.format("Option --image-resolution requires a positive number, got '%s'", value));
+        }
+        if (resolution <= 0) {
+            throw new IllegalArgumentException(
+                    String.format("Option --image-resolution requires a positive number, got %s", resolution));
+        }
+        config.setImageResolution(resolution);
     }
 
     private static void applyPagesOption(Config config, CommandLine commandLine) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
@@ -41,6 +41,7 @@ public class StaticLayoutContainers {
     private static final ThreadLocal<String> imagesDirectory = new ThreadLocal<>();
     private static final ThreadLocal<Boolean> embedImages = new ThreadLocal<>();
     private static final ThreadLocal<String> imageFormat = new ThreadLocal<>();
+    private static final ThreadLocal<Float> imageResolution = ThreadLocal.withInitial(() -> 2000.0f);
     private static final ThreadLocal<Map<Integer, Double>> replacementCharRatios = ThreadLocal.withInitial(ConcurrentHashMap::new);
 
     public static void clearContainers() {
@@ -53,6 +54,7 @@ public class StaticLayoutContainers {
         imagesDirectory.set("");
         embedImages.set(false);
         imageFormat.set(Config.IMAGE_FORMAT_PNG);
+        imageResolution.remove();
         replacementCharRatios.get().clear();
     }
 
@@ -147,6 +149,14 @@ public class StaticLayoutContainers {
 
     public static void setImageFormat(String format) {
         StaticLayoutContainers.imageFormat.set(format);
+    }
+
+    public static Float getImageResolution() {
+        return imageResolution.get();
+    }
+
+    public static void setImageResolution(Float resolution) {
+        StaticLayoutContainers.imageResolution.set(resolution);
     }
 
     public static void setReplacementCharRatio(int pageNumber, double ratio) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -466,6 +466,7 @@ public class DocumentProcessor {
 
         File inputPDF = new File(inputPdfName);
         new File(config.getOutputFolder()).mkdirs();
+        StaticLayoutContainers.setImageResolution(config.getImageResolution());
         if (!config.isImageOutputOff() && (config.isGenerateHtml() || config.isGenerateMarkdown() || config.isGenerateJSON())) {
             String imagesDirectory;
             if (config.getImageDir() != null && !config.getImageDir().isEmpty()) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/ImagesUtils.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/ImagesUtils.java
@@ -95,7 +95,7 @@ public class ImagesUtils {
         int currentImageIndex = StaticLayoutContainers.incrementImageIndex();
         if (currentImageIndex == 1) {
             createImagesDirectory(StaticLayoutContainers.getImagesDirectory());
-            contrastRatioConsumer = StaticLayoutContainers.getContrastRatioConsumer(pdfFilePath, password, false, null);
+            contrastRatioConsumer = StaticLayoutContainers.getContrastRatioConsumer(pdfFilePath, password, false, StaticLayoutContainers.getImageResolution());
         }
         String imageFormat = StaticLayoutContainers.getImageFormat();
         String fileName = String.format(MarkdownSyntax.IMAGE_FILE_NAME_FORMAT, StaticLayoutContainers.getImagesDirectory(), File.separator, currentImageIndex, imageFormat);
@@ -107,7 +107,7 @@ public class ImagesUtils {
         int pictureIndex = picture.getPictureIndex();
         if (contrastRatioConsumer == null) {
             createImagesDirectory(StaticLayoutContainers.getImagesDirectory());
-            contrastRatioConsumer = StaticLayoutContainers.getContrastRatioConsumer(pdfFilePath, password, false, null);
+            contrastRatioConsumer = StaticLayoutContainers.getContrastRatioConsumer(pdfFilePath, password, false, StaticLayoutContainers.getImageResolution());
         }
         String imageFormat = StaticLayoutContainers.getImageFormat();
         String fileName = String.format(MarkdownSyntax.IMAGE_FILE_NAME_FORMAT, StaticLayoutContainers.getImagesDirectory(), File.separator, pictureIndex, imageFormat);

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/ImageResolutionIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/ImageResolutionIntegrationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.processors.DocumentProcessor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test for the --image-resolution option.
+ * Verifies that image extraction works correctly when imagePixelSize is passed
+ * to ContrastRatioConsumer (the OOM fix path for issue #458).
+ */
+class ImageResolutionIntegrationTest {
+
+    private static final String SAMPLE_PDF_WITH_IMAGES = "../../samples/pdf/1901.03003.pdf";
+    private static final String SAMPLE_PDF_BASENAME = "1901.03003";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testImageExtractionWithDefaultResolution() throws IOException {
+        File samplePdf = new File(SAMPLE_PDF_WITH_IMAGES);
+        if (!samplePdf.exists()) {
+            System.out.println("Skipping test: Sample PDF not found");
+            return;
+        }
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setImageOutput(Config.IMAGE_OUTPUT_EXTERNAL);
+        config.setGenerateJSON(true);
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        // Verify image files were created
+        Path imagesDir = tempDir.resolve(SAMPLE_PDF_BASENAME + "_images");
+        if (Files.exists(imagesDir)) {
+            File[] imageFiles = imagesDir.toFile().listFiles((dir, name) ->
+                name.endsWith(".png") || name.endsWith(".jpeg"));
+            assertNotNull(imageFiles);
+            assertTrue(imageFiles.length > 0, "Should extract at least one image with default resolution");
+        }
+    }
+
+    @Test
+    void testImageExtractionWithLowResolution() throws IOException {
+        File samplePdf = new File(SAMPLE_PDF_WITH_IMAGES);
+        if (!samplePdf.exists()) {
+            System.out.println("Skipping test: Sample PDF not found");
+            return;
+        }
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setImageOutput(Config.IMAGE_OUTPUT_EXTERNAL);
+        config.setGenerateJSON(true);
+        config.setImageResolution(500.0f);
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        // Verify image files were created even with low resolution
+        Path imagesDir = tempDir.resolve(SAMPLE_PDF_BASENAME + "_images");
+        if (Files.exists(imagesDir)) {
+            File[] imageFiles = imagesDir.toFile().listFiles((dir, name) ->
+                name.endsWith(".png") || name.endsWith(".jpeg"));
+            assertNotNull(imageFiles);
+            assertTrue(imageFiles.length > 0, "Should extract at least one image with low resolution");
+        }
+    }
+
+    @Test
+    void testImageExtractionWithHighResolution() throws IOException {
+        File samplePdf = new File(SAMPLE_PDF_WITH_IMAGES);
+        if (!samplePdf.exists()) {
+            System.out.println("Skipping test: Sample PDF not found");
+            return;
+        }
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setImageOutput(Config.IMAGE_OUTPUT_EXTERNAL);
+        config.setGenerateJSON(true);
+        config.setImageResolution(4000.0f);
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        // Verify image files were created with high resolution
+        Path imagesDir = tempDir.resolve(SAMPLE_PDF_BASENAME + "_images");
+        if (Files.exists(imagesDir)) {
+            File[] imageFiles = imagesDir.toFile().listFiles((dir, name) ->
+                name.endsWith(".png") || name.endsWith(".jpeg"));
+            assertNotNull(imageFiles);
+            assertTrue(imageFiles.length > 0, "Should extract at least one image with high resolution");
+        }
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/ConfigTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/ConfigTest.java
@@ -335,4 +335,39 @@ class ConfigTest {
         // This will throw "Invalid page range format" because "-1" looks like a range
         assertTrue(exception.getMessage().contains("Invalid page range format"));
     }
+
+    // ===== Image Resolution Tests =====
+
+    @Test
+    void testDefaultImageResolution() {
+        Config config = new Config();
+        assertEquals(2000.0f, config.getImageResolution());
+    }
+
+    @Test
+    void testSetImageResolution() {
+        Config config = new Config();
+        config.setImageResolution(1000.0f);
+        assertEquals(1000.0f, config.getImageResolution());
+    }
+
+    @Test
+    void testSetImageResolutionZeroThrows() {
+        Config config = new Config();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config.setImageResolution(0)
+        );
+        assertTrue(exception.getMessage().contains("must be > 0"));
+    }
+
+    @Test
+    void testSetImageResolutionNegativeThrows() {
+        Config config = new Config();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> config.setImageResolution(-100)
+        );
+        assertTrue(exception.getMessage().contains("must be > 0"));
+    }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsTest.java
@@ -664,4 +664,81 @@ class CLIOptionsTest {
         CLIOptions.addAllTo(ext);
         assertEquals(afterFirst, ext.getOptions().size());
     }
+
+    // ===== Image Resolution Option Tests =====
+
+    @Test
+    void testDefineOptions_containsImageResolutionOption() {
+        assertTrue(options.hasOption("image-resolution"));
+    }
+
+    @Test
+    void testCreateConfig_defaultImageResolution() throws ParseException {
+        String[] args = {testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertEquals(2000.0f, config.getImageResolution());
+    }
+
+    @Test
+    void testCreateConfig_withImageResolution() throws ParseException {
+        String[] args = {"--image-resolution", "1000", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertEquals(1000.0f, config.getImageResolution());
+    }
+
+    @Test
+    void testCreateConfig_withImageResolutionDecimal() throws ParseException {
+        String[] args = {"--image-resolution", "1500.5", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        Config config = CLIOptions.createConfigFromCommandLine(cmd);
+
+        assertEquals(1500.5f, config.getImageResolution());
+    }
+
+    @Test
+    void testCreateConfig_withImageResolutionZero_throws() throws ParseException {
+        String[] args = {"--image-resolution", "0", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            CLIOptions.createConfigFromCommandLine(cmd);
+        });
+    }
+
+    @Test
+    void testCreateConfig_withImageResolutionNegative_throws() throws ParseException {
+        String[] args = {"--image-resolution", "-100", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            CLIOptions.createConfigFromCommandLine(cmd);
+        });
+    }
+
+    @Test
+    void testCreateConfig_withImageResolutionInvalid_throws() throws ParseException {
+        String[] args = {"--image-resolution", "abc", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            CLIOptions.createConfigFromCommandLine(cmd);
+        });
+    }
+
+    @Test
+    void testCreateConfig_withEmptyImageResolution_throws() throws ParseException {
+        String[] args = {"--image-resolution", "", testPdf.getAbsolutePath()};
+        CommandLine cmd = parser.parse(options, args);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            CLIOptions.createConfigFromCommandLine(cmd);
+        });
+    }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/containers/StaticLayoutContainersTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/containers/StaticLayoutContainersTest.java
@@ -119,4 +119,22 @@ class StaticLayoutContainersTest {
         assertEquals(100, id);
         assertEquals(101, StaticLayoutContainers.getCurrentContentId());
     }
+
+    @Test
+    void testClearContainers_resetsImageResolution() {
+        StaticLayoutContainers.setImageResolution(500.0f);
+        assertEquals(500.0f, StaticLayoutContainers.getImageResolution());
+
+        StaticLayoutContainers.clearContainers();
+
+        assertEquals(2000.0f, StaticLayoutContainers.getImageResolution());
+    }
+
+    @Test
+    void testSetAndGetImageResolution() {
+        assertEquals(2000.0f, StaticLayoutContainers.getImageResolution());
+
+        StaticLayoutContainers.setImageResolution(1000.0f);
+        assertEquals(1000.0f, StaticLayoutContainers.getImageResolution());
+    }
 }

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -24,6 +24,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--image-output <value>', 'Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external');
   program.option('--image-format <value>', 'Output format for extracted images. Values: png, jpeg. Default: png');
   program.option('--image-dir <value>', 'Directory for extracted images');
+  program.option('--image-resolution <value>', 'Max pixel size for the longest axis when rendering pages for image extraction. Lower values reduce memory usage. Default: 2000');
   program.option('--pages <value>', 'Pages to extract (e.g., "1,3,5-7"). Default: all pages');
   program.option('--include-header-footer', 'Include page headers and footers in output');
   program.option('--detect-strikethrough', 'Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -39,6 +39,8 @@ export interface ConvertOptions {
   imageFormat?: string;
   /** Directory for extracted images */
   imageDir?: string;
+  /** Max pixel size for the longest axis when rendering pages for image extraction. Lower values reduce memory usage. Default: 2000 */
+  imageResolution?: string;
   /** Pages to extract (e.g., "1,3,5-7"). Default: all pages */
   pages?: string;
   /** Include page headers and footers in output */
@@ -88,6 +90,7 @@ export interface CliOptions {
   imageOutput?: string;
   imageFormat?: string;
   imageDir?: string;
+  imageResolution?: string;
   pages?: string;
   includeHeaderFooter?: boolean;
   detectStrikethrough?: boolean;
@@ -159,6 +162,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.imageDir) {
     convertOptions.imageDir = cliOptions.imageDir;
+  }
+  if (cliOptions.imageResolution) {
+    convertOptions.imageResolution = cliOptions.imageResolution;
   }
   if (cliOptions.pages) {
     convertOptions.pages = cliOptions.pages;
@@ -271,6 +277,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.imageDir) {
     args.push('--image-dir', options.imageDir);
+  }
+  if (options.imageResolution) {
+    args.push('--image-resolution', options.imageResolution);
   }
   if (options.pages) {
     args.push('--pages', options.pages);

--- a/options.json
+++ b/options.json
@@ -137,6 +137,14 @@
       "description": "Directory for extracted images"
     },
     {
+      "name": "image-resolution",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": "2000",
+      "description": "Max pixel size for the longest axis when rendering pages for image extraction. Lower values reduce memory usage. Default: 2000"
+    },
+    {
       "name": "pages",
       "shortName": null,
       "type": "string",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -163,6 +163,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "description": "Directory for extracted images",
     },
     {
+        "name": "image-resolution",
+        "python_name": "image_resolution",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": "2000",
+        "description": "Max pixel size for the longest axis when rendering pages for image extraction. Lower values reduce memory usage. Default: 2000",
+    },
+    {
         "name": "pages",
         "python_name": "pages",
         "short_name": None,

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -28,6 +28,7 @@ def convert(
     image_output: Optional[str] = None,
     image_format: Optional[str] = None,
     image_dir: Optional[str] = None,
+    image_resolution: Optional[str] = None,
     pages: Optional[str] = None,
     include_header_footer: bool = False,
     detect_strikethrough: bool = False,
@@ -64,6 +65,7 @@ def convert(
         image_output: Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external
         image_format: Output format for extracted images. Values: png, jpeg. Default: png
         image_dir: Directory for extracted images
+        image_resolution: Max pixel size for the longest axis when rendering pages for image extraction. Lower values reduce memory usage. Default: 2000
         pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages
         include_header_footer: Include page headers and footers in output
         detect_strikethrough: Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)
@@ -128,6 +130,8 @@ def convert(
         args.extend(["--image-format", image_format])
     if image_dir:
         args.extend(["--image-dir", image_dir])
+    if image_resolution:
+        args.extend(["--image-resolution", image_resolution])
     if pages:
         args.extend(["--pages", pages])
     if include_header_footer:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Issue resolved by this Pull Request:**
Resolves #458

**Description:**

Pass `imagePixelSize` to veraPDF's `ContrastRatioConsumer` to cap the longest axis of rendered page images to a configurable maximum (default 2000px). Previously `null` was passed, causing veraPDF to use a constant 144 DPI which produces unbounded memory usage for large/poster pages.

Memory comparison per rendered page:
| Page size | 144 DPI (current) | imagePixelSize=2000 |
|---|---|---|
| Letter (8.5"x11") | 1224x1584 → 7.8 MB | 1545x2000 → 12 MB |
| A3 poster (16.5"x23.4") | 2376×3369 → 32 MB | 1409×2000 → 11 MB |
| A0 poster (33.1"x46.8") | 4766×6739 → 129 MB | 1414×2000 → 11 MB |

Adds `--image-resolution` CLI option so users can tune this for their needs.

**Remaining work** (follow-up issue):
- `ContrastRatioConsumer` loads a second full copy of the PDDocument — for PDFs with many embedded image streams this doubles memory usage regardless of render resolution. Requires upstream veraPDF change or reusing the already-loaded document.
- No page-batch streaming — all pages are extracted into memory before output generation. For very large PDFs, batching by page count would bound peak memory.

**Checklist:**

- [x] Tests have been added, if necessary.
- [x] `npm run sync` has been run to regenerate bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable image resolution option for PDF image extraction. Control the maximum pixel size on the longest axis during page rendering via the `--image-resolution` CLI flag or configuration settings (default: 2000 pixels). Enables users to balance image quality with processing performance.

* **Tests**
  * Added integration and unit tests validating image extraction functionality across multiple resolution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->