### PR TITLE
fix(hybrid): forward --picture-description-prompt to docling VLM

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -418,7 +418,7 @@ def create_converter(
                   languages are used.
         enrich_formula: If True, enable formula enrichment (LaTeX extraction).
         enrich_picture_description: If True, enable picture description (alt text generation).
-        picture_description_prompt: Custom prompt forwarded to the VLM. If None, docling's default prompt is used.
+        picture_description_prompt: Custom prompt forwarded to the VLM. If None or blank/whitespace-only, docling's default prompt is used.
         device: Accelerator device for model inference. Options: "auto", "cpu", "cuda", "mps", "xpu".
                 "auto" lets Docling select the best available device. Default: "auto".
     """
@@ -534,7 +534,7 @@ def create_app(
         ocr_lang: List of OCR language codes (engine-specific format).
         enrich_formula: If True, enable formula enrichment (LaTeX extraction).
         enrich_picture_description: If True, enable picture description (alt text generation).
-        picture_description_prompt: Custom prompt forwarded to the VLM. If None, docling's default prompt is used.
+        picture_description_prompt: Custom prompt forwarded to the VLM. If None or blank/whitespace-only, docling's default prompt is used.
         max_file_size: Maximum file size in bytes. 0 means no limit (default).
         device: Accelerator device for model inference ("auto", "cpu", "cuda", "mps", "xpu").
     """
@@ -910,7 +910,7 @@ def main():
         "--picture-description-prompt",
         type=str,
         default=None,
-        help="Custom prompt for picture description. If not set, uses docling's default prompt.",
+        help="Custom prompt for picture description. If unset or blank/whitespace-only, uses docling's default prompt.",
     )
     parser.add_argument(
         "--max-file-size",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -418,7 +418,7 @@ def create_converter(
                   languages are used.
         enrich_formula: If True, enable formula enrichment (LaTeX extraction).
         enrich_picture_description: If True, enable picture description (alt text generation).
-        picture_description_prompt: Custom prompt for picture description. If None, uses default.
+        picture_description_prompt: Custom prompt forwarded to the VLM. If None, docling's default prompt is used.
         device: Accelerator device for model inference. Options: "auto", "cpu", "cuda", "mps", "xpu".
                 "auto" lets Docling select the best available device. Default: "auto".
     """
@@ -473,12 +473,19 @@ def create_converter(
     ):
         ocr_options.psm = psm
 
-    # Configure picture description options with custom prompt
+    # Configure picture description options with custom prompt.
+    # When picture_description_prompt is None or blank, omit the field so
+    # docling's built-in default prompt is used. A blank string would otherwise
+    # silently produce empty-prompt output — same class of silent-flag bug
+    # as PDFDLOSP-20 reported.
     picture_description_options = None
     if enrich_picture_description:
-        picture_description_options = PictureDescriptionVlmOptions(
-            repo_id="HuggingFaceTB/SmolVLM-256M-Instruct",
-        )
+        vlm_kwargs: dict[str, Any] = {
+            "repo_id": "HuggingFaceTB/SmolVLM-256M-Instruct",
+        }
+        if picture_description_prompt and picture_description_prompt.strip():
+            vlm_kwargs["prompt"] = picture_description_prompt
+        picture_description_options = PictureDescriptionVlmOptions(**vlm_kwargs)
 
     pipeline_kwargs = {
         "do_ocr": not disable_ocr,
@@ -527,7 +534,7 @@ def create_app(
         ocr_lang: List of OCR language codes (engine-specific format).
         enrich_formula: If True, enable formula enrichment (LaTeX extraction).
         enrich_picture_description: If True, enable picture description (alt text generation).
-        picture_description_prompt: Custom prompt for picture description.
+        picture_description_prompt: Custom prompt forwarded to the VLM. If None, docling's default prompt is used.
         max_file_size: Maximum file size in bytes. 0 means no limit (default).
         device: Accelerator device for model inference ("auto", "cpu", "cuda", "mps", "xpu").
     """
@@ -903,7 +910,7 @@ def main():
         "--picture-description-prompt",
         type=str,
         default=None,
-        help="Custom prompt for picture description. If not set, uses default prompt optimized for charts and images.",
+        help="Custom prompt for picture description. If not set, uses docling's default prompt.",
     )
     parser.add_argument(
         "--max-file-size",

--- a/python/opendataloader-pdf/tests/test_hybrid_server_picture_description.py
+++ b/python/opendataloader-pdf/tests/test_hybrid_server_picture_description.py
@@ -1,0 +1,101 @@
+"""Tests for `--picture-description-prompt` propagation in the hybrid server.
+
+Covers PDFDLOSP-20: the CLI accepted `--picture-description-prompt` without
+error but the prompt was never written into `PictureDescriptionVlmOptions`,
+so output was byte-identical regardless of the user's prompt. These tests
+lock in both halves of the contract:
+
+    * A custom prompt reaches `PictureDescriptionVlmOptions.prompt`.
+    * Omitting the prompt preserves docling's built-in default.
+    * Blank / whitespace-only prompts are treated as "not provided" so they
+      never silently inject an empty prompt into the VLM.
+    * The whole feature is gated by `enrich_picture_description=True`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from opendataloader_pdf import hybrid_server
+
+
+def _capture_pipeline_options(**kwargs):
+    """Build a converter while mocking out docling's heavy bits so we can
+    introspect the PdfPipelineOptions instance.
+    """
+    captured = {}
+
+    def fake_pdf_format_option(*, pipeline_options):
+        captured["pipeline_options"] = pipeline_options
+        return object()
+
+    with patch(
+        "docling.document_converter.DocumentConverter"
+    ) as mock_dc, patch(
+        "docling.document_converter.PdfFormatOption", side_effect=fake_pdf_format_option
+    ):
+        mock_dc.return_value = object()
+        hybrid_server.create_converter(**kwargs)
+
+    return captured["pipeline_options"]
+
+
+def test_custom_prompt_is_forwarded_to_vlm_options():
+    """The user-supplied prompt must end up on PictureDescriptionVlmOptions.
+
+    Regression for PDFDLOSP-20.
+    """
+    opts = _capture_pipeline_options(
+        enrich_picture_description=True,
+        picture_description_prompt="HELLO WORLD",
+    )
+    assert opts.picture_description_options is not None
+    assert opts.picture_description_options.prompt == "HELLO WORLD"
+
+
+def test_default_prompt_is_preserved_when_user_omits_flag():
+    """When no prompt is given, docling's built-in default must survive.
+
+    Locks the current docling default. If a docling upgrade changes the
+    phrase, this canary fires — at which point we decide whether to track
+    the new default or pin our own.
+    """
+    opts = _capture_pipeline_options(enrich_picture_description=True)
+    assert opts.picture_description_options is not None
+    assert (
+        opts.picture_description_options.prompt
+        == "Describe this image in a few sentences."
+    )
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+def test_blank_prompt_falls_back_to_default(blank):
+    """Empty / whitespace-only prompts must not inject an empty prompt.
+
+    Otherwise we recreate the same class of silent-flag misbehavior that
+    PDFDLOSP-20 reported.
+    """
+    opts = _capture_pipeline_options(
+        enrich_picture_description=True,
+        picture_description_prompt=blank,
+    )
+    assert opts.picture_description_options is not None
+    assert (
+        opts.picture_description_options.prompt
+        == "Describe this image in a few sentences."
+    )
+
+
+def test_prompt_ignored_when_enrichment_disabled():
+    """Without --enrich-picture-description, the prompt has no destination.
+
+    Docling populates a default `picture_description_options` object on
+    `PdfPipelineOptions` even when do_picture_description=False, so we
+    assert on the gate (`do_picture_description`) rather than identity of
+    the options object.
+    """
+    opts = _capture_pipeline_options(
+        enrich_picture_description=False,
+        picture_description_prompt="HELLO WORLD",
+    )
+    assert opts.do_picture_description is False


### PR DESCRIPTION
## Objective

Users passing `--picture-description-prompt` to the hybrid server get byte-identical output regardless of the prompt value — the CLI accepts the flag without error but it has no effect.

Reported via internal Jira [PDFDLOSP-20](https://hancom.atlassian.net/browse/PDFDLOSP-20) across multiple PDFs (arXiv paper, Korean policy PDF) and prompts (`"Describe the image in Korean."`, `"Output exactly: HELLO WORLD"`); all runs produced identical 58803-byte JSON.

## Approach

Thread the prompt into `PictureDescriptionVlmOptions(prompt=...)` inside `create_converter()` — the value was already wired through the call chain (`argparse → main → create_app → create_converter`) but never written into the options object.

Treat `None` and blank/whitespace strings as "not provided" so docling's built-in default prompt (`"Describe this image in a few sentences."`) is preserved. This mirrors how `ocr_lang` handles empty input and avoids recreating the same class of silent-flag misbehavior that this bug report described.

No Java/Node sync required — this option exists only in the Python `hybrid_server` and is not part of `options.json`.

Companion docs update in opendataloader.org: [opendataloader-project/opendataloader.org#20](https://github.com/opendataloader-project/opendataloader.org/pull/20) (warns about SmolVLM's English-centric output).

## Evidence

Loaded `HuggingFaceTB/SmolVLM-256M-Instruct` via docling and ran on a dummy 2-rectangle PNG, then ran the new pytest suite (6 cases, 0 model loads — captures `PdfPipelineOptions` via patched `DocumentConverter`).

| Scenario | Expected | Actual |
|----------|----------|--------|
| No prompt (default) | docling default prompt reaches VLM | Output: `"The image consists of two rectangles. The first rectangle is red and the second rectangle is blue."` |
| `--picture-description-prompt "Describe the image in Korean."` | Custom prompt reaches VLM (output differs from default) | Output: `"한국어: 제어사항 제어지기 마지링지 제어사합"` (proves injection works; gibberish reflects SmolVLM-256M's poor non-English ability, addressed in docs PR) |
| `--picture-description-prompt ""` (blank) | Fall back to docling default | Output identical to "No prompt" case |
| `--picture-description-prompt "   "` (whitespace) | Fall back to docling default | Output identical to "No prompt" case |
| `enrich_picture_description=False` with prompt | Prompt ignored, no VLM invoked | `do_picture_description=False` |
| Full test suite | OCR + CLI + new tests pass | 52/52 |

## Test plan

- [x] New regression tests: `tests/test_hybrid_server_picture_description.py` (6 cases)
- [x] Adjacent suites (`test_hybrid_server_ocr_options`, `test_cli_options`) still pass
- [x] Manual probe with real SmolVLM model confirms prompt reaches VLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Picture description prompt handling: unset, empty, or whitespace-only prompts now correctly fall back to the built-in docling default instead of using an empty value.

* **Documentation**
  * Clarified CLI help for the picture-description prompt to state that leaving it unset uses docling's default.

* **Tests**
  * Added tests to verify prompt propagation, default fallback, whitespace handling, and gating when enrichment is disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/503)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->