### PR TITLE
Add check for PUA in Alt entry

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -397,20 +397,19 @@ public class AutoTaggingProcessor {
             if (contentsText == null) {
                 contentsText = replacementText;
             }
-            setStringEntry(contentsText, annotObj, replacementText, ASAtom.CONTENTS);
+            setStringEntry(contentsText, annotObj, replacementText, ASAtom.CONTENTS, false);
         } else {
             if (PUAHelper.containPUA(existingContents)) {
-                setStringEntry(existingContents, annotObj, replacementText, ASAtom.CONTENTS);
+                setStringEntry(existingContents, annotObj, replacementText, ASAtom.CONTENTS, false);
             }
         }
     }
 
-    private static void setStringEntry(String contents, COSObject object, String replacementText, ASAtom key) {
-        if (PUAHelper.containPUA(contents)) {
-            contents = stripPuaCodePoints(contents);
-        }
+    //PDF/UA-2 rule 8.4.3-3
+    private static void setStringEntry(String contents, COSObject object, String replacementText, ASAtom key,  boolean useFigureCounter) {
+        contents = stripPuaCodePoints(contents);
         if (contents.isEmpty()) {
-            if (Objects.equals(replacementText, "image ")) {
+            if (useFigureCounter) {
                 contents = replacementText + (++imageChunkFigureCounter);
             } else {
                 contents = replacementText;
@@ -758,9 +757,7 @@ public class AutoTaggingProcessor {
         // Write as hex string (isHex=true). UTF-16BE code units whose low byte is 0x5C (e.g. U+D55C "한")
         // would be misparsed as a backslash escape inside a PDF literal string, shifting all subsequent
         // bytes by one and producing PUA code points that fail PDF/UA-2 clause 8.4.3.3.
-        setStringEntry(altText, figureObject, replacementText, ASAtom.ALT);
-        figureObject.setKey(ASAtom.ALT,
-                COSString.construct(altText.getBytes(StandardCharsets.UTF_16), true));
+        setStringEntry(altText, figureObject, replacementText, ASAtom.ALT, true);
         cosDocument.addChangedObject(figureObject);
         processImageNode(image, figureObject);
         addCaptionIfPresent(image, figureObject, cosDocument);
@@ -773,9 +770,9 @@ public class AutoTaggingProcessor {
         double[] bbox = {formula.getLeftX(), formula.getBottomY(), formula.getRightX(), formula.getTopY()};
         addAttributeToStructElem(formulaObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         //PDF/UA-1 rule 7.7-1
-        String replacementText = "formula ";
+        String replacementText = "formula";
         String altText = formula.getLatex().isEmpty() ? replacementText : formula.getLatex();
-        setStringEntry(altText, formulaObject, replacementText, ASAtom.ALT);
+        setStringEntry(altText, formulaObject, replacementText, ASAtom.ALT, false);
         cosDocument.addChangedObject(formulaObject);
         addMcidChildren(formula.getStreamInfos(), formula.getPageNumber(), formulaObject);
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -47,6 +47,7 @@ public class AutoTaggingProcessor {
     private static final Map<Integer, COSObject> pageNumberToFirstStructElement = new HashMap<>();
     private static final String FORMULA_REPLACEMENT_TEXT = "formula";
     private static final String IMAGE_REPLACEMENT_TEXT = "image ";
+    private static final String ANNOTATION_REPLACEMENT_TEXT = "Annotation";
     // Namespace for PDF 2.0-only structure types (FENote, etc.), created in createStructTreeRoot.
     private static COSObject pdf2_0Namespace;
     // Caption elements keyed by their linked content ID (Raman's approach from #377)
@@ -381,7 +382,6 @@ public class AutoTaggingProcessor {
 
     private static void setAnnotationContents(PDAnnotation annotation, COSObject annotObj) {
         String existingContents = annotation.getContents();
-        String replacementText = "Annotation";
         // Preserve the annotation's existing Contents when present
         if (existingContents == null || existingContents.isEmpty()) {
             // Prefer any existing Contents authored on the annotation (accessibility
@@ -396,13 +396,10 @@ public class AutoTaggingProcessor {
                 }
             }
             //TODO Use AI to generate descriptions
-            if (contentsText == null) {
-                contentsText = replacementText;
-            }
-            setStringEntry(contentsText, annotObj, replacementText, ASAtom.CONTENTS, false);
+            setStringEntry(contentsText, annotObj, ANNOTATION_REPLACEMENT_TEXT, ASAtom.CONTENTS, false);
         } else {
             if (PUAHelper.containPUA(existingContents)) {
-                setStringEntry(existingContents, annotObj, replacementText, ASAtom.CONTENTS, false);
+                setStringEntry(existingContents, annotObj, ANNOTATION_REPLACEMENT_TEXT, ASAtom.CONTENTS, false);
             }
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -408,7 +408,7 @@ public class AutoTaggingProcessor {
     //PDF/UA-2 rule 8.4.3-3
     private static void setStringEntry(String contents, COSObject object, String replacementText, ASAtom key,  boolean useFigureCounter) {
         contents = stripPuaCodePoints(contents);
-        if (contents.isEmpty()) {
+        if (contents == null || contents.isEmpty()) {
             if (useFigureCounter) {
                 contents = replacementText + (++imageChunkFigureCounter);
             } else {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -10,6 +10,7 @@ import org.verapdf.as.io.ASMemoryInStream;
 import org.verapdf.cos.*;
 
 import org.verapdf.gf.model.factory.chunks.GraphicsState;
+import org.verapdf.gf.model.impl.operator.textshow.PUAHelper;
 import org.verapdf.gf.model.impl.sa.util.ResourceHandler;
 import org.verapdf.pd.*;
 import org.verapdf.pd.actions.PDAction;
@@ -378,6 +379,7 @@ public class AutoTaggingProcessor {
 
     private static void setAnnotationContents(PDAnnotation annotation, COSObject annotObj) {
         String existingContents = annotation.getContents();
+        String replacementText = "Annotation";
         // Preserve the annotation's existing Contents when present
         if (existingContents == null || existingContents.isEmpty()) {
             // Prefer any existing Contents authored on the annotation (accessibility
@@ -393,12 +395,30 @@ public class AutoTaggingProcessor {
             }
             //TODO Use AI to generate descriptions
             if (contentsText == null) {
-                contentsText = "Annotation";
+                contentsText = replacementText;
             }
-            COSObject textObject = COSString.construct(
-                contentsText.getBytes(StandardCharsets.UTF_16), true);
-            annotObj.setKey(ASAtom.CONTENTS, textObject);
+            setStringEntry(contentsText, annotObj, replacementText, ASAtom.CONTENTS);
+        } else {
+            if (PUAHelper.containPUA(existingContents)) {
+                setStringEntry(existingContents, annotObj, replacementText, ASAtom.CONTENTS);
+            }
         }
+    }
+
+    private static void setStringEntry(String contents, COSObject object, String replacementText, ASAtom key) {
+        if (PUAHelper.containPUA(contents)) {
+            contents = stripPuaCodePoints(contents);
+        }
+        if (contents.isEmpty()) {
+            if (Objects.equals(replacementText, "image ")) {
+                contents = replacementText + (++imageChunkFigureCounter);
+            } else {
+                contents = replacementText;
+            }
+        }
+        COSObject textObject = COSString.construct(
+            contents.getBytes(StandardCharsets.UTF_16), true);
+        object.setKey(key, textObject);
     }
 
     private static void processAnnotations(PDDocument document, COSDocument cosDocument, int pageNumber) {
@@ -684,7 +704,7 @@ public class AutoTaggingProcessor {
      * Remove Unicode Private Use Area code points. PDF/UA-2 clause 8.4.3.3 forbids PUA chars in
      * /Alt entries. Iterates by code point so surrogate pairs for supplementary PUA are handled.
      */
-    private static String stripPuaCodePoints(String in) {
+    public static String stripPuaCodePoints(String in) {
         if (in == null || in.isEmpty()) return in;
         StringBuilder sb = new StringBuilder(in.length());
         int i = 0;
@@ -731,16 +751,14 @@ public class AutoTaggingProcessor {
         addAttributeToStructElem(figureObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         //PDF/UA-1 rule 7.3-1 / PDF/UA-2 rule 8.2.5.28.2-1
         // Use enriched description if available, otherwise fallback "image N"
+        String replacementText = "image ";
         String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
                 ? ((EnrichedImageChunk) image).sanitizeDescription()
-                : "image " + (++imageChunkFigureCounter);
-        altText = stripPuaCodePoints(altText);
-        if (altText.isEmpty()) {
-            altText = "image " + (++imageChunkFigureCounter);
-        }
+                : replacementText + (++imageChunkFigureCounter);
         // Write as hex string (isHex=true). UTF-16BE code units whose low byte is 0x5C (e.g. U+D55C "한")
         // would be misparsed as a backslash escape inside a PDF literal string, shifting all subsequent
         // bytes by one and producing PUA code points that fail PDF/UA-2 clause 8.4.3.3.
+        setStringEntry(altText, figureObject, replacementText, ASAtom.ALT);
         figureObject.setKey(ASAtom.ALT,
                 COSString.construct(altText.getBytes(StandardCharsets.UTF_16), true));
         cosDocument.addChangedObject(figureObject);
@@ -755,9 +773,9 @@ public class AutoTaggingProcessor {
         double[] bbox = {formula.getLeftX(), formula.getBottomY(), formula.getRightX(), formula.getTopY()};
         addAttributeToStructElem(formulaObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         //PDF/UA-1 rule 7.7-1
-        String altText = formula.getLatex().isEmpty() ? "formula" : formula.getLatex();
-        formulaObject.setKey(ASAtom.ALT,
-                COSString.construct(altText.getBytes(StandardCharsets.UTF_16), true));
+        String replacementText = "formula ";
+        String altText = formula.getLatex().isEmpty() ? replacementText : formula.getLatex();
+        setStringEntry(altText, formulaObject, replacementText, ASAtom.ALT);
         cosDocument.addChangedObject(formulaObject);
         addMcidChildren(formula.getStreamInfos(), formula.getPageNumber(), formulaObject);
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -45,6 +45,8 @@ public class AutoTaggingProcessor {
     private static final Map<Integer, COSObject> annotationStructParents = new HashMap<>();
     // First created struct element per page, used to rewrite page destinations to structure destinations.
     private static final Map<Integer, COSObject> pageNumberToFirstStructElement = new HashMap<>();
+    private static final String FORMULA_REPLACEMENT_TEXT = "formula";
+    private static final String IMAGE_REPLACEMENT_TEXT = "image ";
     // Namespace for PDF 2.0-only structure types (FENote, etc.), created in createStructTreeRoot.
     private static COSObject pdf2_0Namespace;
     // Caption elements keyed by their linked content ID (Raman's approach from #377)
@@ -742,22 +744,20 @@ public class AutoTaggingProcessor {
         createFigureStructElemReturning(image, parent, cosDocument);
     }
 
-
-
     private static COSObject createFigureStructElemReturning(ImageChunk image, COSObject parent, COSDocument cosDocument) {
         COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE, image.getPageNumber());
         double[] bbox = {image.getLeftX(), image.getBottomY(), image.getRightX(), image.getTopY()};
         addAttributeToStructElem(figureObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         //PDF/UA-1 rule 7.3-1 / PDF/UA-2 rule 8.2.5.28.2-1
         // Use enriched description if available, otherwise fallback "image N"
-        String replacementText = "image ";
-        String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
-                ? ((EnrichedImageChunk) image).sanitizeDescription()
-                : replacementText + (++imageChunkFigureCounter);
+        String altText = null;
+        if (image instanceof EnrichedImageChunk) {
+            altText = ((EnrichedImageChunk) image).sanitizeDescription();
+        }
         // Write as hex string (isHex=true). UTF-16BE code units whose low byte is 0x5C (e.g. U+D55C "한")
         // would be misparsed as a backslash escape inside a PDF literal string, shifting all subsequent
         // bytes by one and producing PUA code points that fail PDF/UA-2 clause 8.4.3.3.
-        setStringEntry(altText, figureObject, replacementText, ASAtom.ALT, true);
+        setStringEntry(altText, figureObject, IMAGE_REPLACEMENT_TEXT, ASAtom.ALT, true);
         cosDocument.addChangedObject(figureObject);
         processImageNode(image, figureObject);
         addCaptionIfPresent(image, figureObject, cosDocument);
@@ -770,9 +770,8 @@ public class AutoTaggingProcessor {
         double[] bbox = {formula.getLeftX(), formula.getBottomY(), formula.getRightX(), formula.getTopY()};
         addAttributeToStructElem(formulaObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         //PDF/UA-1 rule 7.7-1
-        String replacementText = "formula";
-        String altText = formula.getLatex().isEmpty() ? replacementText : formula.getLatex();
-        setStringEntry(altText, formulaObject, replacementText, ASAtom.ALT, false);
+        String altText = formula.getLatex();
+        setStringEntry(altText, formulaObject, FORMULA_REPLACEMENT_TEXT, ASAtom.ALT, false);
         cosDocument.addChangedObject(formulaObject);
         addMcidChildren(formula.getStreamInfos(), formula.getPageNumber(), formulaObject);
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized and improved sanitization of hidden/invalid (PUA) characters across annotations, image alts, and formulas.
  * Adds sensible default labels for empty or invalid content (default annotation label; image alt uses descriptive text with incremented figure numbers; formula alt falls back to a clear placeholder).
  * Ensures alternative text and annotation contents are written consistently and reliably, with the sanitizer now exposed for reuse.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/491)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->