### PR TITLE
fix: clean error for .pdf-named non-PDF input (PDFDLOSP-14)

### DIFF
--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -20,6 +20,7 @@ import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.api.OpenDataLoaderPDF;
 import org.opendataloader.pdf.api.cli.CLIOptions;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.exceptions.InvalidPdfFileException;
 import org.verapdf.exceptions.InvalidPasswordException;
 
 import java.io.File;
@@ -151,7 +152,7 @@ public class CLIMain {
                     + "' is not a PDF file. Input must be a PDF file or a folder containing PDF files.");
                 return new PathResult(false, 0);
             }
-            return new PathResult(processFile(file, config), isPdf ? 1 : 0);
+            return new PathResult(processFile(file, config, source), isPdf ? 1 : 0);
         }
         return new PathResult(true, 0);
     }
@@ -204,15 +205,32 @@ public class CLIMain {
     /**
      * Processes a single PDF file.
      *
-     * @return true if processing succeeded, false if an error occurred.
+     * <p>{@code source} controls how an {@link InvalidPdfFileException} from
+     * the magic-number guard is surfaced: {@link InputSource#CLI_ARGUMENT}
+     * routes it to stdout as a user-facing error and fails the run;
+     * {@link InputSource#DIRECTORY_CHILD} logs a WARNING and treats the file
+     * as silently skipped so batch-folder runs can still exit 0.
+     *
+     * @param file the file to process
+     * @param config the processing configuration
+     * @param source whether the file came from a CLI argument or directory traversal
+     * @return true if processing succeeded (or the file was a silently
+     *         skipped non-PDF inside a directory), false on error.
      */
-    private static boolean processFile(File file, Config config) {
+    private static boolean processFile(File file, Config config, InputSource source) {
         if (!isPdfFile(file)) {
             LOGGER.log(Level.FINE, "Skipping non-PDF file " + file.getAbsolutePath());
             return true;
         }
         try {
             OpenDataLoaderPDF.processFile(file.getAbsolutePath(), config);
+            return true;
+        } catch (InvalidPdfFileException invalid) {
+            if (source == InputSource.CLI_ARGUMENT) {
+                System.out.println("Error: " + invalid.getMessage());
+                return false;
+            }
+            LOGGER.log(Level.WARNING, invalid.getMessage() + " Skipping.");
             return true;
         } catch (InvalidPasswordException exception) {
             String password = config.getPassword();

--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
@@ -28,6 +28,12 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -359,6 +365,164 @@ class CLIMainTest {
             document.save(target.toFile());
         }
         return target;
+    }
+
+    // --- PDFDLOSP-14: magic-number guard regressions ----------------------
+
+    private static final byte[] JPEG_PREFIX = new byte[]{
+        (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+        0x00, 0x10, 'J', 'F', 'I', 'F', 0x00
+    };
+
+    /**
+     * A .pdf-named file whose content is not actually PDF must produce the
+     * user-facing magic-number error on stdout, fail with non-zero exit, AND
+     * must not leak any veraPDF internal stack trace. Regression for
+     * PDFDLOSP-14.
+     */
+    @Test
+    void testPdfExtensionWithNonPdfContentEmitsMagicNumberError() throws IOException {
+        Path fakePdf = tempDir.resolve("fake.pdf");
+        Files.write(fakePdf, JPEG_PREFIX);
+
+        String[] stdoutHolder = new String[1];
+        int exitCode = (int) runCapturingStdout(
+            () -> CLIMain.run(new String[]{fakePdf.toString()}),
+            stdoutHolder);
+
+        assertNotEquals(0, exitCode,
+            "Exit code must be non-zero when input content is not PDF");
+        assertTrue(stdoutHolder[0].contains("'fake.pdf' is not a valid PDF file (missing %PDF- header)"),
+            "stdout must contain the magic-number error; got: " + stdoutHolder[0]);
+    }
+
+    /**
+     * Stack-trace leakage guard: the veraPDF internals must NEVER appear on
+     * stdout for the non-PDF-content case. This is the core regression we
+     * are preventing — if the catch branch is reverted or the guard moves
+     * back behind PDDocument construction, this test fails.
+     */
+    @Test
+    void testPdfExtensionWithNonPdfContentDoesNotLeakStackTrace() throws IOException {
+        Path fakePdf = tempDir.resolve("fake.pdf");
+        Files.write(fakePdf, JPEG_PREFIX);
+
+        String[] stdoutHolder = new String[1];
+        runCapturingStdout(
+            () -> CLIMain.run(new String[]{fakePdf.toString()}),
+            stdoutHolder);
+
+        String out = stdoutHolder[0];
+        assertFalse(out.toLowerCase(java.util.Locale.ROOT).contains("verapdf"),
+            "Output must not contain 'verapdf'; got: " + out);
+        assertFalse(out.contains("java.io.IOException:"),
+            "Output must not contain 'java.io.IOException:'; got: " + out);
+        assertFalse(out.contains("\tat "),
+            "Output must not contain a Java stack trace ('\\tat '); got: " + out);
+    }
+
+    /**
+     * A directory containing a .pdf-named non-PDF file alongside another
+     * non-PDF file must (a) NOT print the top-level magic-number error to
+     * stdout, (b) still exit 0 (silent skip preserves PR #496's batch-folder
+     * semantics), and (c) emit a single WARNING log line so operators can
+     * investigate why a file was skipped. Captures CLIMain's JUL logger
+     * directly because java.util.logging routes WARNING to a ConsoleHandler
+     * on stderr by default and may be suppressed entirely under --quiet.
+     */
+    @Test
+    void testPdfExtensionNonPdfInsideDirectoryIsSilentlySkipped() throws IOException {
+        Path dir = tempDir.resolve("mixed");
+        Files.createDirectory(dir);
+        Files.write(dir.resolve("fake.pdf"), JPEG_PREFIX);
+        Files.write(dir.resolve("note.png"), new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47});
+
+        List<LogRecord> records = new ArrayList<>();
+        String[] stdoutHolder = new String[1];
+        int exitCode = (int) captureLogsOf(records, () -> runCapturingStdout(
+            () -> CLIMain.run(new String[]{dir.toString()}),
+            stdoutHolder)).intValue();
+
+        assertEquals(0, exitCode,
+            "Directory containing only invalid files must still exit 0 (silent skip)");
+        assertFalse(stdoutHolder[0].contains("Error:"),
+            "Directory traversal must not surface 'Error:' on stdout; got: " + stdoutHolder[0]);
+        assertFalse(stdoutHolder[0].contains("missing %PDF- header"),
+            "Directory traversal must not surface the magic-number error on stdout; got: "
+            + stdoutHolder[0]);
+        long warningMatches = records.stream().filter(r ->
+                r.getLevel() == Level.WARNING
+                && r.getMessage() != null
+                && r.getMessage().contains("'fake.pdf'")
+                && r.getMessage().contains("missing %PDF- header")).count();
+        assertEquals(1L, warningMatches,
+            "Exactly one WARNING log must name the offending file and the missing header; "
+            + "got: " + records);
+    }
+
+    /**
+     * A genuinely corrupted PDF (has %PDF- header, body broken) is OUT of
+     * scope for this fix and must continue to fail via the existing SEVERE
+     * path — NOT through the new magic-number branch. This test pins that
+     * behavior by asserting (a) the user-facing magic-number error never
+     * appears, and (b) the SEVERE log line from CLIMain.processFile is
+     * actually emitted (proving the existing SEVERE path was the one taken).
+     */
+    @Test
+    void testCorruptPdfStillFailsViaExistingPath() throws IOException {
+        Path corrupt = tempDir.resolve("corrupt.pdf");
+        // Valid header, but nothing else — veraPDF will fail at parse time.
+        Files.write(corrupt, "%PDF-1.4\n<garbage>".getBytes(StandardCharsets.UTF_8));
+
+        List<LogRecord> records = new ArrayList<>();
+        String[] stdoutHolder = new String[1];
+        int exitCode = (int) captureLogsOf(records, () -> runCapturingStdout(
+            () -> CLIMain.run(new String[]{corrupt.toString()}),
+            stdoutHolder)).intValue();
+
+        assertNotEquals(0, exitCode,
+            "Corrupt PDF must still fail (non-zero exit)");
+        assertFalse(stdoutHolder[0].contains("missing %PDF- header"),
+            "Corrupt-but-headered PDFs must NOT be misreported as missing the header; got: "
+            + stdoutHolder[0]);
+        assertTrue(records.stream().anyMatch(r ->
+                r.getLevel() == Level.SEVERE
+                && r.getMessage() != null
+                && r.getMessage().contains("Exception during processing file")),
+            "Corrupt PDF must take the SEVERE path (not the magic-number branch); got: "
+            + records);
+    }
+
+    /**
+     * Runs {@code action} with a temporary {@link Handler} attached to
+     * {@link CLIMain}'s JUL logger, collecting every {@link LogRecord} into
+     * {@code sink}. Restores the prior handler list and level on exit.
+     *
+     * <p>JUL is global; this helper assumes sequential test execution
+     * (JUnit 5 + Surefire default). Returns whatever {@code action} returned.
+     */
+    private static <T> T captureLogsOf(List<LogRecord> sink, java.util.concurrent.Callable<T> action) {
+        Logger logger = Logger.getLogger(CLIMain.class.getCanonicalName());
+        Level priorLevel = logger.getLevel();
+        boolean priorUseParent = logger.getUseParentHandlers();
+        Handler capture = new Handler() {
+            @Override public void publish(LogRecord record) { sink.add(record); }
+            @Override public void flush() { }
+            @Override public void close() { }
+        };
+        capture.setLevel(Level.ALL);
+        logger.addHandler(capture);
+        logger.setLevel(Level.ALL);
+        logger.setUseParentHandlers(false);
+        try {
+            return action.call();
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        } finally {
+            logger.removeHandler(capture);
+            logger.setLevel(priorLevel);
+            logger.setUseParentHandlers(priorUseParent);
+        }
     }
 
     private static String captureStdoutOf(Runnable action) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/exceptions/InvalidPdfFileException.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/exceptions/InvalidPdfFileException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.exceptions;
+
+import java.io.IOException;
+
+/**
+ * Thrown when an input file does not look like a PDF (the {@code %PDF-} magic
+ * number is missing from the first 1024 bytes).
+ *
+ * <p>This is a checked subtype of {@link IOException} so callers that already
+ * handle {@code IOException} keep compiling, while callers that want to
+ * distinguish "not a PDF" from other I/O failures can catch this type
+ * specifically.
+ *
+ * <p>Public entry points that may surface this exception:
+ * <ul>
+ *   <li>{@code OpenDataLoaderPDF.processFile(String, Config)}</li>
+ *   <li>{@code DocumentProcessor.processFile(String, Config)}</li>
+ *   <li>{@code DocumentProcessor.processFileWithResult(String, Config)}</li>
+ *   <li>{@code DocumentProcessor.extractContents(String, Config)}</li>
+ *   <li>{@code DocumentProcessor.preprocessing(String, Config)}</li>
+ *   <li>{@code AutoTagger.tag(String, Config, Float)}</li>
+ * </ul>
+ */
+public class InvalidPdfFileException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidPdfFileException(String message) {
+        super(message);
+    }
+
+    public InvalidPdfFileException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -51,9 +51,15 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.consumers.LinesPreprocessi
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 import org.verapdf.xmp.containers.StaticXmpCoreContainers;
 
+import org.opendataloader.pdf.exceptions.InvalidPdfFileException;
+
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.ForkJoinPool;
@@ -518,6 +524,7 @@ public class DocumentProcessor {
      */
     public static void preprocessing(String pdfName, Config config) throws IOException {
         LOGGER.log(Level.INFO, () -> "File name: " + pdfName);
+        validatePdfMagicNumber(pdfName);
         updateStaticContainers(config);
         PDDocument pdDocument = new PDDocument(pdfName);
         StaticResources.setDocument(pdDocument);
@@ -544,6 +551,51 @@ public class DocumentProcessor {
         LinesPreprocessingConsumer linesPreprocessingConsumer = new LinesPreprocessingConsumer();
         linesPreprocessingConsumer.findTableBorders();
         StaticContainers.setTableBordersCollection(new TableBordersCollection(linesPreprocessingConsumer.getTableBorders()));
+    }
+
+    /**
+     * Verifies the input file contains the PDF magic number ({@code %PDF-})
+     * within its first 1024 bytes.
+     *
+     * <p>ISO 32000-1 §7.5.2 allows the {@code %PDF-} header to appear "near
+     * the beginning" of the file rather than strictly at byte 0; real-world
+     * PDFs sometimes have a leading UTF-8 BOM or whitespace. A 1024-byte
+     * search window matches that tolerance while still rejecting any
+     * JPG/PNG/HTML/empty file.
+     *
+     * @throws InvalidPdfFileException if the magic number is not present
+     * @throws IOException if the file cannot be opened or read
+     */
+    private static void validatePdfMagicNumber(String pdfName) throws IOException {
+        Path path = Path.of(pdfName);
+        byte[] head;
+        try (InputStream in = Files.newInputStream(path)) {
+            head = in.readNBytes(1024);
+        }
+        byte[] marker = "%PDF-".getBytes(StandardCharsets.US_ASCII);
+        if (indexOfBytes(head, marker) < 0) {
+            Path fileName = path.getFileName();
+            String displayName = fileName != null ? fileName.toString() : pdfName;
+            throw new InvalidPdfFileException(
+                "'" + displayName + "' is not a valid PDF file (missing %PDF- header).");
+        }
+    }
+
+    private static int indexOfBytes(byte[] haystack, byte[] needle) {
+        if (needle.length == 0 || haystack.length < needle.length) {
+            return -1;
+        }
+        int last = haystack.length - needle.length;
+        outer:
+        for (int i = 0; i <= last; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+        return -1;
     }
 
     private static void updateStaticContainers(Config config) {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorMagicNumberTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorMagicNumberTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.processors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.exceptions.InvalidPdfFileException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for PDFDLOSP-14: DocumentProcessor.preprocessing must reject
+ * files whose content is not PDF with a typed InvalidPdfFileException, before
+ * the veraPDF parser is invoked.
+ */
+class DocumentProcessorMagicNumberTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void preprocessingRejectsJpegContentWithInvalidPdfFileException() throws IOException {
+        Path jpgAsPdf = tempDir.resolve("fake.pdf");
+        // JPEG SOI + JFIF APP0 segment header — definitely not PDF.
+        Files.write(jpgAsPdf, new byte[]{
+            (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+            0x00, 0x10, 'J', 'F', 'I', 'F', 0x00
+        });
+
+        InvalidPdfFileException thrown = assertThrows(
+            InvalidPdfFileException.class,
+            () -> DocumentProcessor.preprocessing(jpgAsPdf.toString(), new Config()));
+
+        String message = thrown.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("fake.pdf"),
+            "Message must include the file name; got: " + message);
+        assertTrue(message.contains("%PDF-"),
+            "Message must mention the %PDF- header; got: " + message);
+    }
+
+    @Test
+    void preprocessingAcceptsHeaderAfterBomAndWhitespace() throws IOException {
+        Path bomPdf = tempDir.resolve("bom.pdf");
+        // UTF-8 BOM + spaces + valid PDF header. The magic-number guard must
+        // accept this (1024-byte search window). It will still fail later in
+        // veraPDF because the body is incomplete — that failure must NOT be
+        // an InvalidPdfFileException, since the header IS present.
+        byte[] prefix = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, ' ', ' '};
+        byte[] header = "%PDF-1.4\n".getBytes(StandardCharsets.US_ASCII);
+        byte[] content = new byte[prefix.length + header.length];
+        System.arraycopy(prefix, 0, content, 0, prefix.length);
+        System.arraycopy(header, 0, content, prefix.length, header.length);
+        Files.write(bomPdf, content);
+
+        // Any exception thrown must NOT be InvalidPdfFileException — the
+        // magic-number guard accepted the file. veraPDF may still reject it
+        // later, but that goes through the normal IOException path.
+        Throwable thrown = assertThrows(Throwable.class,
+            () -> DocumentProcessor.preprocessing(bomPdf.toString(), new Config()));
+        assertTrue(!(thrown instanceof InvalidPdfFileException),
+            "Magic-number guard must accept %PDF- preceded by BOM/whitespace; "
+            + "got InvalidPdfFileException: " + thrown.getMessage());
+    }
+
+    @Test
+    void preprocessingRejectsEmptyFile() throws IOException {
+        Path empty = tempDir.resolve("empty.pdf");
+        Files.write(empty, new byte[0]);
+
+        assertThrows(InvalidPdfFileException.class,
+            () -> DocumentProcessor.preprocessing(empty.toString(), new Config()));
+    }
+}


### PR DESCRIPTION
## Summary

- A `.pdf`-named file whose content is not actually PDF (JPG renamed, corrupted download) currently surfaces a 15-line `org.verapdf.parser.PDFParser` stack trace to the user. PR #496 closed the wrong-extension case (`note.png`); this PR closes the orthogonal wrong-content case for both CLI users and Java API consumers.
- New checked exception `InvalidPdfFileException extends IOException` thrown by `DocumentProcessor.preprocessing` when the first 1024 bytes do not contain the `%PDF-` marker. CLI catches the specific type: top-level argument → clean stdout `Error: …`; directory child → WARNING log + silent skip (preserves PR #496's batch-folder semantics).
- 1024-byte search window (not strict 0-byte) honors ISO 32000-1 §7.5.2 tolerance for leading BOM/whitespace.

## Approach

1. Add `InvalidPdfFileException` (core `exceptions` package).
2. `DocumentProcessor.preprocessing` reads the first 1024 bytes via `Files.newInputStream` + `readNBytes(1024)`, searches for the `%PDF-` byte sequence, throws on miss. Runs before `updateStaticContainers` so static state is never mutated for invalid input.
3. `CLIMain.processFile(File, Config, InputSource)` — thread the existing `InputSource` enum (from PR #496) one level deeper into `processFile`, then branch the new typed catch on it.
4. Tests added at both layers, including a no-stack-trace-leak regression guard that asserts `stdout` contains neither `verapdf` nor `java.io.IOException:` nor `\tat ` for the wrong-content scenario.

## Test plan

- [x] `mvn -pl opendataloader-pdf-cli -am test -Dtest=CLIMainTest` → Tests run: 14, Failures: 0
- [x] `mvn -pl opendataloader-pdf-core -am test -Dtest=DocumentProcessorMagicNumberTest` → Tests run: 3, Failures: 0
- [x] Manual end-to-end against built jar:
  - JPG renamed to `fake.pdf` (top-level): `Error: 'fake.pdf' is not a valid PDF file (missing %PDF- header).` exit 1, no stack trace.
  - Real PDF: exit 0, no error.
  - Directory containing both fake `.pdf` and `.png`: WARNING log only (`경고: 'fake.pdf' is not a valid PDF file (missing %PDF- header). Skipping.`), no `Error:` on stdout, exit 0.
  - Corrupt-but-headered PDF (`%PDF-1.4\\n<garbage>`): still fails via existing SEVERE path, exit 1 — out of scope for this fix, behavior unchanged.
- [ ] CI on this branch

## Scope notes

- **Out of scope:** corrupted PDFs with valid header but broken body (still go through the SEVERE log path — different UX problem). PDF version range checks. Hybrid server-side validation (different entry point).
- **`npm run sync` not required** — no CLI option definitions changed.
- **Python/Node wrappers** pass Java stdout and exit code through unchanged → automatic UX improvement, no wrapper code touched.
- **`opendataloader-pdfua` and other Java API consumers** keep compiling — `InvalidPdfFileException extends IOException`, so existing `throws IOException` signatures are source- and binary-compatible. Consumers that want to special-case "not a PDF" can now catch by subtype.

## Files changed

- New: `java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/exceptions/InvalidPdfFileException.java`
- New: `java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorMagicNumberTest.java`
- Modified: `java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java` (+50 lines: magic-number guard + helper)
- Modified: `java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java` (typed catch in `processFile`; `InputSource` parameter)
- Modified: `java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java` (+5 regression tests, JUL handler capture helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added upfront validation to detect non-PDF inputs by file header.

* **Bug Fixes**
  * CLI: non-PDF files provided directly now print a clear missing‑header message and cause a non‑zero exit.
  * Directory/batch runs: non‑PDF files are skipped with a WARNING and overall run can still exit successfully.
  * Corrupted-but-headered PDFs continue to fail through the existing error path.

* **Tests**
  * New tests cover header rejection, skipping behavior, logging assertions, and prevention of stack‑trace leakage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/506)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->