### PR TITLE
Remove StructParent from annotations that are artifacts

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -419,6 +419,12 @@ public class AutoTaggingProcessor {
                 annotObj.setKey(ASAtom.STRUCT_PARENT, COSInteger.construct(structParentInt));
                 cosDocument.addChangedObject(annotObj);
                 pageChanged = true;
+            } else {
+                if (annotation.knownKey(ASAtom.STRUCT_PARENT)) {
+                    annotation.removeKey(ASAtom.STRUCT_PARENT);
+                    cosDocument.addChangedObject(annotObj);
+                    pageChanged = true;
+                }
             }
         }
         // Flush the Annots array (may be an indirect object separate from the page)

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -420,8 +420,8 @@ public class AutoTaggingProcessor {
                 cosDocument.addChangedObject(annotObj);
                 pageChanged = true;
             } else {
-                if (annotation.knownKey(ASAtom.STRUCT_PARENT)) {
-                    annotation.removeKey(ASAtom.STRUCT_PARENT);
+                if (annotObj.knownKey(ASAtom.STRUCT_PARENT)) {
+                    annotObj.removeKey(ASAtom.STRUCT_PARENT);
                     cosDocument.addChangedObject(annotObj);
                     pageChanged = true;
                 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of annotation structure links so stale structure parent references are removed when an annotation is detached from the structure tree.
  * Ensures page state is correctly updated and changes are tracked when structure references are cleaned up, reducing inconsistent document state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->