### PR TITLE
docs(use-struct-tree): clarify that output quality depends on tag quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ Combine formats: `format="json,markdown"`
 
 When a PDF has structure tags, OpenDataLoader extracts the **exact layout** the author intended — no guessing, no heuristics. Headings, lists, tables, and reading order are preserved from the source.
 
+> **Output quality depends on tag quality.** Not all tagged PDFs are well-tagged. For PDFs with sparse or incorrect tags, the default heuristic mode or `--hybrid docling-fast` often produces better results.
+
 ```python
 # Batch all files in one call — each convert() spawns a JVM process, so repeated calls are slow
 opendataloader_pdf.convert(

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -106,7 +106,7 @@ public class CLIOptions {
 
     // ===== Use Struct Tree =====
     private static final String USE_STRUCT_TREE_LONG_OPTION = "use-struct-tree";
-    private static final String USE_STRUCT_TREE_DESC = "Use PDF structure tree (tagged PDF) for reading order and semantic structure";
+    private static final String USE_STRUCT_TREE_DESC = "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality";
 
     // ===== Table Method =====
     private static final String TABLE_METHOD_LONG_OPTION = "table-method";

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -15,7 +15,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--sanitize', 'Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders');
   program.option('--keep-line-breaks', 'Preserve original line breaks in extracted text');
   program.option('--replace-invalid-chars <value>', 'Replacement character for invalid/unrecognized characters. Default: space');
-  program.option('--use-struct-tree', 'Use PDF structure tree (tagged PDF) for reading order and semantic structure');
+  program.option('--use-struct-tree', 'Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality');
   program.option('--table-method <value>', 'Table detection method. Values: default (border-based), cluster (border + cluster). Default: default');
   program.option('--reading-order <value>', 'Reading order algorithm. Values: off, xycut. Default: xycut');
   program.option('--markdown-page-separator <value>', 'Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -21,7 +21,7 @@ export interface ConvertOptions {
   keepLineBreaks?: boolean;
   /** Replacement character for invalid/unrecognized characters. Default: space */
   replaceInvalidChars?: string;
-  /** Use PDF structure tree (tagged PDF) for reading order and semantic structure */
+  /** Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality */
   useStructTree?: boolean;
   /** Table detection method. Values: default (border-based), cluster (border + cluster). Default: default */
   tableMethod?: string;

--- a/options.json
+++ b/options.json
@@ -70,7 +70,7 @@
       "type": "boolean",
       "required": false,
       "default": false,
-      "description": "Use PDF structure tree (tagged PDF) for reading order and semantic structure"
+      "description": "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality"
     },
     {
       "name": "table-method",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -88,7 +88,7 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "type": "boolean",
         "required": False,
         "default": False,
-        "description": "Use PDF structure tree (tagged PDF) for reading order and semantic structure",
+        "description": "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality",
     },
     {
         "name": "table-method",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -56,7 +56,7 @@ def convert(
         sanitize: Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders
         keep_line_breaks: Preserve original line breaks in extracted text
         replace_invalid_chars: Replacement character for invalid/unrecognized characters. Default: space
-        use_struct_tree: Use PDF structure tree (tagged PDF) for reading order and semantic structure
+        use_struct_tree: Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality
         table_method: Table detection method. Values: default (border-based), cluster (border + cluster). Default: default
         reading_order: Reading order algorithm. Values: off, xycut. Default: xycut
         markdown_page_separator: Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none


### PR DESCRIPTION
## Objective
A user reported that `--use-struct-tree` drops markdown headings (`##`) and omits some content. After inspecting the PDF, it turned out to be a deck-style document tagged entirely as `<P>` with **zero** heading tags — the option was behaving exactly as designed (faithful to the source tag tree), but the user expected it to recover structure. The docs did not set this expectation anywhere.

Fixes PDFDLOSP-8

## Approach
No behavior change. Keep `--use-struct-tree` strict — its value is predictability and tag fidelity, and once we start supplementing untagged content the contract breaks (related discussion: [#456](https://github.com/opendataloader-project/opendataloader-pdf-tasks/issues/456)).

Instead, align user expectation with actual behavior in two places:

- **CLI option description** ([CLIOptions.java](java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java)): append "Output quality depends on tag quality"
- **README Tagged PDF Support section**: add a Note block pointing users with sparse/incorrect tags to the default heuristic mode or `--hybrid docling-fast`

Kept the wording general — not all poorly-tagged PDFs come from one source, so the docs avoid singling out specific authoring tools.

## Evidence
Ran `npm run sync` to regenerate the SDK bindings and docs, then verified the new description propagates to every surface the user can see.

| Scenario | Expected | Actual |
|----------|----------|--------|
| `--help` CLI output | Shows new clause | Shows "Output quality depends on tag quality" |
| `options.json` (generator source) | Updated description field | Updated |
| Python SDK (`cli_options_generated.py`) | Regenerated | Regenerated, matches |
| Node SDK (`cli-options.generated.ts`) | Regenerated | Regenerated, matches |
| README Tagged PDF Support | Note block added | Note block added below the existing paragraph |
| Maven build | SUCCESS | SUCCESS, 21 tests passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified the `--use-struct-tree` option documentation to emphasize that output quality depends on the quality of the input PDF tag structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/512)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->