### PR TITLE
fix(hybrid): activate --hybrid-fallback on server-absent path (PDFDLOSP-21)

### DIFF
--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
@@ -371,9 +371,10 @@ class CLIMainTest {
 
     /**
      * When the hybrid backend is unreachable and {@code --hybrid-fallback} is
-     * NOT supplied, CLIMain must surface the friendly fail-fast message on
-     * stdout (including the new {@code --hybrid-fallback} hint) and must never
-     * leak a Java stack trace. Regression for PDFDLOSP-21.
+     * NOT supplied, CLIMain must surface the friendly fail-fast message
+     * (including the new {@code --hybrid-fallback} hint) via the SEVERE log
+     * record and must never leak a Java stack trace to stdout. Regression for
+     * PDFDLOSP-21.
      */
     @Test
     void testHybridUnavailableWithoutFallbackEmitsFriendlyMessageNoStackTrace() throws IOException {
@@ -392,20 +393,50 @@ class CLIMainTest {
         }
 
         String[] stdoutHolder = new String[1];
-        int exitCode = (int) runCapturingStdout(() -> CLIMain.run(new String[]{
-            "--hybrid", "docling-fast",
-            "--hybrid-mode", "full",
-            "--hybrid-url", "http://127.0.0.1:" + closedPort,
-            "--output", tempDir.toString(),
-            testPdf.toString()
-        }), stdoutHolder);
+        StringBuilder logCapture = new StringBuilder();
+        java.util.logging.Logger cliLogger = java.util.logging.Logger.getLogger(
+            "org.opendataloader.pdf.cli.CLIMain");
+        java.util.logging.Handler captureHandler = new java.util.logging.Handler() {
+            @Override public void publish(java.util.logging.LogRecord record) {
+                logCapture.append(record.getMessage()).append('\n');
+                Throwable thrown = record.getThrown();
+                while (thrown != null) {
+                    logCapture.append(thrown).append('\n');
+                    for (StackTraceElement frame : thrown.getStackTrace()) {
+                        logCapture.append("\tat ").append(frame).append('\n');
+                    }
+                    thrown = thrown.getCause();
+                }
+            }
+            @Override public void flush() {}
+            @Override public void close() {}
+        };
+        cliLogger.addHandler(captureHandler);
+        int exitCode;
+        try {
+            exitCode = (int) runCapturingStdout(() -> CLIMain.run(new String[]{
+                "--hybrid", "docling-fast",
+                "--hybrid-mode", "full",
+                "--hybrid-url", "http://127.0.0.1:" + closedPort,
+                "--output", tempDir.toString(),
+                testPdf.toString()
+            }), stdoutHolder);
+        } finally {
+            cliLogger.removeHandler(captureHandler);
+        }
 
         assertNotEquals(0, exitCode,
             "Exit code must be non-zero when hybrid backend is unreachable and fallback is off");
 
         String out = stdoutHolder[0];
         assertFalse(out.contains("\tat "),
-            "Output must not contain a Java stack trace ('\\tat '); got: " + out);
+            "stdout must not contain a Java stack trace ('\\tat '); got: " + out);
+
+        String logged = logCapture.toString();
+        assertTrue(logged.contains("Hybrid server is not available"),
+            "Log output should explain that the hybrid backend is unreachable; got: " + logged);
+        assertTrue(logged.contains("--hybrid-fallback"),
+            "Log output should include the --hybrid-fallback recovery hint; got: " + logged);
     }
 
     // --- PDFDLOSP-14: magic-number guard regressions ----------------------

--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
@@ -367,6 +367,47 @@ class CLIMainTest {
         return target;
     }
 
+    // --- PDFDLOSP-21: hybrid backend unavailable, stack-trace guard -------
+
+    /**
+     * When the hybrid backend is unreachable and {@code --hybrid-fallback} is
+     * NOT supplied, CLIMain must surface the friendly fail-fast message on
+     * stdout (including the new {@code --hybrid-fallback} hint) and must never
+     * leak a Java stack trace. Regression for PDFDLOSP-21.
+     */
+    @Test
+    void testHybridUnavailableWithoutFallbackEmitsFriendlyMessageNoStackTrace() throws IOException {
+        Path testPdf = tempDir.resolve("ok.pdf");
+        // Minimal but valid-enough header so the file reaches HybridDocumentProcessor.
+        // PDF parsing happens after health-check on this branch.
+        try (PDDocument doc = new PDDocument()) {
+            doc.addPage(new PDPage());
+            doc.save(testPdf.toFile());
+        }
+
+        // Reserve an ephemeral port and release it so connect() is refused.
+        int closedPort;
+        try (java.net.ServerSocket socket = new java.net.ServerSocket(0)) {
+            closedPort = socket.getLocalPort();
+        }
+
+        String[] stdoutHolder = new String[1];
+        int exitCode = (int) runCapturingStdout(() -> CLIMain.run(new String[]{
+            "--hybrid", "docling-fast",
+            "--hybrid-mode", "full",
+            "--hybrid-url", "http://127.0.0.1:" + closedPort,
+            "--output", tempDir.toString(),
+            testPdf.toString()
+        }), stdoutHolder);
+
+        assertNotEquals(0, exitCode,
+            "Exit code must be non-zero when hybrid backend is unreachable and fallback is off");
+
+        String out = stdoutHolder[0];
+        assertFalse(out.contains("\tat "),
+            "Output must not contain a Java stack trace ('\\tat '); got: " + out);
+    }
+
     // --- PDFDLOSP-14: magic-number guard regressions ----------------------
 
     private static final byte[] JPEG_PREFIX = new byte[]{

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingFastServerClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingFastServerClient.java
@@ -117,6 +117,7 @@ public class DoclingFastServerClient implements HybridClient {
                 + "  1. Install: pip install \"opendataloader-pdf[hybrid]\"\n"
                 + "  2. Start:   opendataloader-pdf-hybrid --port 5002\n"
                 + "To use a remote server or custom port: --hybrid-url http://host:port\n"
+                + "Or pass --hybrid-fallback to fall back to Java-only output for this run.\n"
                 + "Or run without --hybrid flag for Java-only processing.", e);
         }
         try (response) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomClient.java
@@ -121,6 +121,7 @@ public class HancomClient implements HybridClient {
             throw new IOException(
                 "Hybrid server is not available at " + baseUrl + "\n"
                 + "Please check the server URL and ensure the Hancom API is accessible.\n"
+                + "Or pass --hybrid-fallback to fall back to Java-only output for this run.\n"
                 + "Or run without --hybrid flag for Java-only processing.", e);
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -184,7 +184,20 @@ public class HybridDocumentProcessor {
         // Phase 0: Check backend availability before any processing.
         // Runs before triage intentionally — if the user explicitly requested hybrid mode,
         // they expect the server to be available regardless of how pages would be routed.
-        getClient(config).checkAvailability();
+        // When the health check fails and --hybrid-fallback is enabled, route every page
+        // through the Java path instead of aborting the whole run (PDFDLOSP-21).
+        try {
+            getClient(config).checkAvailability();
+        } catch (IOException e) {
+            if (config.getHybridConfig().isFallbackToJava()) {
+                LOGGER.log(Level.WARNING,
+                    "Hybrid backend unavailable; falling back to Java-only processing: {0}",
+                    e.getMessage());
+                return processAllPagesAsJavaFallback(
+                    inputPdfName, config, pagesToProcess, totalPages);
+            }
+            throw e;
+        }
 
         // Phase 1: Filter all pages and collect filtered contents
         Map<Integer, List<IObject>> filteredContents = filterAllPages(inputPdfName, config, pagesToProcess, totalPages);
@@ -276,6 +289,40 @@ public class HybridDocumentProcessor {
         // Phase 6: Post-processing (cross-page operations)
         postProcess(contents, config, pagesToProcess, totalPages);
 
+        return contents;
+    }
+
+    /**
+     * Runs the full document through the Java path when the hybrid backend health check
+     * fails and {@code --hybrid-fallback} is enabled. Mirrors the structure of
+     * {@link #processDocument} so the caller still gets a per-page result list, but
+     * skips triage and the backend chunk loop entirely.
+     */
+    private static List<List<IObject>> processAllPagesAsJavaFallback(
+            String inputPdfName,
+            Config config,
+            Set<Integer> pagesToProcess,
+            int totalPages) throws IOException {
+
+        Map<Integer, List<IObject>> filteredContents =
+            filterAllPages(inputPdfName, config, pagesToProcess, totalPages);
+
+        Set<Integer> allPages = new HashSet<>();
+        for (int pageNumber = 0; pageNumber < totalPages; pageNumber++) {
+            if (shouldProcessPage(pageNumber, pagesToProcess)) {
+                allPages.add(pageNumber);
+            }
+        }
+
+        Map<Integer, List<IObject>> javaResults =
+            processJavaPath(filteredContents, allPages, config, totalPages);
+
+        List<List<IObject>> contents = new ArrayList<>();
+        for (int i = 0; i < totalPages; i++) {
+            contents.add(new ArrayList<>());
+        }
+        mergeResults(contents, javaResults, new HashMap<>(), pagesToProcess, totalPages);
+        postProcess(contents, config, pagesToProcess, totalPages);
         return contents;
     }
 

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridBackendFailureIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridBackendFailureIntegrationTest.java
@@ -29,8 +29,11 @@ import org.opendataloader.pdf.processors.DocumentProcessor;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -121,5 +124,114 @@ class HybridBackendFailureIntegrationTest {
 
         assertTrue(ex.getMessage().contains("page(s) with fallback disabled"),
             "exception should mention fallback context: " + ex.getMessage());
+    }
+
+    /**
+     * PDFDLOSP-21 case 1 (P0): backend is entirely unreachable and
+     * {@code --hybrid-fallback} is ON. {@code processDocument} must catch the
+     * health-check IOException and route every page through the Java path so the
+     * run completes normally and writes a valid JSON output.
+     */
+    @Test
+    void serverAbsent_withFallback_processesWithJava() throws IOException {
+        // Reserve a port and immediately close the socket so connection attempts
+        // hit a closed port (most reliable connection-refused simulation that
+        // does not depend on platform DNS quirks).
+        int closedPort = reserveClosedPort();
+        String unreachableUrl = "http://127.0.0.1:" + closedPort;
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setHybrid("docling-fast");
+        config.getHybridConfig().setMode(HybridConfig.MODE_FULL);
+        config.getHybridConfig().setUrl(unreachableUrl);
+        config.getHybridConfig().setFallbackToJava(true);
+
+        assertDoesNotThrow(
+            () -> DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config),
+            "with --hybrid-fallback the run must succeed when the backend is absent");
+
+        Path jsonOutput = tempDir.resolve("lorem.json");
+        assertTrue(Files.exists(jsonOutput),
+            "Java-fallback path should still produce JSON output at " + jsonOutput);
+        assertTrue(Files.size(jsonOutput) > 0L,
+            "JSON output must not be empty when fallback ran successfully");
+    }
+
+    /**
+     * PDFDLOSP-21 case 2 (P0): backend is entirely unreachable and
+     * {@code --hybrid-fallback} is OFF. The run must fail fast with an
+     * {@link IOException} whose message points the user at the new
+     * {@code --hybrid-fallback} escape hatch (DoclingFastServerClient patch).
+     */
+    @Test
+    void serverAbsent_withoutFallback_failsFastWithHelpfulMessage() throws IOException {
+        int closedPort = reserveClosedPort();
+        String unreachableUrl = "http://127.0.0.1:" + closedPort;
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setHybrid("docling-fast");
+        config.getHybridConfig().setMode(HybridConfig.MODE_FULL);
+        config.getHybridConfig().setUrl(unreachableUrl);
+        // Document the precondition: fallback stays off, so health-check failure
+        // must propagate.
+        assertFalse(config.getHybridConfig().isFallbackToJava(),
+            "fallback must be disabled for the fail-fast scenario");
+
+        IOException ex = assertThrows(IOException.class,
+            () -> DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config));
+
+        String msg = ex.getMessage() == null ? "" : ex.getMessage();
+        assertTrue(msg.contains("Hybrid server is not available"),
+            "exception should identify the health-check failure: " + msg);
+        assertTrue(msg.contains("--hybrid-fallback"),
+            "exception should point user to --hybrid-fallback escape hatch: " + msg);
+    }
+
+    /**
+     * PDFDLOSP-21 case 3 (P0): same as case 1 but with an aggressive 1 ms
+     * timeout. The fallback path must be triggered by any IOException raised
+     * from {@code checkAvailability()} — connection refused, connect timeout,
+     * read timeout — so this guards H-6/H-7 equivalence: timeout-driven failures
+     * are recovered just like connection-refused failures.
+     */
+    @Test
+    void serverAbsent_withFallbackAndTinyTimeout_processesWithJava() throws IOException {
+        int closedPort = reserveClosedPort();
+        String unreachableUrl = "http://127.0.0.1:" + closedPort;
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(true);
+        config.setHybrid("docling-fast");
+        config.getHybridConfig().setMode(HybridConfig.MODE_FULL);
+        config.getHybridConfig().setUrl(unreachableUrl);
+        config.getHybridConfig().setFallbackToJava(true);
+        config.getHybridConfig().setTimeoutMs(1);
+
+        assertDoesNotThrow(
+            () -> DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config),
+            "fallback must handle timeout-driven health-check failures too");
+
+        Path jsonOutput = tempDir.resolve("lorem.json");
+        assertTrue(Files.exists(jsonOutput),
+            "Java-fallback path should still produce JSON output at " + jsonOutput);
+        assertTrue(Files.size(jsonOutput) > 0L,
+            "JSON output must not be empty when fallback ran with tiny timeout");
+    }
+
+    /**
+     * Binds an ephemeral port and releases it. Subsequent connect() attempts to
+     * the returned port number are extremely likely to be refused, giving a
+     * deterministic "backend unreachable" condition without relying on
+     * unrouteable IPs (which can hang on some hosts).
+     */
+    private static int reserveClosedPort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Phase 0 health check (`HybridDocumentProcessor.processDocument`) now respects `--hybrid-fallback` — connection refused / health check `IOException` routes through the Java-only path instead of aborting the run
- Hybrid server unavailability message now points users to `--hybrid-fallback` as an alternative escape hatch (was only suggesting `--hybrid` removal)
- Adds P0 regression coverage for the server-absent path so the call-site bug cannot regress

## Root cause

`HybridDocumentProcessor.java:187` invoked `getClient(config).checkAvailability()` *outside* the fallback try/catch at lines 240-252. When the hybrid server was absent, the resulting `IOException` propagated past every `isFallbackToJava()` check (lines 246/259/306) and reached `CLIMain.processFile`, so the option was effectively a no-op in the server-absent path. The timeout path remained healthy because chunk-level `IOException` (line 546) was caught inside the protected region.

This explains the H-6/H-7 equivalence reported in PDFDLOSP-21 (same 23 PDFs failed with identical exit codes regardless of `--hybrid-timeout`).

## Changes

| File | Change |
|---|---|
| `processors/HybridDocumentProcessor.java` | Wrap Phase 0 `checkAvailability()` in try/catch; on `IOException` with fallback enabled, route through new `processAllPagesAsJavaFallback` helper (filterAllPages → processJavaPath → mergeResults → postProcess) |
| `hybrid/DoclingFastServerClient.java` | Add `--hybrid-fallback` hint to the unavailability message |
| `hybrid/HancomClient.java` | Same hint |
| `test/HybridBackendFailureIntegrationTest.java` | P0 cases: fallback ON / OFF / ON+timeout=1 against a closed port via `reserveClosedPort()` helper |
| `cli/CLIMainTest.java` | Stack-trace exposure guard for hybrid-unavailable path (`\tat ` grep, mirrors PDFDLOSP-14 pattern) |

## Test plan

- [x] \`mvn -pl opendataloader-pdf-core -am -o -Dtest=HybridBackendFailureIntegrationTest test\` — 4/4 PASS (1 existing + 3 new)
- [x] \`mvn -pl opendataloader-pdf-core test -Dtest='*Hybrid*'\` — 111/111 PASS, no regression
- [x] \`mvn -pl opendataloader-pdf-cli test -Dtest=CLIMainTest\` — 22/22 PASS
- [x] CLI smoke test (hybrid server stopped, \`samples/pdf/lorem.pdf\`):
  - \`--hybrid docling-fast\` (no fallback) → exit 1, stderr suggests both \`--hybrid-fallback\` and dropping \`--hybrid\`
  - \`--hybrid docling-fast --hybrid-fallback\` → **exit 0, JSON generated** (was: exit 1, no JSON)
  - \`--hybrid docling-fast --hybrid-fallback --hybrid-timeout 1\` → exit 0, JSON generated (H-6/H-7 equivalence restored)

## Out of scope (separate PRs)

- Stack-trace sanitization for the fallback-disabled path (PDFDLOSP-21 recommendation #3, PDFDLOSP-9/12/14 family). Requires a \`HybridUnavailableException\` domain type to avoid brittle message-prefix matching in \`CLIMain\`. Filed as follow-up.
- \`--hybrid-timeout\` default (currently 0 = infinite) — should be a finite value to prevent hangs after server \`bad_alloc\`. Behavior change, separate discussion.
- Circuit breaker for batch processing (long-running automation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit runtime fallback to run Java-only processing when the hybrid backend is unavailable.

* **Bug Fixes**
  * Improved user-facing error messages to mention the fallback hint.
  * Suppressed Java stack traces from standard output on hybrid connection failures.
  * When fallback is enabled, requests automatically route through Java-only processing instead of aborting.

* **Tests**
  * Added regression and integration tests for hybrid absent/unreachable scenarios (with/without fallback and tight timeouts).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/511)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->