### PR TITLE
fix(hybrid)!: fail fast when backend left pages unprocessed with fallback disabled

### DIFF
--- a/docs/hybrid/hybrid-mode-design.md
+++ b/docs/hybrid/hybrid-mode-design.md
@@ -41,7 +41,7 @@ opendataloader-pdf --hybrid hancom input.pdf
 | `--hybrid <name>` | Hybrid backend: `off` (default), `docling`, `hancom`, etc. |
 | `--hybrid-url <url>` | Backend server URL (overrides default) |
 | `--hybrid-timeout <ms>` | Request timeout in milliseconds (default: 0, no timeout) |
-| `--hybrid-fallback` | Fallback to Java on backend error (default: true) |
+| `--hybrid-fallback` | Opt in to Java fallback on backend error (default: disabled — backend failures fail fast with non-zero exit) |
 
 ## Supported Backends
 
@@ -109,7 +109,7 @@ opendataloader-pdf --hybrid hancom input.pdf
 
 | Risk | Mitigation |
 |------|------------|
-| Backend unavailable | `--hybrid-fallback` (default: true) |
+| Backend unavailable or returns failed pages | Fail fast with non-zero exit (default). Opt in to `--hybrid-fallback` to fall back to Java for backend-routed pages. |
 | Triage FN (missed tables) | Conservative threshold, benchmark monitoring |
 | Schema mismatch | Step-by-step validation, type checking |
 | Slow processing | Parallel execution, batch API calls |

--- a/docs/hybrid/hybrid-mode-tasks.md
+++ b/docs/hybrid/hybrid-mode-tasks.md
@@ -519,7 +519,7 @@ Add configuration classes for hybrid processing.
 public class HybridConfig {
     private String url;                  // null = use backend default
     private int timeoutMs = 0;  // 0 = no timeout
-    private boolean fallbackToJava = true;
+    private boolean fallbackToJava = false;
     private int maxConcurrentRequests = 4;
     // getters, setters, builder pattern
 
@@ -593,7 +593,7 @@ New options:
   --hybrid <off|docling|hancom|...> Hybrid backend to use (default: off)
   --hybrid-url <url>                Backend server URL (default: backend-specific)
   --hybrid-timeout <ms>             Request timeout in ms (default: 0, no timeout)
-  --hybrid-fallback                 Fallback to Java on error (default: true)
+  --hybrid-fallback                 Opt in to Java fallback on backend error (default: disabled)
 ```
 
 ```java
@@ -604,8 +604,8 @@ new OptionDefinition("hybrid-url", null, "string", null,
     "Hybrid backend server URL (overrides default)", true),
 new OptionDefinition("hybrid-timeout", null, "string", "0",
     "Hybrid backend request timeout in milliseconds (0 = no timeout)", true),
-new OptionDefinition("hybrid-fallback", null, "boolean", true,
-    "Fallback to Java on hybrid backend error", true),
+new OptionDefinition("hybrid-fallback", null, "boolean", false,
+    "Opt in to Java fallback on hybrid backend error (default: disabled)", true),
 ```
 
 ### Success Criteria

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -263,8 +263,9 @@ public class HybridDocumentProcessor {
                 );
                 backendResults.putAll(fallbackResults);
             } else {
-                LOGGER.log(Level.WARNING, "Backend returned partial_success: {0} page(s) failed (pages {1}), fallback disabled — skipping failed pages",
+                LOGGER.log(Level.WARNING, "Backend returned partial_success: {0} page(s) failed (pages {1}), fallback disabled — failing fast",
                     new Object[]{backendFailedPages.size(), failedPages1Indexed});
+                failFastIfBackendFailedWithoutFallback(backendFailedPages, config.getHybridConfig());
             }
         }
 
@@ -283,6 +284,30 @@ public class HybridDocumentProcessor {
             contents.add(new ArrayList<>());
         }
         return contents;
+    }
+
+    /**
+     * Fails fast when the backend left pages unprocessed and fallback to Java is disabled.
+     * Without this, the CLI would exit 0 with a sparse JSON that drops failed pages,
+     * making backend failures invisible to automation. See PDFDLOSP-11.
+     *
+     * @param backendFailedPages 0-indexed pages that the backend failed to process.
+     * @param hybridConfig       Hybrid configuration; consulted for the fallback flag.
+     * @throws IOException if {@code backendFailedPages} is non-empty and
+     *                     {@code hybridConfig.isFallbackToJava()} returns false. The
+     *                     exception message lists the 1-indexed failed page numbers.
+     */
+    static void failFastIfBackendFailedWithoutFallback(
+            Set<Integer> backendFailedPages,
+            HybridConfig hybridConfig) throws IOException {
+        if (backendFailedPages.isEmpty() || hybridConfig.isFallbackToJava()) {
+            return;
+        }
+        List<Integer> failedPages1Indexed = backendFailedPages.stream()
+            .map(p -> p + 1).sorted().collect(Collectors.toList());
+        throw new IOException(String.format(
+            "Backend processing failed for %d page(s) with fallback disabled: pages %s",
+            backendFailedPages.size(), failedPages1Indexed));
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -62,6 +62,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -300,6 +301,8 @@ public class HybridDocumentProcessor {
     static void failFastIfBackendFailedWithoutFallback(
             Set<Integer> backendFailedPages,
             HybridConfig hybridConfig) throws IOException {
+        Objects.requireNonNull(backendFailedPages, "backendFailedPages");
+        Objects.requireNonNull(hybridConfig, "hybridConfig");
         if (backendFailedPages.isEmpty() || hybridConfig.isFallbackToJava()) {
             return;
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -289,7 +289,7 @@ public class HybridDocumentProcessor {
     /**
      * Fails fast when the backend left pages unprocessed and fallback to Java is disabled.
      * Without this, the CLI would exit 0 with a sparse JSON that drops failed pages,
-     * making backend failures invisible to automation. See PDFDLOSP-11.
+     * making backend failures invisible to automation.
      *
      * @param backendFailedPages 0-indexed pages that the backend failed to process.
      * @param hybridConfig       Hybrid configuration; consulted for the fallback flag.

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridBackendFailureIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridBackendFailureIntegrationTest.java
@@ -71,7 +71,13 @@ class HybridBackendFailureIntegrationTest {
     @AfterEach
     void tearDown() throws IOException {
         try {
-            server.shutdown();
+            // Guard against partial @BeforeEach failure leaving server unassigned
+            // (HybridClientFactory.shutdown() or `new MockWebServer()` could throw
+            // before the assignment). JUnit 5 still calls tearDown, so the guard
+            // prevents an NPE from masking the real setup failure.
+            if (server != null) {
+                server.shutdown();
+            }
         } finally {
             // Drop the cached HybridClient holding the mock server's URL so other
             // tests don't accidentally reuse it. Runs even if server.shutdown()

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridBackendFailureIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridBackendFailureIntegrationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.api.OpenDataLoaderPDF;
+import org.opendataloader.pdf.hybrid.HybridClientFactory;
+import org.opendataloader.pdf.hybrid.HybridConfig;
+import org.opendataloader.pdf.processors.DocumentProcessor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end test for the fail-fast contract on hybrid backend failures.
+ *
+ * <p>Wires a real PDF through {@link DocumentProcessor#processFile} with a mocked
+ * hybrid backend, verifying that the failure surfaces as an {@link IOException}
+ * all the way to the caller — guarding the call site at which
+ * {@code HybridDocumentProcessor.processDocument} invokes the fail-fast helper.
+ * The {@code HybridDocumentProcessorTest} suite covers the helper in isolation;
+ * this test covers the wiring.
+ */
+class HybridBackendFailureIntegrationTest {
+
+    private static final String SAMPLE_PDF = "../../samples/pdf/lorem.pdf";
+
+    @TempDir
+    Path tempDir;
+
+    private MockWebServer server;
+    private File samplePdf;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // HybridClientFactory keeps a process-wide cache keyed by backend name,
+        // so any earlier test that touched docling-fast leaves a client wired
+        // to its own URL. Clear it before standing up our MockWebServer URL.
+        HybridClientFactory.shutdown();
+
+        server = new MockWebServer();
+        server.start();
+        samplePdf = new File(SAMPLE_PDF);
+        assertTrue(samplePdf.exists(), "Sample PDF not found at " + samplePdf.getAbsolutePath());
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        try {
+            server.shutdown();
+        } finally {
+            // Drop the cached HybridClient holding the mock server's URL so other
+            // tests don't accidentally reuse it. Runs even if server.shutdown()
+            // throws, so the cache never leaks the mock URL into other tests.
+            OpenDataLoaderPDF.shutdown();
+        }
+    }
+
+    @Test
+    void backendPartialSuccessFailsFastWhenFallbackDisabled() {
+        // /health probe (Phase 0 checkAvailability)
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+        // /v1/convert/file response — the single page of lorem.pdf is marked
+        // failed. Listing just the requested pages keeps the test's intent
+        // explicit instead of relying on the processor's intersection logic.
+        String partialSuccess = "{"
+            + "\"status\": \"partial_success\","
+            + "\"document\": {\"json_content\": {\"pages\": {}}},"
+            + "\"processing_time\": 0.5,"
+            + "\"errors\": [\"Unknown page: pipeline terminated early\"],"
+            + "\"failed_pages\": [1]"
+            + "}";
+        server.enqueue(new MockResponse()
+            .setBody(partialSuccess)
+            .addHeader("Content-Type", "application/json"));
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setHybrid("docling-fast");
+        // Full mode routes every page to the backend, so the mocked response
+        // covers all of them without depending on triage decisions.
+        config.getHybridConfig().setMode(HybridConfig.MODE_FULL);
+        config.getHybridConfig().setUrl(server.url("").toString().replaceAll("/$", ""));
+        // setFallbackToJava is false by default; assert to document the precondition.
+        assertFalse(config.getHybridConfig().isFallbackToJava(),
+            "fallback should be disabled by default for this scenario");
+
+        IOException ex = assertThrows(IOException.class,
+            () -> DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config));
+
+        assertTrue(ex.getMessage().contains("page(s) with fallback disabled"),
+            "exception should mention fallback context: " + ex.getMessage());
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
@@ -536,10 +536,14 @@ public class HybridDocumentProcessorTest {
 
         // Message must carry enough information that automation reading stderr can
         // identify which pages failed without re-running with verbose logs.
+        // Anchor on the rendered list prefix/suffix so the assertion fails if the
+        // list itself disappears — a bare contains("1") would pass on "1 page(s)".
         Assertions.assertTrue(ex.getMessage().contains("21 page(s)"),
             "message should include failed page count: " + ex.getMessage());
-        Assertions.assertTrue(ex.getMessage().contains("1") && ex.getMessage().contains("21"),
-            "message should include 1-indexed page numbers: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("[1, 2,"),
+            "message should render 1-indexed page list starting at 1: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains(", 21]"),
+            "message should render 1-indexed page list ending at 21: " + ex.getMessage());
         Assertions.assertTrue(ex.getMessage().contains("fallback disabled"),
             "message should explain why processing failed: " + ex.getMessage());
     }
@@ -563,7 +567,29 @@ public class HybridDocumentProcessorTest {
 
         Assertions.assertTrue(ex.getMessage().contains("3 page(s)"),
             "message should include failed page count: " + ex.getMessage());
-        Assertions.assertTrue(ex.getMessage().contains("2") && ex.getMessage().contains("6") && ex.getMessage().contains("21"),
-            "message should include 1-indexed page numbers: " + ex.getMessage());
+        // The exact rendered list — both that the right pages are present and
+        // that they are sorted 1-indexed ascending.
+        Assertions.assertTrue(ex.getMessage().contains("[2, 6, 21]"),
+            "message should render sorted 1-indexed list [2, 6, 21]: " + ex.getMessage());
+    }
+
+    @Test
+    public void testFailFast_SinglePageFailed_RendersSingleElementList() {
+        // Contract guard for single-element list rendering. Keeps the
+        // [<page>] form honest when only one page failed (the most common
+        // partial-failure case in practice).
+        HybridConfig config = new HybridConfig();
+        config.setFallbackToJava(false);
+
+        Set<Integer> failed = new HashSet<>();
+        failed.add(6); // page 7 (1-indexed)
+
+        java.io.IOException ex = Assertions.assertThrows(java.io.IOException.class, () ->
+            HybridDocumentProcessor.failFastIfBackendFailedWithoutFallback(failed, config));
+
+        Assertions.assertTrue(ex.getMessage().contains("1 page(s)"),
+            "message should include failed page count: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("[7]"),
+            "message should render single-element list as [7]: " + ex.getMessage());
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
@@ -484,10 +484,12 @@ public class HybridDocumentProcessorTest {
         Assertions.assertEquals(pages, allChunked);
     }
 
-    // failFastIfBackendFailedWithoutFallback — PDFDLOSP-11 regression tests.
+    // failFastIfBackendFailedWithoutFallback — fail-fast contract for backend failures.
 
     @Test
     public void testFailFast_EmptyFailedPages_NoFallback_DoesNotThrow() throws Exception {
+        // Contract: no failed pages means processing succeeded — never throw,
+        // regardless of fallback flag.
         HybridConfig config = new HybridConfig();
         config.setFallbackToJava(false);
 
@@ -504,6 +506,8 @@ public class HybridDocumentProcessorTest {
 
     @Test
     public void testFailFast_NonEmptyFailedPages_WithFallback_DoesNotThrow() throws Exception {
+        // Contract: when fallback is enabled, failed pages are reprocessed via Java
+        // path elsewhere — this helper must stay silent and never throw.
         HybridConfig config = new HybridConfig();
         config.setFallbackToJava(true);
 
@@ -516,8 +520,9 @@ public class HybridDocumentProcessorTest {
 
     @Test
     public void testFailFast_AllPagesFailed_NoFallback_ThrowsWithPageNumbers() {
-        // PDFDLOSP-11 scenario: every backend page failed (e.g., 500 response per chunk)
-        // and fallback is disabled. Must throw — without this the CLI exits 0 with empty JSON.
+        // Contract: backend left every page unprocessed and fallback is disabled —
+        // throw so the caller (CLI / library wrapper) can surface a non-zero exit
+        // instead of producing an empty result silently.
         HybridConfig config = new HybridConfig();
         config.setFallbackToJava(false);
 
@@ -529,8 +534,8 @@ public class HybridDocumentProcessorTest {
         java.io.IOException ex = Assertions.assertThrows(java.io.IOException.class, () ->
             HybridDocumentProcessor.failFastIfBackendFailedWithoutFallback(failed, config));
 
-        // Message must list failed pages in 1-indexed form so users can identify them
-        // from stderr without re-running with verbose logs.
+        // Message must carry enough information that automation reading stderr can
+        // identify which pages failed without re-running with verbose logs.
         Assertions.assertTrue(ex.getMessage().contains("21 page(s)"),
             "message should include failed page count: " + ex.getMessage());
         Assertions.assertTrue(ex.getMessage().contains("1") && ex.getMessage().contains("21"),
@@ -541,9 +546,10 @@ public class HybridDocumentProcessorTest {
 
     @Test
     public void testFailFast_PartialPagesFailed_NoFallback_ThrowsWithPageNumbers() {
-        // PDFDLOSP-11 also affects partial_success — some pages succeed, others fail,
-        // and fallback is disabled. Earlier behavior would log WARN and continue,
-        // returning exit 0 with sparse JSON. Must also throw.
+        // Contract: partial failure is treated the same as total failure when
+        // fallback is disabled — any unprocessed page must surface as a non-zero
+        // exit, otherwise downstream consumers cannot tell a sparse result from
+        // a successful one.
         HybridConfig config = new HybridConfig();
         config.setFallbackToJava(false);
 

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/HybridDocumentProcessorTest.java
@@ -483,4 +483,81 @@ public class HybridDocumentProcessorTest {
         }
         Assertions.assertEquals(pages, allChunked);
     }
+
+    // failFastIfBackendFailedWithoutFallback — PDFDLOSP-11 regression tests.
+
+    @Test
+    public void testFailFast_EmptyFailedPages_NoFallback_DoesNotThrow() throws Exception {
+        HybridConfig config = new HybridConfig();
+        config.setFallbackToJava(false);
+
+        HybridDocumentProcessor.failFastIfBackendFailedWithoutFallback(new HashSet<>(), config);
+    }
+
+    @Test
+    public void testFailFast_EmptyFailedPages_WithFallback_DoesNotThrow() throws Exception {
+        HybridConfig config = new HybridConfig();
+        config.setFallbackToJava(true);
+
+        HybridDocumentProcessor.failFastIfBackendFailedWithoutFallback(new HashSet<>(), config);
+    }
+
+    @Test
+    public void testFailFast_NonEmptyFailedPages_WithFallback_DoesNotThrow() throws Exception {
+        HybridConfig config = new HybridConfig();
+        config.setFallbackToJava(true);
+
+        Set<Integer> failed = new HashSet<>();
+        failed.add(0);
+        failed.add(3);
+
+        HybridDocumentProcessor.failFastIfBackendFailedWithoutFallback(failed, config);
+    }
+
+    @Test
+    public void testFailFast_AllPagesFailed_NoFallback_ThrowsWithPageNumbers() {
+        // PDFDLOSP-11 scenario: every backend page failed (e.g., 500 response per chunk)
+        // and fallback is disabled. Must throw — without this the CLI exits 0 with empty JSON.
+        HybridConfig config = new HybridConfig();
+        config.setFallbackToJava(false);
+
+        Set<Integer> failed = new HashSet<>();
+        for (int i = 0; i < 21; i++) {
+            failed.add(i);
+        }
+
+        java.io.IOException ex = Assertions.assertThrows(java.io.IOException.class, () ->
+            HybridDocumentProcessor.failFastIfBackendFailedWithoutFallback(failed, config));
+
+        // Message must list failed pages in 1-indexed form so users can identify them
+        // from stderr without re-running with verbose logs.
+        Assertions.assertTrue(ex.getMessage().contains("21 page(s)"),
+            "message should include failed page count: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("1") && ex.getMessage().contains("21"),
+            "message should include 1-indexed page numbers: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("fallback disabled"),
+            "message should explain why processing failed: " + ex.getMessage());
+    }
+
+    @Test
+    public void testFailFast_PartialPagesFailed_NoFallback_ThrowsWithPageNumbers() {
+        // PDFDLOSP-11 also affects partial_success — some pages succeed, others fail,
+        // and fallback is disabled. Earlier behavior would log WARN and continue,
+        // returning exit 0 with sparse JSON. Must also throw.
+        HybridConfig config = new HybridConfig();
+        config.setFallbackToJava(false);
+
+        Set<Integer> failed = new HashSet<>();
+        failed.add(1); // page 2 (1-indexed)
+        failed.add(5); // page 6
+        failed.add(20); // page 21
+
+        java.io.IOException ex = Assertions.assertThrows(java.io.IOException.class, () ->
+            HybridDocumentProcessor.failFastIfBackendFailedWithoutFallback(failed, config));
+
+        Assertions.assertTrue(ex.getMessage().contains("3 page(s)"),
+            "message should include failed page count: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("2") && ex.getMessage().contains("6") && ex.getMessage().contains("21"),
+            "message should include 1-indexed page numbers: " + ex.getMessage());
+    }
 }


### PR DESCRIPTION
## Objective

When using hybrid mode with `--hybrid-fallback` disabled (the default), if the backend returns `partial_success` for any pages (e.g., HTTP 500 per chunk), the CLI logs WARN and continues, producing a sparse/empty JSON and exiting **0**. Automation reading the exit code cannot detect the failure — `subprocess.run(check=True)` does not raise, CI exit-code branches take the success path, and the empty result propagates silently downstream.

The same silent path also triggers on chunk-level transient HTTP/network failures: `HybridDocumentProcessor.java:518-527` catches `IOException` per chunk and populates `backendFailedPages` rather than aborting. With fallback disabled, those failed pages used to flow through the same WARN-and-continue branch.

## Approach

The connection-failure path is already covered by #288 via `IOException` propagation from `processBackendPath()`. A `partial_success` response, however, is a normal Java control-flow path with no exception — `processBackendPath()` returns normally and populates `backendFailedPages` with the failed page numbers. The existing `else` branch (where fallback is disabled) only logged a WARN and continued, leaving the failure invisible to callers.

Extract a small package-private helper `failFastIfBackendFailedWithoutFallback()` that throws `IOException` when `backendFailedPages` is non-empty and the fallback flag is off. Call it from the existing `else` branch. The exception propagates through `OpenDataLoaderPDF.processFile()` to `CLIMain.processFile()`, which catches it and returns `false`, causing the JVM to exit with code 1 — the same contract #288 established for connection failures.

The helper takes only `Set<Integer>` and `HybridConfig`, making the throw logic unit-testable. An end-to-end test wires a real PDF through `DocumentProcessor.processFile` with a `MockWebServer` returning `partial_success`, verifying the `IOException` propagates to the caller and guarding the call site against future refactors. Stale `--hybrid-fallback` default wording in `docs/hybrid/hybrid-mode-design.md` and `docs/hybrid/hybrid-mode-tasks.md` is corrected in the same change. The Python wrapper docstring sync was deferred to a follow-up — the legacy `run()` function does not accept `hybrid_*` kwargs, so the actual edit needs to land in `options.json` or the convert generator template (which feeds `convert_generated.py`).

## Evidence

Verification methods:
- **Helper unit tests (6 in `HybridDocumentProcessorTest`)**: 2×2 matrix of empty/non-empty failed pages × fallback on/off, plus message-content assertions for total, partial (multi-page), and single-page throwing cases. The assertions check the rendered 1-indexed list (e.g. `[2, 6, 21]`, `[7]`) rather than substrings, so a regression in list rendering is caught.
- **End-to-end integration test (`HybridBackendFailureIntegrationTest`)**: `MockWebServer` serves a `/health` probe and a `/v1/convert/file` `partial_success` response with `failed_pages`. `DocumentProcessor.processFile` is invoked with `--hybrid docling-fast` and full triage mode; the test asserts `IOException` propagates with a `"page(s) with fallback disabled"` message. This guards the call site at which `processDocument` invokes the helper.
- **Full regression**: `mvn test` on `opendataloader-pdf-core` + `opendataloader-pdf-cli` continues to pass with no behavior change for existing paths.
- **CLI fail-fast contract (real execution)**: invoked the CLI against an unreachable hybrid backend (`--hybrid-url http://127.0.0.1:1`) and confirmed exit code != 0. This exercises the `processBackendPath()` → catch → throw path from #288 rather than the new helper's path, but verifies the broader fail-fast contract the new helper joins.

| Scenario | Before | After |
|----------|--------|-------|
| Helper, all 21 pages failed, fallback off | (helper did not exist) | Throws `IOException`, message renders `[1, 2, ..., 21]` |
| Helper, 3 pages failed, fallback off | (helper did not exist) | Throws `IOException`, message renders `[2, 6, 21]` |
| Helper, 1 page failed, fallback off | (helper did not exist) | Throws `IOException`, message renders `[7]` |
| Helper, any failed pages, fallback on | (helper did not exist) | Does not throw |
| Helper, empty failed pages, fallback off | (helper did not exist) | Does not throw |
| `MockWebServer` returns `partial_success` through `processDocument` (full triage, fallback off) | Returned normally, sparse JSON written | `IOException` propagates with `"page(s) with fallback disabled"` |
| CLI with `--hybrid-url <unreachable>` (fallback off) | exit 1 (from #288) | exit 1 (regression-guarded) |

## Breaking change

For users invoking `--hybrid <backend>` with `--hybrid-fallback` disabled (the default), exit code is now **1** instead of **0** whenever any backend page failed — including both the `partial_success` response path and chunk-level HTTP/network failures captured in `processBackendPath`. Migration:

- `subprocess.run(check=True)` callers: no change needed — they will now correctly raise on failure.
- Callers that depended on `exit 0 + parsing the sparse JSON`: switch to catching the non-zero exit and reading the `IOException` message from stderr to identify the failed page numbers (the message lists them 1-indexed).
- Users running with `--hybrid-fallback` (Java fallback enabled): unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hybrid processor now fails fast with clear, user-facing error messages listing failed pages when backend-routed pages error and Java fallback is disabled.

* **Behavior Changes**
  * Hybrid fallback to Java is disabled by default; opt in via the hybrid-fallback flag/setting.

* **Documentation**
  * Hybrid mode docs updated to reflect the new default and fail-fast behavior.

* **Tests**
  * Added unit and integration tests covering fail-fast scenarios and error-message content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/499)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->