### PR TITLE
fix(python): deduplicate CLI failure output

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
@@ -78,10 +78,14 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
     except subprocess.CalledProcessError as error:
         print("Error running opendataloader-pdf CLI.", file=sys.stderr)
         print(f"Return code: {error.returncode}", file=sys.stderr)
-        if error.output:
-            print(f"Output: {error.output}", file=sys.stderr)
-        if error.stderr:
-            print(f"Stderr: {error.stderr}", file=sys.stderr)
-        if error.stdout:
-            print(f"Stdout: {error.stdout}", file=sys.stderr)
+        # Streaming mode already wrote the JAR's output live to stdout, so
+        # re-printing the captured copy would duplicate it. Only surface the
+        # captured streams in quiet mode, where the caller has not seen them.
+        # Note: CalledProcessError.output and .stdout are aliases for the same
+        # attribute — printing both produces the same content twice.
+        if quiet:
+            if error.stdout:
+                print(f"Stdout: {error.stdout}", file=sys.stderr)
+            if error.stderr:
+                print(f"Stderr: {error.stderr}", file=sys.stderr)
         raise

--- a/python/opendataloader-pdf/tests/test_runner.py
+++ b/python/opendataloader-pdf/tests/test_runner.py
@@ -1,0 +1,90 @@
+"""Unit tests for runner.py error-handling behaviour.
+
+Regression: when the JAR fails, the streaming branch already wrote the
+JAR's stdout to the console live, so the except handler must not re-emit
+the captured copy. The quiet branch, conversely, has not surfaced anything
+yet and is allowed to print the captured streams — but only once
+(``CalledProcessError.output`` and ``.stdout`` are the same attribute).
+"""
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from opendataloader_pdf import runner
+
+
+class _FakeAsFile:
+    def __init__(self, path):
+        self._path = path
+
+    def __enter__(self):
+        return self._path
+
+    def __exit__(self, *_args):
+        return False
+
+
+@pytest.fixture
+def patched_jar(monkeypatch, tmp_path):
+    """Bypass the real resources lookup so run_jar reaches subprocess."""
+    fake_jar = tmp_path / "opendataloader-pdf-cli.jar"
+    fake_jar.write_bytes(b"")
+    fake_traversable = MagicMock()
+    fake_traversable.joinpath = lambda *_a, **_kw: fake_jar
+    monkeypatch.setattr(runner.resources, "files", lambda _pkg: fake_traversable)
+    monkeypatch.setattr(runner.resources, "as_file", lambda p: _FakeAsFile(p))
+
+
+def test_streaming_failure_does_not_duplicate_output(monkeypatch, capsys, patched_jar):
+    """Streaming mode prints JAR output live; the except handler must not
+    re-emit the captured copy on stderr."""
+    jar_output = "Invalid page range format: '-10'\nusage: [options] ...\n"
+
+    fake_process = MagicMock()
+    fake_process.stdout = iter([jar_output])
+    fake_process.wait.return_value = 2
+    fake_process.__enter__ = lambda self: self
+    fake_process.__exit__ = lambda self, *_a: False
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *_a, **_kw: fake_process)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.run_jar(["--bogus"], quiet=False)
+
+    captured = capsys.readouterr()
+    # JAR text appears exactly once: the live streaming write.
+    assert "Invalid page range format" in captured.out
+    assert captured.out.count("usage: [options]") == 1
+    # The except handler did NOT re-emit the captured copy on stderr.
+    assert "Invalid page range format" not in captured.err
+    assert "usage: [options]" not in captured.err
+    # Meta info is still surfaced.
+    assert "Error running opendataloader-pdf CLI." in captured.err
+    assert "Return code: 2" in captured.err
+
+
+def test_quiet_failure_prints_captured_streams_once(monkeypatch, capsys, patched_jar):
+    """Quiet mode captures output, so the except handler surfaces it — but
+    must avoid the old bug where Output and Stdout (aliases) both printed."""
+    error = subprocess.CalledProcessError(
+        returncode=2,
+        cmd=["java", "-jar", "fake.jar"],
+        output="captured stdout text",
+        stderr="captured stderr text",
+    )
+    monkeypatch.setattr(runner.subprocess, "run", MagicMock(side_effect=error))
+
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.run_jar(["--bogus"], quiet=True)
+
+    err = capsys.readouterr().err
+    assert err.count("captured stdout text") == 1
+    assert err.count("captured stderr text") == 1
+    # The pre-fix code printed both "Output:" and "Stdout:" with the same text.
+    assert "Output:" not in err
+    assert "Stdout: captured stdout text" in err
+    assert "Stderr: captured stderr text" in err
+    assert "Error running opendataloader-pdf CLI." in err
+    assert "Return code: 2" in err


### PR DESCRIPTION
## Objective

When the bundled JAR exits non-zero (e.g. `--pages -10`), the Python wrapper printed the JAR's error + help banner **three times** in a row. Reported internally as PDFDLOSP-4.

## Root cause

In [`runner.py`](python/opendataloader-pdf/src/opendataloader_pdf/runner.py) the streaming branch (`quiet=False`) writes the JAR's combined stdout/stderr to the console live as it arrives. The `except subprocess.CalledProcessError` handler then re-emitted the captured copy — twice, because `CalledProcessError.output` and `.stdout` are the **same attribute**, so `if error.output: print(Output: …)` followed by `if error.stdout: print(Stdout: …)` repeated the same buffer.

```
JAR streaming write       ← banner #1 (already on console)
Error running ...                                   ← meta
Return code: 2                                      ← meta
Output:  <captured copy>  ← banner #2 (duplicate of #1)
Stdout:  <captured copy>  ← banner #3 (alias of `output`)
```

## Approach

- Move the captured-stream prints behind a `quiet` guard. Only quiet mode has *not* surfaced the JAR output to the user, so it's the only path that should print the captured copy.
- Drop the legacy `Output:` line — `error.output` is an alias for `error.stdout`; printing both repeats the same text.
- Comment why the guard exists so the next reader doesn't undo it.

## Evidence

Reproducer:
```python
opendataloader_pdf.convert(input_path="samples/pdf/lorem.pdf", pages="-10", quiet=False)
```

| | before | after |
|---|---|---|
| total lines emitted | 515 | 196 |
| `Invalid page range format` occurrences | 3 | **1** |
| `usage:` banner occurrences | 3 | **1** |
| duplicate `Output:` / `Stdout:` pair | yes | **gone** |
| `Error running … / Return code: 2` | 1 | 1 (unchanged) |

Tests:
```
$ pytest python/opendataloader-pdf/tests/test_runner.py -v
test_streaming_failure_does_not_duplicate_output PASSED
test_quiet_failure_prints_captured_streams_once   PASSED
```

`tests/test_runner.py` covers both branches and is structured to fail loudly if either regression returns.

## Risk

- `quiet=True` path: no user-visible change — the captured stdout/stderr are still surfaced, just without the redundant `Output:` line. `Stdout:` / `Stderr:` headers preserved.
- `quiet=False` path: callers that grep wrapper stderr for the JAR's error text will need to grep wrapper stdout instead (where it was already being streamed). Documented behaviour was always streaming-to-console for the live branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate output when JAR execution encounters errors in non-quiet mode.
  * Improved error message handling in quiet mode to display captured output exactly once.

* **Tests**
  * Added regression tests for error output behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/495)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->