### PR TITLE
fix(tagged): assign ids to items materialised after struct-tree traversal

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
@@ -60,7 +60,70 @@ public class TaggedDocumentProcessor {
             List<IObject> pageContents = TextLineProcessor.processTextLines(contents.get(pageNumber));
             contents.set(pageNumber, ParagraphProcessor.processParagraphs(pageContents));
         }
+        // PDFDLOSP-7: ParagraphProcessor (and earlier helpers) materialise new
+        // top-level objects (paragraphs, images, list/table containers) that
+        // did not exist when addObjectToContent assigned ids during struct-tree
+        // traversal. Walk the final per-page contents and fill in any missing
+        // ids. Items that already have one are left untouched so the order
+        // produced by the struct-tree pass is preserved.
+        for (int pageNumber = 0; pageNumber < totalPages; pageNumber++) {
+            if (shouldProcessPage(pageNumber)) {
+                fillMissingIds(contents.get(pageNumber));
+            }
+        }
         return contents;
+    }
+
+    private static void fillMissingIds(List<IObject> contents) {
+        for (IObject object : contents) {
+            assignIdIfMissing(object);
+        }
+    }
+
+    private static void assignIdIfMissing(IObject object) {
+        if (object == null) {
+            return;
+        }
+        if (object.getRecognizedStructureId() == null) {
+            object.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+        }
+        if (object instanceof SemanticHeaderOrFooter) {
+            for (IObject child : ((SemanticHeaderOrFooter) object).getContents()) {
+                assignIdIfMissing(child);
+            }
+        } else if (object instanceof PDFList) {
+            for (IObject child : ((PDFList) object).getListItems()) {
+                assignIdIfMissing(child);
+            }
+        } else if (object instanceof ListItem) {
+            for (IObject child : ((ListItem) object).getContents()) {
+                assignIdIfMissing(child);
+            }
+        } else if (object instanceof TableBorder) {
+            TableBorder table = (TableBorder) object;
+            TableBorderRow[] rows = table.getRows();
+            if (rows == null) {
+                return;
+            }
+            for (TableBorderRow row : rows) {
+                if (row == null) {
+                    continue;
+                }
+                TableBorderCell[] cells = row.getCells();
+                if (cells == null) {
+                    continue;
+                }
+                for (TableBorderCell cell : cells) {
+                    if (cell == null) {
+                        continue;
+                    }
+                    assignIdIfMissing(cell);
+                    for (IObject content : cell.getContents()) {
+                        assignIdIfMissing(content);
+                    }
+                }
+            }
+        }
     }
 
     private static List<List<IObject>> collectArtifacts(int totalPages) {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PdfDlospStructTreeIdsIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PdfDlospStructTreeIdsIntegrationTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.processors.DocumentProcessor;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for PDFDLOSP-7: when `--use-struct-tree` is enabled,
+ * recognised content items must carry a stable `id` so downstream consumers
+ * can correlate elements across passes (caption linking, hybrid backends,
+ * external pipelines). Prior to the fix only the items that flowed through
+ * HeaderFooterProcessor (e.g. footers) had an id; paragraphs, images,
+ * headings and list containers produced via the tagged-PDF code path were
+ * silently emitted without one.
+ */
+class PdfDlospStructTreeIdsIntegrationTest {
+
+    private static final String SAMPLE_PDF =
+            "../../samples/pdf/pdfua-1-reference-suite-1-1/PDFUA-Ref-2-01_Magazine-danish.pdf";
+
+    /**
+     * Element types for which every emitted instance must carry an id.
+     * Sub-elements that are conventionally addressed via their parent's id
+     * (text chunks inside a footer, individual table cells) are excluded.
+     *
+     * Note: the Magazine fixture exercises paragraph/heading/image/list/list
+     * item/footer/caption. `table` and `header` are listed for completeness
+     * but are not present in this PDF; they remain in the set so a future
+     * fixture that produces them will be checked automatically.
+     */
+    private static final Set<String> ID_MANDATORY_TYPES = new HashSet<>(Arrays.asList(
+            "paragraph",
+            "heading",
+            "image",
+            "list",
+            "list item",
+            "footer",
+            "header",
+            "caption",
+            "table"
+    ));
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void structTreeMode_emitsIdForEveryRecognisedContentItem() throws Exception {
+        List<String> missing = runAndCollectMissingIds(true);
+        assertTrue(missing.isEmpty(),
+                "Every content item of an id-mandatory type must carry an `id` " +
+                        "field when --use-struct-tree is enabled. Offending paths: " + missing);
+    }
+
+    /**
+     * Locks in the no-regression half of the PDFDLOSP-7 fix: the fix is
+     * deliberately localised to the tagged-PDF path so non-tagged output is
+     * unchanged. The default code path already gives every top-level
+     * paragraph/heading/image/list/footer/caption an id via
+     * DocumentProcessor.setIDs; list items have never been emitted with an id
+     * in this mode (they are still addressed via their parent list) and that
+     * is preserved here. If a future refactor accidentally promotes the
+     * recursive id-fill into shared code and changes that, this test catches
+     * it by failing on the top-level types instead.
+     */
+    @Test
+    void nonStructTreeMode_topLevelItemsStillCarryIds() throws Exception {
+        List<String> missing = runAndCollectMissingIds(false);
+        // Filter out list items: in default mode they have always been emitted
+        // without an id (PDFDLOSP separate latent bug, intentionally out of
+        // scope for this fix).
+        List<String> material = new ArrayList<>();
+        for (String path : missing) {
+            if (!path.contains("type=list item")) {
+                material.add(path);
+            }
+        }
+        assertTrue(material.isEmpty(),
+                "Non-tagged mode must still emit ids for top-level " +
+                        "paragraph/heading/image/list/footer/caption. Offending paths: " + material);
+    }
+
+    private List<String> runAndCollectMissingIds(boolean useStructTree) throws Exception {
+        File source = new File(SAMPLE_PDF);
+        assertTrue(source.exists(), "Sample PDF not found at " + source.getAbsolutePath());
+
+        Path inputPdf = tempDir.resolve("input-" + useStructTree + ".pdf");
+        Files.copy(source.toPath(), inputPdf);
+
+        Path outputDir = tempDir.resolve("output-" + useStructTree);
+        Files.createDirectories(outputDir);
+
+        Config config = new Config();
+        config.setOutputFolder(outputDir.toString());
+        config.setGenerateJSON(true);
+        config.setUseStructTree(useStructTree);
+
+        DocumentProcessor.processFile(inputPdf.toAbsolutePath().toString(), config);
+
+        Path resultJson = outputDir.resolve(inputPdf.getFileName().toString().replace(".pdf", ".json"));
+        assertTrue(Files.exists(resultJson),
+                "Expected JSON output at " + resultJson.toAbsolutePath());
+
+        JsonNode root = new ObjectMapper().readTree(resultJson.toFile());
+        List<String> missing = new ArrayList<>();
+        collectIdMissingPaths(root, "$", missing);
+        return missing;
+    }
+
+    private static void collectIdMissingPaths(JsonNode node, String path, List<String> missing) {
+        if (node == null) {
+            return;
+        }
+        if (node.isObject()) {
+            JsonNode typeNode = node.get("type");
+            if (typeNode != null && typeNode.isTextual()
+                    && ID_MANDATORY_TYPES.contains(typeNode.asText())
+                    && !node.has("id")) {
+                missing.add(path + " (type=" + typeNode.asText() + ")");
+            }
+            node.fields().forEachRemaining(entry ->
+                    collectIdMissingPaths(entry.getValue(),
+                            path + "." + entry.getKey(), missing));
+        } else if (node.isArray()) {
+            for (int i = 0; i < node.size(); i++) {
+                collectIdMissingPaths(node.get(i), path + "[" + i + "]", missing);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Objective
When `--use-struct-tree` is enabled, JSON output omits `id` on most paragraphs and images while the same PDF without `--use-struct-tree` produces ids for every item. Downstream consumers that correlate items across passes (caption linking, hybrid backends, external pipelines) cannot match anything emitted via the tagged-PDF path.

Refs Jira PDFDLOSP-7.

## Approach
`TaggedDocumentProcessor.addObjectToContent` assigns ids during the initial struct-tree walk, but the subsequent `TextLineProcessor` / `ParagraphProcessor.processParagraphs` post-processing materialises new top-level objects (`SemanticParagraph`, `ImageChunk`, `PDFList`, `TableBorder`, …) that miss that hook. Those new objects are then serialised without an `id`.

Add a final per-page id-fill pass at the end of `TaggedDocumentProcessor.processDocument` that walks each page's top-level items and recurses into the recognised containers (`SemanticHeaderOrFooter`, `PDFList`, `ListItem`, `TableBorder`), assigning an id only when one is missing. The helper is intentionally local to the tagged path; promoting it into `DocumentProcessor.setIDs` would change the non-tagged path's id ordering, which `remapMetadataToContents` and `CaptionProcessor` depend on.

## Evidence
Ran the CLI on `samples/pdf/pdfua-1-reference-suite-1-1/PDFUA-Ref-2-01_Magazine-danish.pdf` with and without `--use-struct-tree` and audited every JSON node by `type`.

| Scenario | Expected | Actual |
|----------|----------|--------|
| `--use-struct-tree`, before fix | id-mandatory types may be missing ids | image 67/98, paragraph 291/332, text chunk 0/28 — ~70 items missing |
| `--use-struct-tree`, after fix | every id-mandatory type 100% | image 98/98, paragraph 332/332, heading 70/70, list 6/6, list item 30/30, footer 28/28, text chunk 28/28 |
| default mode, before vs after | unchanged | per-type counts byte-identical; top-level item type sequence diff = 0 |
| full core test suite | green | 645/645 (was 643 + 2 new regression tests) |

New regression test `PdfDlospStructTreeIdsIntegrationTest` covers both modes and fails on the pre-fix build (69 offending paths) while passing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF documents now receive complete structure identification with proper ID assignment for all recognized content types when using struct tree mode.

* **Tests**
  * Added integration tests to verify complete ID assignment for recognized content items and validate struct tree mode functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/505)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->