### PR TITLE
fix(cli): replace verapdf password exception stack trace with friendly error

### DIFF
--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -20,6 +20,7 @@ import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.api.OpenDataLoaderPDF;
 import org.opendataloader.pdf.api.cli.CLIOptions;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.verapdf.exceptions.InvalidPasswordException;
 
 import java.io.File;
 import java.util.Locale;
@@ -213,6 +214,13 @@ public class CLIMain {
         try {
             OpenDataLoaderPDF.processFile(file.getAbsolutePath(), config);
             return true;
+        } catch (InvalidPasswordException exception) {
+            String password = config.getPassword();
+            String message = (password == null || password.isEmpty())
+                ? "Error: '" + file.getName() + "' is password-protected. Use --password option."
+                : "Error: Incorrect password for '" + file.getName() + "'.";
+            System.out.println(message);
+            return false;
         } catch (Exception exception) {
             LOGGER.log(Level.SEVERE, "Exception during processing file " + file.getAbsolutePath() + ": " +
                 exception.getMessage(), exception);

--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
@@ -15,6 +15,10 @@
  */
 package org.opendataloader.pdf.cli;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.encryption.AccessPermission;
+import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -277,6 +281,84 @@ class CLIMainTest {
             "Exit code must be non-zero when any top-level argument is not a PDF");
         assertTrue(stdoutHolder[0].contains("'note.png' is not a PDF file"),
             "stdout must call out the non-PDF argument by name; got: " + stdoutHolder[0]);
+    }
+
+    /**
+     * Password-protected PDF with no password supplied must produce a single
+     * user-friendly error message (no verapdf stack trace) and exit non-zero.
+     *
+     * <p>Regression test for PDFDLOSP-9.
+     */
+    @Test
+    void testPasswordProtectedWithoutPasswordEmitsFriendlyError() throws IOException {
+        Path pdf = createPasswordProtectedPdf(tempDir.resolve("locked.pdf"), "1234");
+
+        String[] holder = new String[1];
+        int exitCode = (int) runCapturingStdout(
+            () -> CLIMain.run(new String[]{pdf.toString()}),
+            holder);
+
+        assertNotEquals(0, exitCode, "exit code must be non-zero");
+        assertTrue(holder[0].contains("'locked.pdf' is password-protected"),
+            "stdout must call out the file by name and explain it is password-protected; got: " + holder[0]);
+        assertTrue(holder[0].contains("--password"),
+            "stdout must guide the user to the --password option; got: " + holder[0]);
+        assertFalse(holder[0].contains("InvalidPasswordException"),
+            "stdout must not expose internal exception type; got: " + holder[0]);
+        assertFalse(holder[0].contains("at org.verapdf"),
+            "stdout must not expose a stack trace; got: " + holder[0]);
+    }
+
+    /**
+     * Password-protected PDF with an incorrect password must produce a single
+     * user-friendly error message (no verapdf stack trace) and exit non-zero.
+     *
+     * <p>Regression test for PDFDLOSP-9.
+     */
+    @Test
+    void testPasswordProtectedWithWrongPasswordEmitsFriendlyError() throws IOException {
+        Path pdf = createPasswordProtectedPdf(tempDir.resolve("locked.pdf"), "1234");
+
+        String[] holder = new String[1];
+        int exitCode = (int) runCapturingStdout(
+            () -> CLIMain.run(new String[]{pdf.toString(), "--password", "wrongpw"}),
+            holder);
+
+        assertNotEquals(0, exitCode, "exit code must be non-zero");
+        assertTrue(holder[0].contains("Incorrect password for 'locked.pdf'"),
+            "stdout must report incorrect password and the file name; got: " + holder[0]);
+        assertFalse(holder[0].contains("InvalidPasswordException"),
+            "stdout must not expose internal exception type; got: " + holder[0]);
+        assertFalse(holder[0].contains("at org.verapdf"),
+            "stdout must not expose a stack trace; got: " + holder[0]);
+    }
+
+    /**
+     * Correct password must keep the existing success path: exit code 0 and
+     * the JSON output produced next to the input. Regression guard for the
+     * happy case while fixing PDFDLOSP-9.
+     */
+    @Test
+    void testPasswordProtectedWithCorrectPasswordSucceeds() throws IOException {
+        Path pdf = createPasswordProtectedPdf(tempDir.resolve("locked.pdf"), "1234");
+
+        int exitCode = CLIMain.run(new String[]{pdf.toString(), "--password", "1234"});
+
+        assertEquals(0, exitCode, "correct password must keep exit code 0");
+        assertTrue(Files.exists(tempDir.resolve("locked.json")),
+            "JSON output must be produced next to the input PDF");
+    }
+
+    private static Path createPasswordProtectedPdf(Path target, String password) throws IOException {
+        try (PDDocument document = new PDDocument()) {
+            document.addPage(new PDPage());
+            AccessPermission permissions = new AccessPermission();
+            StandardProtectionPolicy policy = new StandardProtectionPolicy(password, password, permissions);
+            policy.setEncryptionKeyLength(128);
+            document.protect(policy);
+            document.save(target.toFile());
+        }
+        return target;
     }
 
     private static String captureStdoutOf(Runnable action) {


### PR DESCRIPTION
## Objective
When a password-protected PDF is opened without a password or with a wrong password, the CLI exposes a 14-line verapdf `InvalidPasswordException` stack trace. End users perceive the program as having crashed.

Fixes [PDFDLOSP-9](https://hancom.atlassian.net/browse/PDFDLOSP-9) (internal tracker)

## Approach
Catch `InvalidPasswordException` in `CLIMain.processFile` and print a single user-friendly message — distinguishing "no password supplied" from "wrong password" — while keeping exit code 1. The library API and all other exception paths are untouched, so the change is scoped to the CLI user experience.

Alternative considered: defining a domain-level exception in `OpenDataLoaderPDF` and rethrowing. Deferred — would change the public API (impacts Python/Node bindings) and is not required to resolve this issue. Can be done as a follow-up if other consumers want the same clean behavior.

## Evidence
Built the shade jar and ran it against the reporter's `password.pdf` (password `1234`) for all three cases:

| Scenario | Expected | Actual |
|----------|----------|--------|
| `--password 1234` | exit 0, `password.json` created | exit 0, JSON created (no regression) |
| no password | one-line error, exit 1, no stack trace | `Error: 'password.pdf' is password-protected. Use --password option.` exit 1, no `InvalidPasswordException` / no `at org.verapdf` |
| `--password wrongpw` | one-line error, exit 1, no stack trace | `Error: Incorrect password for 'password.pdf'.` exit 1, no `InvalidPasswordException` / no `at org.verapdf` |

`CLIMainTest` adds three regression tests using a dynamically generated encrypted PDF (no fixture file checked in). Full suite passes 13/13.

Note: The verapdf logger still emits one `WARNING: Your password for this document is incorrect.` line for the wrong-password case. Suppressing this requires global java.util.logging configuration and is outside the scope of this fix; the actionable error line directly below it gives the user what they need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for processing password-protected PDF files with the `--password` flag.

* **Bug Fixes**
  * Improved error messaging for password-protected files—users are now instructed to use `--password` when missing, and receive clear feedback when an incorrect password is provided.

* **Tests**
  * Added regression tests validating password-protected file handling with various credential scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/504)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->