### PR TITLE
fix: pass headless JVM flags so macOS does not show Dock icon

### DIFF
--- a/node/opendataloader-pdf/src/index.ts
+++ b/node/opendataloader-pdf/src/index.ts
@@ -37,7 +37,16 @@ function executeJar(args: string[], executionOptions: JarExecutionOptions = {}):
     }
 
     const command = 'java';
-    const commandArgs = ['-jar', jarPath, ...args];
+    // Force headless AWT so macOS doesn't surface a Dock icon (and steal focus)
+    // every time the JVM touches ImageIO/PDFBox rendering. Safe on all OSes —
+    // the CLI never opens a UI window, only manipulates BufferedImages.
+    const commandArgs = [
+      '-Djava.awt.headless=true',
+      '-Dapple.awt.UIElement=true',
+      '-jar',
+      jarPath,
+      ...args,
+    ];
 
     const javaProcess = spawn(command, commandArgs);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OpenDataLoader PDF - Monorepo workspace",
   "scripts": {
     "build-java": "bash scripts/build-java.sh",
-    "export-options": "npm run build-java && java -jar java/opendataloader-pdf-cli/target/opendataloader-pdf-cli-0.0.0.jar --export-options > options.json",
+    "export-options": "npm run build-java && java -Djava.awt.headless=true -Dapple.awt.UIElement=true -jar java/opendataloader-pdf-cli/target/opendataloader-pdf-cli-0.0.0.jar --export-options > options.json",
     "generate-options": "node scripts/generate-options.mjs",
     "sync-options": "npm run export-options && npm run generate-options",
     "generate-schema": "node scripts/generate-schema.mjs",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
@@ -16,7 +16,18 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
         # Access the embedded JAR inside the package
         jar_ref = resources.files("opendataloader_pdf").joinpath("jar", _JAR_NAME)
         with resources.as_file(jar_ref) as jar_path:
-            command = ["java", "-jar", str(jar_path), *args]
+            # Force headless AWT so macOS doesn't surface a Dock icon (and
+            # steal focus) every time the JVM touches ImageIO/PDFBox
+            # rendering. Safe on all OSes — the CLI never opens a UI window,
+            # only manipulates BufferedImages.
+            command = [
+                "java",
+                "-Djava.awt.headless=true",
+                "-Dapple.awt.UIElement=true",
+                "-jar",
+                str(jar_path),
+                *args,
+            ]
 
             if quiet:
                 # Quiet mode → capture all output

--- a/scripts/run-cli.sh
+++ b/scripts/run-cli.sh
@@ -54,5 +54,6 @@ else
     ARGS=("$@")
 fi
 
-# Run the CLI
-java -jar "$JAR_PATH" "${ARGS[@]}"
+# Run the CLI. Headless flags suppress the macOS Dock icon / focus theft when
+# AWT/ImageIO/PDFBox initialize. Safe on all OSes — the CLI never opens a UI.
+java -Djava.awt.headless=true -Dapple.awt.UIElement=true -jar "$JAR_PATH" "${ARGS[@]}"


### PR DESCRIPTION
## Objective
On macOS, every CLI run pops a Java icon in the Dock and steals focus from the active window. For repeated/batch PDF conversion this turns into a constant flickering, focus-thrashing experience.

## Approach
Pass `-Djava.awt.headless=true` and `-Dapple.awt.UIElement=true` as JVM args **ahead of `-jar`** at every spawn site:

- Node wrapper (`executeJar` in [`node/opendataloader-pdf/src/index.ts`](../blob/fix/macos-headless-jvm-flags/node/opendataloader-pdf/src/index.ts))
- Python wrapper (`run_jar` in [`python/opendataloader-pdf/src/opendataloader_pdf/runner.py`](../blob/fix/macos-headless-jvm-flags/python/opendataloader-pdf/src/opendataloader_pdf/runner.py))
- Maintainer helper [`scripts/run-cli.sh`](../blob/fix/macos-headless-jvm-flags/scripts/run-cli.sh)
- `npm run export-options` in [`package.json`](../blob/fix/macos-headless-jvm-flags/package.json) (used by `npm run sync`)

The CLI never opens a UI — it only manipulates `BufferedImage`s and renders PDFBox pages off-screen — so `java.awt.headless=true` is safe everywhere. `apple.awt.UIElement=true` is the macOS-specific flag the launcher reads to skip Dock registration; it is silently ignored on other OSes.

The `python-mcp` wrapper imports `opendataloader_pdf` and calls `convert()`, so it inherits the fix transitively (no separate change needed).

## Evidence
Ran the built jar and the Node wrapper against `samples/pdf/1901.03003.pdf` on macOS:

| Scenario | Expected | Actual |
|----------|----------|--------|
| `java -D... -jar opendataloader-pdf-cli.jar samples/pdf/1901.03003.pdf` | No Dock icon, PDF processed | No Dock icon, JSON written to output dir |
| Node `convert()` via built `dist/index.js` | No Dock icon, resolves successfully | No Dock icon, resolved with empty stdout (quiet mode) |
| Without flags (baseline, prior behavior) | Java Dock icon appears, steals focus | Confirmed: Dock icon appears every invocation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS compatibility by configuring the CLI to run in true headless mode, preventing unwanted UI elements and Dock icon activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->