### PR TITLE
fix(cli): emit error for non-PDF top-level input

### DIFF
--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -85,7 +85,7 @@ public class CLIMain {
         boolean hasFailure = false;
         try {
             for (String argument : arguments) {
-                if (!processPath(new File(argument), config)) {
+                if (!processPath(new File(argument), config, true)) {
                     hasFailure = true;
                 }
             }
@@ -110,15 +110,26 @@ public class CLIMain {
 
     /**
      * Processes a file or directory, returning true if all files succeeded.
+     *
+     * <p>{@code isTopLevel} distinguishes user-provided arguments from files
+     * discovered during directory traversal: a non-PDF given directly on the
+     * command line is reported as an error, while non-PDF files inside a
+     * directory are silently skipped (preserves batch-folder processing).
      */
-    private static boolean processPath(File file, Config config) {
+    private static boolean processPath(File file, Config config, boolean isTopLevel) {
         if (!file.exists()) {
             LOGGER.log(Level.WARNING, "File or folder " + file.getAbsolutePath() + " not found.");
             return false;
         }
         if (file.isDirectory()) {
             return processDirectory(file, config);
-        } else if (file.isFile()) {
+        }
+        if (file.isFile()) {
+            if (isTopLevel && !isPdfFile(file)) {
+                System.out.println("Error: '" + file.getName()
+                    + "' is not a PDF file. Input must be a PDF file or a folder containing PDF files.");
+                return false;
+            }
             return processFile(file, config);
         }
         return true;
@@ -132,7 +143,7 @@ public class CLIMain {
         }
         boolean allSucceeded = true;
         for (File child : children) {
-            if (!processPath(child, config)) {
+            if (!processPath(child, config, false)) {
                 allSucceeded = false;
             }
         }

--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -33,6 +33,8 @@ public class CLIMain {
 
     private static final String HELP = "[options] <INPUT FILE OR FOLDER>...\n Options:";
 
+    private enum InputSource { CLI_ARGUMENT, DIRECTORY_CHILD }
+
     public static void main(String[] args) {
         int exitCode = run(args);
         if (exitCode != 0) {
@@ -85,7 +87,7 @@ public class CLIMain {
         boolean hasFailure = false;
         try {
             for (String argument : arguments) {
-                if (!processPath(new File(argument), config, true)) {
+                if (!processPath(new File(argument), config, InputSource.CLI_ARGUMENT)) {
                     hasFailure = true;
                 }
             }
@@ -111,12 +113,13 @@ public class CLIMain {
     /**
      * Processes a file or directory, returning true if all files succeeded.
      *
-     * <p>{@code isTopLevel} distinguishes user-provided arguments from files
-     * discovered during directory traversal: a non-PDF given directly on the
-     * command line is reported as an error, while non-PDF files inside a
+     * <p>{@code source} distinguishes user-provided arguments
+     * ({@link InputSource#CLI_ARGUMENT}) from files discovered during directory
+     * traversal ({@link InputSource#DIRECTORY_CHILD}): a non-PDF given directly
+     * on the command line is reported as an error, while non-PDF files inside a
      * directory are silently skipped (preserves batch-folder processing).
      */
-    private static boolean processPath(File file, Config config, boolean isTopLevel) {
+    private static boolean processPath(File file, Config config, InputSource source) {
         if (!file.exists()) {
             LOGGER.log(Level.WARNING, "File or folder " + file.getAbsolutePath() + " not found.");
             return false;
@@ -125,7 +128,7 @@ public class CLIMain {
             return processDirectory(file, config);
         }
         if (file.isFile()) {
-            if (isTopLevel && !isPdfFile(file)) {
+            if (source == InputSource.CLI_ARGUMENT && !isPdfFile(file)) {
                 System.out.println("Error: '" + file.getName()
                     + "' is not a PDF file. Input must be a PDF file or a folder containing PDF files.");
                 return false;
@@ -143,7 +146,7 @@ public class CLIMain {
         }
         boolean allSucceeded = true;
         for (File child : children) {
-            if (!processPath(child, config, false)) {
+            if (!processPath(child, config, InputSource.DIRECTORY_CHILD)) {
                 allSucceeded = false;
             }
         }

--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
@@ -18,7 +18,10 @@ package org.opendataloader.pdf.cli;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -107,5 +110,116 @@ class CLIMainTest {
         int exitCode = CLIMain.run(new String[]{"/nonexistent/path/file.pdf"});
         assertNotEquals(0, exitCode,
             "Exit code must be non-zero when input file does not exist");
+    }
+
+    /**
+     * A non-PDF file given directly on the command line must produce a clear
+     * error message on stdout and a non-zero exit code, instead of silently
+     * exiting with success.
+     *
+     * <p>Regression test for PDFDLOSP-5.
+     */
+    @Test
+    void testNonPdfTopLevelArgumentEmitsErrorAndFails() throws IOException {
+        Path png = tempDir.resolve("abcd.png");
+        Files.write(png, new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47});
+
+        String stdout = captureStdoutOf(() -> CLIMain.run(new String[]{png.toString()}));
+
+        assertTrue(stdout.contains("'abcd.png' is not a PDF file"),
+            "stdout must mention the offending file name and that it is not a PDF; got: " + stdout);
+        assertTrue(stdout.contains("Input must be a PDF file or a folder containing PDF files"),
+            "stdout must guide the user to valid input; got: " + stdout);
+    }
+
+    @Test
+    void testNonPdfTopLevelArgumentReturnsNonZeroExitCode() throws IOException {
+        Path png = tempDir.resolve("abcd.png");
+        Files.write(png, new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47});
+
+        int exitCode = CLIMain.run(new String[]{png.toString()});
+
+        assertNotEquals(0, exitCode,
+            "Exit code must be non-zero when the top-level argument is not a PDF");
+    }
+
+    /**
+     * Non-PDF files inside a directory must continue to be silently skipped —
+     * batch-folder processing with mixed file types is a legitimate use case
+     * and must not regress.
+     */
+    @Test
+    void testNonPdfFileInsideDirectoryIsSilentlySkipped() throws IOException {
+        Path dir = tempDir.resolve("mixed");
+        Files.createDirectory(dir);
+        Files.write(dir.resolve("note.png"), new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47});
+        Files.write(dir.resolve("readme.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+
+        String stdout = captureStdoutOf(() -> CLIMain.run(new String[]{dir.toString()}));
+
+        assertFalse(stdout.contains("is not a PDF file"),
+            "Files discovered during directory traversal must not trigger the top-level error; got: " + stdout);
+    }
+
+    @Test
+    void testDirectoryWithOnlyNonPdfFilesReturnsZero() throws IOException {
+        Path dir = tempDir.resolve("non-pdf-only");
+        Files.createDirectory(dir);
+        Files.write(dir.resolve("note.png"), new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47});
+
+        int exitCode = CLIMain.run(new String[]{dir.toString()});
+
+        assertEquals(0, exitCode,
+            "Directories containing only non-PDF files must succeed (silent skip)");
+    }
+
+    /**
+     * When the command line mixes a valid PDF argument with a top-level non-PDF
+     * argument, the run must fail overall but only the non-PDF entry should
+     * produce the user-facing error message.
+     */
+    @Test
+    void testMixedTopLevelArgumentsReportOnlyNonPdfAndFailOverall() throws IOException {
+        Path png = tempDir.resolve("note.png");
+        Files.write(png, new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47});
+        Path pdf = tempDir.resolve("doc.pdf");
+        Files.write(pdf, "%PDF-1.4 minimal".getBytes(StandardCharsets.UTF_8));
+
+        String[] stdoutHolder = new String[1];
+        int exitCode = (int) runCapturingStdout(
+            () -> CLIMain.run(new String[]{pdf.toString(), png.toString()}),
+            stdoutHolder);
+
+        assertNotEquals(0, exitCode,
+            "Exit code must be non-zero when any top-level argument is not a PDF");
+        assertTrue(stdoutHolder[0].contains("'note.png' is not a PDF file"),
+            "stdout must call out the non-PDF argument by name; got: " + stdoutHolder[0]);
+    }
+
+    private static String captureStdoutOf(Runnable action) {
+        String[] holder = new String[1];
+        runCapturingStdout(() -> {
+            action.run();
+            return 0;
+        }, holder);
+        return holder[0];
+    }
+
+    // System.setOut is JVM-global; this helper assumes sequential test
+    // execution (JUnit 5 + maven-surefire default). Revisit if parallel
+    // test execution is enabled — concurrent captures would interleave.
+    private static long runCapturingStdout(java.util.concurrent.Callable<Integer> action, String[] stdoutHolder) {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(buffer, true, StandardCharsets.UTF_8));
+        try {
+            int exitCode = action.call();
+            stdoutHolder[0] = buffer.toString(StandardCharsets.UTF_8);
+            return exitCode;
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        } finally {
+            System.setOut(originalOut);
+        }
     }
 }


### PR DESCRIPTION
## Objective

A non-PDF file passed directly on the command line exits silently with code 0, leaving users unsure whether their file was processed. README declares PDF as the only supported input, so this silence is a UX bug rather than intended behavior.

## Approach

Introduce an `isTopLevel` flag in `processPath` to distinguish user-provided arguments from files discovered during directory traversal. Top-level non-PDF arguments now print an error message on stdout and make the run report failure via the existing `hasFailure` path. Files encountered while walking a directory continue to be skipped silently — this preserves the legitimate batch-folder use case (mixed PDF/non-PDF directories).

`npm run sync` is not required — no CLI option definitions changed. Python and Node wrappers pass Java stdout and exit code through unchanged.

## Evidence

Built before/after jars and ran the CLI against each:

| Scenario | Before | After |
|----------|--------|-------|
| top-level non-PDF (`abcd.png`) | silent, exit 0 | error message, exit 1 |
| folder with PDF + png | silent, exit 0 | silent, exit 0 (no regression) |
| mixed args (`doc.pdf abcd.png`) | png silent, exit 0 | png error, exit 1 |
| valid PDF only (sanity) | exit 0, `doc.json` | exit 0, `doc.json` (no regression) |

After-only stdout for top-level non-PDF:

```
Error: 'abcd.png' is not a PDF file. Input must be a PDF file or a folder containing PDF files.
```

Unit tests: `mvn -pl opendataloader-pdf-cli -am test -Dtest=CLIMainTest` → `Tests run: 10, Failures: 0, Errors: 0` (5 new regression-guard cases included: top-level non-PDF error message, top-level non-PDF exit code, directory silent-skip regression guard, directory-of-only-non-PDFs returning 0, mixed-argument partial-failure behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now reports an error and fails for non-PDF top-level inputs, while silently skipping non-PDF files found inside directories; mixed top-level inputs fail overall with error reported for the non-PDF entry.

* **Tests**
  * Added regression tests covering top-level vs directory-child non-PDF handling, exit codes, and stdout behavior; includes helpers to capture and assert console output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/496)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->