### PR TITLE
fix(processors): log actual page count being processed, not document total

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -283,7 +283,8 @@ public class DocumentProcessor {
 
         int parallelism = config.getThreads();
         ForkJoinPool pool = new ForkJoinPool(parallelism);
-        LOGGER.log(Level.INFO, "Processing {0} pages with {1} threads", new Object[]{totalPages, parallelism});
+        int pagesToProcessCount = (pagesToProcess != null) ? pagesToProcess.size() : totalPages;
+        LOGGER.log(Level.INFO, "Processing {0} pages with {1} threads", new Object[]{pagesToProcessCount, parallelism});
 
         try {
             // Loop 1: ContentFilter per-page (largest bottleneck)


### PR DESCRIPTION
## Objective
When users pass `--pages` with values that are out of range (e.g. `--pages 99999` on a 15-page PDF), warnings correctly report that no pages will be processed, but the same run also logs `Processing 15 pages with 1 threads`. Users reading the log cannot tell whether processing actually happened or not, and the contradiction between WARN and INFO lines undermines trust in every other log message.

Example before this patch:

```
WARN: Requested pages [99999] do not exist in document (total pages: 15). Processing only existing pages: []
WARN: No valid pages to process. Document has 15 pages but requested: [99999]
INFO: Processing 15 pages with 1 threads
```

The same contradiction occurs with `--pages 1,99999`, `--pages 22-30`, and any other input that filters out some or all pages — the INFO line always echoes the document's total page count rather than what is actually being processed.

## Approach
In `DocumentProcessor.processDocument`, switch the INFO log to report the size of `pagesToProcess` (the validated set) instead of the document's total page count. When `pagesToProcess` is `null` (no `--pages` filter), fall back to `totalPages` so full-document runs still report correctly.

This is the smallest change that resolves the contradiction. Surrounding behavior — exit code on empty results, empty-output file generation, the range auto-clamp asymmetry between `1-99999` and `22-30` — is intentionally left alone. Those belong to a separate discussion about CLI validation policy, not log accuracy.

## Evidence
Built the CLI and ran five scenarios against a 15-page PDF (`samples/pdf/1901.03003.pdf`), grepping for the `Processing N pages with 1 threads` line.

| Scenario | Expected | Before | After |
|----------|----------|--------|-------|
| no `--pages` (full doc) | 15 | `Processing 15 pages` | `Processing 15 pages` |
| `--pages 99999` (all invalid) | 0 | `Processing 15 pages` | `Processing 0 pages` |
| `--pages 1,99999` (1 valid + 1 invalid) | 1 | `Processing 15 pages` | `Processing 1 pages` |
| `--pages 1-5` (5 valid) | 5 | `Processing 15 pages` | `Processing 5 pages` |
| `--pages 22-30` (all out of range) | 0 | `Processing 15 pages` | `Processing 0 pages` |

After the patch, the INFO line matches both the WARN messages emitted by `getValidPageNumbers` and the actual JSON output content.

## Test plan
- [x] Build passes (`mvn clean install -DskipTests`)
- [x] Full-document runs still report total page count
- [x] All-invalid `--pages` reports 0
- [x] Mixed valid/invalid `--pages` reports only the valid count
- [x] Range input reports actual processed count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of page processing logs to correctly reflect the number of pages selected for processing rather than always reporting the total document page count.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/513)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->