### PR TITLE
fix(cli): announce when a folder contains zero processable PDFs (PDFDLOSP-15)

### DIFF
--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -35,6 +35,22 @@ public class CLIMain {
 
     private enum InputSource { CLI_ARGUMENT, DIRECTORY_CHILD }
 
+    /**
+     * Result of processing a path: whether all files succeeded, and how many
+     * PDF files were processed under it (counted recursively for directories,
+     * 1 or 0 for a single file). Used by {@link #processDirectory} to print a
+     * clear summary when a user-supplied folder contains no PDFs (PDFDLOSP-15).
+     */
+    private static final class PathResult {
+        final boolean allSucceeded;
+        final int pdfCount;
+
+        PathResult(boolean allSucceeded, int pdfCount) {
+            this.allSucceeded = allSucceeded;
+            this.pdfCount = pdfCount;
+        }
+    }
+
     public static void main(String[] args) {
         int exitCode = run(args);
         if (exitCode != 0) {
@@ -87,7 +103,7 @@ public class CLIMain {
         boolean hasFailure = false;
         try {
             for (String argument : arguments) {
-                if (!processPath(new File(argument), config, InputSource.CLI_ARGUMENT)) {
+                if (!processPath(new File(argument), config, InputSource.CLI_ARGUMENT).allSucceeded) {
                     hasFailure = true;
                 }
             }
@@ -119,38 +135,69 @@ public class CLIMain {
      * on the command line is reported as an error, while non-PDF files inside a
      * directory are silently skipped (preserves batch-folder processing).
      */
-    private static boolean processPath(File file, Config config, InputSource source) {
+    private static PathResult processPath(File file, Config config, InputSource source) {
         if (!file.exists()) {
             LOGGER.log(Level.WARNING, "File or folder " + file.getAbsolutePath() + " not found.");
-            return false;
+            return new PathResult(false, 0);
         }
         if (file.isDirectory()) {
-            return processDirectory(file, config);
+            return processDirectory(file, config, source);
         }
         if (file.isFile()) {
-            if (source == InputSource.CLI_ARGUMENT && !isPdfFile(file)) {
+            boolean isPdf = isPdfFile(file);
+            if (source == InputSource.CLI_ARGUMENT && !isPdf) {
                 System.out.println("Error: '" + file.getName()
                     + "' is not a PDF file. Input must be a PDF file or a folder containing PDF files.");
-                return false;
+                return new PathResult(false, 0);
             }
-            return processFile(file, config);
+            return new PathResult(processFile(file, config), isPdf ? 1 : 0);
         }
-        return true;
+        return new PathResult(true, 0);
     }
 
-    private static boolean processDirectory(File file, Config config) {
+    /**
+     * Counts PDF files processed under the directory rooted at {@code file}
+     * (recursively), so the CLI can surface a clear summary when a
+     * user-supplied folder contains no PDFs. Without this feedback the program
+     * would exit silently with status 0 and the user could not distinguish
+     * "wrong folder", "empty folder", and "successful run" (PDFDLOSP-15).
+     *
+     * <p>The summary is only printed for folders given directly on the command
+     * line ({@link InputSource#CLI_ARGUMENT}) — nested subdirectories aggregate
+     * upward into the top-level count rather than each printing their own line.
+     *
+     * <p>The summary line is the final <em>result</em> of the run, not a log
+     * entry, and is therefore intentionally emitted on stdout even under
+     * {@code --quiet}. {@code --quiet} suppresses processing logs; users
+     * still need to see whether anything was actually processed. The path
+     * shown is {@link File#getPath()} (the literal argument the user typed,
+     * e.g. {@code .} or {@code basic_images}) rather than {@link File#getName()},
+     * which would be empty for {@code .} or trailing-slash inputs.
+     */
+    private static PathResult processDirectory(File file, Config config, InputSource source) {
         File[] children = file.listFiles();
         if (children == null) {
             LOGGER.log(Level.WARNING, "Unable to read folder " + file.getAbsolutePath());
-            return false;
+            return new PathResult(false, 0);
         }
         boolean allSucceeded = true;
+        int pdfCount = 0;
         for (File child : children) {
-            if (!processPath(child, config, InputSource.DIRECTORY_CHILD)) {
+            PathResult childResult = processPath(child, config, InputSource.DIRECTORY_CHILD);
+            if (!childResult.allSucceeded) {
                 allSucceeded = false;
             }
+            pdfCount += childResult.pdfCount;
         }
-        return allSucceeded;
+        if (source == InputSource.CLI_ARGUMENT) {
+            if (pdfCount == 0) {
+                System.out.println("No PDF files found in '" + file.getPath() + "'.");
+            } else {
+                System.out.println("Processed " + pdfCount + " PDF file"
+                    + (pdfCount == 1 ? "" : "s") + " in '" + file.getPath() + "'.");
+            }
+        }
+        return new PathResult(allSucceeded, pdfCount);
     }
 
     /**

--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
@@ -174,6 +174,89 @@ class CLIMainTest {
     }
 
     /**
+     * A folder containing zero processable PDFs must emit a clear "No PDF files
+     * found" message instead of exiting silently with status 0 — without this
+     * the user cannot distinguish "wrong folder", "empty folder", and
+     * "successful run". The path shown is the literal argument the user typed
+     * (File#getPath), so {@code .} and trailing-slash inputs render correctly.
+     *
+     * <p>Regression test for PDFDLOSP-15.
+     */
+    @Test
+    void testEmptyDirectoryEmitsNoPdfFoundMessage() throws IOException {
+        Path dir = tempDir.resolve("empty");
+        Files.createDirectory(dir);
+
+        String[] stdoutHolder = new String[1];
+        int exitCode = (int) runCapturingStdout(
+            () -> CLIMain.run(new String[]{dir.toString()}),
+            stdoutHolder);
+
+        assertEquals(0, exitCode, "Empty folder is not an error");
+        assertTrue(stdoutHolder[0].contains("No PDF files found in '" + dir + "'"),
+            "stdout must report that no PDFs were found; got: " + stdoutHolder[0]);
+    }
+
+    @Test
+    void testDirectoryWithOnlyNonPdfFilesEmitsNoPdfFoundMessage() throws IOException {
+        Path dir = tempDir.resolve("basic_images");
+        Files.createDirectory(dir);
+        Files.write(dir.resolve("a.png"), new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47});
+        Files.write(dir.resolve("b.jpg"), new byte[]{(byte) 0xFF, (byte) 0xD8});
+
+        String[] stdoutHolder = new String[1];
+        int exitCode = (int) runCapturingStdout(
+            () -> CLIMain.run(new String[]{dir.toString()}),
+            stdoutHolder);
+
+        assertEquals(0, exitCode);
+        assertTrue(stdoutHolder[0].contains("No PDF files found in '" + dir + "'"),
+            "stdout must report that no PDFs were found; got: " + stdoutHolder[0]);
+    }
+
+    /**
+     * Subdirectories must aggregate into the top-level summary rather than
+     * emit their own "No PDF files found" / "Processed N..." lines — only the
+     * user-supplied folder path appears in the output.
+     */
+    @Test
+    void testNestedSubdirectoriesAggregateIntoTopLevelSummary() throws IOException {
+        Path top = tempDir.resolve("top");
+        Path sub = top.resolve("sub");
+        Files.createDirectories(sub);
+        Files.write(sub.resolve("nested.pdf"), "%PDF-1.4 minimal".getBytes(StandardCharsets.UTF_8));
+
+        String[] stdoutHolder = new String[1];
+        runCapturingStdout(
+            () -> CLIMain.run(new String[]{top.toString()}),
+            stdoutHolder);
+
+        assertTrue(stdoutHolder[0].contains("Processed 1 PDF file in '" + top + "'"),
+            "stdout must summarize at the top-level folder including nested PDFs; got: "
+                + stdoutHolder[0]);
+        assertFalse(stdoutHolder[0].contains("in '" + sub + "'"),
+            "stdout must not emit a separate summary for nested subdirectories; got: "
+                + stdoutHolder[0]);
+    }
+
+    @Test
+    void testDirectoryWithMultiplePdfsEmitsProcessedSummary() throws IOException {
+        Path dir = tempDir.resolve("docs");
+        Files.createDirectory(dir);
+        Files.write(dir.resolve("a.pdf"), "%PDF-1.4 minimal".getBytes(StandardCharsets.UTF_8));
+        Files.write(dir.resolve("b.pdf"), "%PDF-1.4 minimal".getBytes(StandardCharsets.UTF_8));
+
+        String[] stdoutHolder = new String[1];
+        runCapturingStdout(
+            () -> CLIMain.run(new String[]{dir.toString()}),
+            stdoutHolder);
+
+        assertTrue(stdoutHolder[0].contains("Processed 2 PDF files in '" + dir + "'"),
+            "stdout must summarize with plural 'files' when count > 1; got: "
+                + stdoutHolder[0]);
+    }
+
+    /**
      * When the command line mixes a valid PDF argument with a top-level non-PDF
      * argument, the run must fail overall but only the non-PDF entry should
      * produce the user-facing error message.


### PR DESCRIPTION
## Objective
When a user runs `opendataloader-pdf <folder>` on a folder that has no PDFs (empty folder, or a folder of images / other files), the program prints nothing and exits 0. The user cannot tell whether the conversion succeeded, the wrong folder was given, or the folder simply had no PDFs.

Fixes [PDFDLOSP-15](https://hancom.atlassian.net/browse/PDFDLOSP-15)

## Approach
After traversing a user-supplied folder, print exactly one summary line:
- 0 PDFs → `No PDF files found in '<folder>'.`
- N PDFs → `Processed N PDF file(s) in '<folder>'.` (singular/plural)

A folder with no PDFs is not an error, so the exit code stays 0 — only actual processing failures still flip it to non-zero. Nested subdirectories aggregate into the top-level count rather than each printing their own line, so the output stays one line per CLI argument. The path is rendered with `File#getPath()` (the literal argument the user typed) so `.` and trailing-slash inputs render correctly. The summary is the run's *result*, not a log entry, and is intentionally emitted even under `--quiet` (which suppresses processing logs, not results) — this is documented in the Javadoc on `processDirectory`.

Implementation detail: a small `PathResult { allSucceeded, pdfCount }` is threaded through `processPath` / `processDirectory` so the boolean success axis and the integer count axis stay independent. The PDF count is taken from the filename extension, not from `processFile`'s return value — the summary truthfully reports how many `.pdf` files were attempted even when individual files fail.

## Evidence
Built the packaged CLI jar and ran it under the exact conditions the ticket describes:

| Scenario | Expected | Actual |
|----------|----------|--------|
| Empty folder | clear "no PDFs" message, exit 0 | `No PDF files found in '/tmp/.../empty'.`, exit 0 |
| Folder containing only a `.png` | clear "no PDFs" message, exit 0 | `No PDF files found in '/tmp/.../basic_images'.`, exit 0 |
| `cd empty_dir && opendataloader-pdf .` | path shown as `.`, not empty string | `No PDF files found in '.'.` |
| Folder with one PDF | singular "1 PDF file", exit 0 | `Processed 1 PDF file in '/tmp/.../single'.`, exit 0 |
| Folder whose PDFs live in a subdirectory only | one summary at the top-level, not two | `Processed 1 PDF file in '<top>'` only; no `'sub'` line |
| `--quiet` on an empty folder | result still visible | summary printed; processing logs suppressed |

Test suite: `mvn -pl opendataloader-pdf-cli -am test` — **BUILD SUCCESS**, CLI 14/14 pass (4 new regression tests for PDFDLOSP-15), core 59/59 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI now provides summary feedback when processing directories, displaying either "No PDF files found" or "Processed N PDF file(s)" for top-level paths, with improved tracking across nested directories.

* **Tests**
  * Added regression tests for directory-processing output behavior, covering empty directories, non-PDF-only directories, nested PDF discovery, and multiple-file scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/507)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->