### PR TITLE
fix(tagged-pdf): refuse encrypted documents with friendly message

### DIFF
--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -20,6 +20,7 @@ import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.api.OpenDataLoaderPDF;
 import org.opendataloader.pdf.api.cli.CLIOptions;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.opendataloader.pdf.exceptions.EncryptedTaggedPdfNotSupportedException;
 import org.opendataloader.pdf.exceptions.InvalidPdfFileException;
 import org.verapdf.exceptions.InvalidPasswordException;
 
@@ -238,6 +239,9 @@ public class CLIMain {
                 ? "Error: '" + file.getName() + "' is password-protected. Use --password option."
                 : "Error: Incorrect password for '" + file.getName() + "'.";
             System.out.println(message);
+            return false;
+        } catch (EncryptedTaggedPdfNotSupportedException exception) {
+            System.out.println("Error: " + exception.getMessage());
             return false;
         } catch (Exception exception) {
             LOGGER.log(Level.SEVERE, "Exception during processing file " + file.getAbsolutePath() + ": " +

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/exceptions/EncryptedTaggedPdfNotSupportedException.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/exceptions/EncryptedTaggedPdfNotSupportedException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.exceptions;
+
+import java.io.IOException;
+
+/**
+ * Thrown when tagged-pdf generation is requested for an encrypted document.
+ *
+ * <p>Encrypted PDFs (those with an {@code /Encrypt} dictionary in the trailer)
+ * are not supported for tagged-pdf output. Writing a tagged copy requires
+ * re-serializing the document, which interacts poorly with the document's
+ * encryption state and is also not permitted by the PDF specification for
+ * documents whose permissions deny modification.
+ */
+public class EncryptedTaggedPdfNotSupportedException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public EncryptedTaggedPdfNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -5,6 +5,7 @@ import org.opendataloader.pdf.autotagging.OperatorStreamKey;
 import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticFootnote;
 import org.opendataloader.pdf.entities.SemanticFormula;
+import org.opendataloader.pdf.exceptions.EncryptedTaggedPdfNotSupportedException;
 import org.verapdf.as.ASAtom;
 import org.verapdf.as.io.ASMemoryInStream;
 import org.verapdf.cos.*;
@@ -93,6 +94,11 @@ public class AutoTaggingProcessor {
      * Tag a PDF document and save to disk. Existing behavior preserved.
      */
     public static synchronized void createTaggedPDF(File inputPDF, String outputFolder, PDDocument document, List<List<IObject>> contents) throws IOException {
+        COSObject encrypt = document.getDocument().getTrailer().getEncrypt();
+        if (encrypt != null && !encrypt.empty()) {
+            throw new EncryptedTaggedPdfNotSupportedException(
+                "'" + inputPDF.getName() + "' is encrypted; tagged-pdf conversion is not supported for encrypted documents.");
+        }
         tagDocument(document, contents, null);
         String outputFileName = outputFolder + File.separator +
             inputPDF.getName().substring(0, inputPDF.getName().length() - 4) + "_tagged.pdf";


### PR DESCRIPTION
## Objective
Running `--format tagged-pdf` on an encrypted PDF fails deep in the save step with a Java stack trace ("AES initializing vector is not fully read" or "Error writing document"). The failure mode is opaque: the tool produces a stub file, exits non-zero, and dumps internal frames. Affects every encrypted document — signed or not, owner-password-restricted or not, regardless of the actual content.

Fixes [opendataloader-project/opendataloader-pdf-tasks#461](https://github.com/opendataloader-project/opendataloader-pdf-tasks/issues/461)

## Approach
Refuse tagged-pdf at the entry of `AutoTaggingProcessor.createTaggedPDF` when the trailer has an `Encrypt` entry, throwing a typed exception that the CLI surfaces as a one-line `Error: ...` message — the same pattern PR #504 used for the password case.

Per maintainer policy ([opendataloader-project/opendataloader-pdf-tasks#462](https://github.com/opendataloader-project/opendataloader-pdf-tasks/issues/462#issuecomment-4449420287): _"ODL should not generate Annotated PDF or perform auto-tagging of encrypted documents"_), this is a blanket refusal that sidesteps the AES re-serialization bug without touching veraPDF or the saveAs path. The bit-4-set carve-out and owner-password authentication are intentionally out of scope — those can be revisited if real demand surfaces.

The guard is placed in `createTaggedPDF` (the disk-writing entry point) so in-memory tagging via `tagDocument` is unaffected. The default JSON path on encrypted PDFs continues to work since it never re-serializes.

## Evidence
Built the CLI and ran 17 scenarios covering every combination of encryption type × user-password state × `--password` input, plus the original reporter PDF and regression checks for non-tagged-pdf paths. Full matrix (with PDF synthesis details) is in [#461 comment thread](https://github.com/opendataloader-project/opendataloader-pdf-tasks/issues/461).

| Scenario | Expected | Before | After |
|---|---|---|---|
| Plain PDF + tagged-pdf | OK | OK | OK |
| AES-256 + no pw | Friendly refusal | saveAs fails (stack trace) | `Error: '...' is encrypted; tagged-pdf conversion is not supported for encrypted documents.` |
| AES-256 + owner pw | Friendly refusal | saveAs fails (stack trace) | Friendly refusal |
| AES-128 + user pw | Friendly refusal | saveAs fails | Friendly refusal |
| RC4 + no pw | Friendly refusal | OK (silently bypassed permissions) | Friendly refusal |
| Original PDFDLOSP-12 PDF | Friendly refusal | Stack trace at AES IV read | Friendly refusal |
| Encrypted PDF + default JSON (regression) | OK | OK | OK |
| Plain PDF + default JSON (regression) | OK | OK | OK |

No stack trace surfaces in any encrypted-PDF tagged-pdf scenario after the patch. Non-tagged-pdf paths and unencrypted PDFs are unchanged.

## Test plan
- [x] Build passes (`mvn clean install -DskipTests`)
- [x] Plain PDF tagged-pdf still works
- [x] AES-encrypted PDF (all variants) produces friendly refusal, no stack trace
- [x] RC4-encrypted PDF produces friendly refusal (aligns with maintainer policy)
- [x] Default JSON conversion on encrypted PDFs unchanged
- [x] Original reporter PDF no longer produces stack trace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to reject encrypted PDF files when tagged PDF output is requested, with improved error messaging and handling during processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/514)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->