### PR TITLE
fix(generators): emit page separator only for pages selected by --pages

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
@@ -44,7 +44,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -71,6 +73,15 @@ public class HtmlGenerator implements Closeable {
     protected int tableNesting = 0;
     /** String to insert between pages in HTML output. */
     protected String htmlPageSeparator = "";
+    /**
+     * Page numbers (1-based) selected by --pages; an empty set means all pages.
+     * Sourced from the raw {@link Config#getPageNumbers()} list (not the
+     * validated set built by {@code DocumentProcessor.getValidPageNumbers}).
+     * Safe to compare against {@code pageNumber + 1} because the surrounding
+     * loop is bounded by the document's actual page count, so out-of-range
+     * values from the raw list are never tested for membership.
+     */
+    protected final Set<Integer> selectedPageNumbers;
     /** Whether to embed images as Base64 data URIs. */
     protected boolean embedImages = false;
     /** Format for extracted images (png or jpeg). */
@@ -96,6 +107,7 @@ public class HtmlGenerator implements Closeable {
         this.htmlFilePath = Path.of(config.getOutputFolder(), htmlFileName);
         this.htmlWriter = new FileWriter(htmlFilePath.toFile(), StandardCharsets.UTF_8);
         this.htmlPageSeparator = config.getHtmlPageSeparator();
+        this.selectedPageNumbers = new HashSet<>(config.getPageNumbers());
         this.embedImages = config.isEmbedImages();
         this.imageFormat = config.getImageFormat();
         this.includeHeaderFooter = config.isIncludeHeaderFooter();
@@ -114,7 +126,9 @@ public class HtmlGenerator implements Closeable {
             htmlWriter.write("</head>\n<body>\n");
 
             for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
-                writePageSeparator(pageNumber);
+                if (selectedPageNumbers.isEmpty() || selectedPageNumbers.contains(pageNumber + 1)) {
+                    writePageSeparator(pageNumber);
+                }
                 for (IObject content : contents.get(pageNumber)) {
                     this.write(content);
                 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -42,7 +42,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -54,6 +56,15 @@ public class MarkdownGenerator implements Closeable {
     protected int tableNesting = 0;
     protected boolean isImageSupported;
     protected String markdownPageSeparator;
+    /**
+     * Page numbers (1-based) selected by --pages; an empty set means all pages.
+     * Sourced from the raw {@link Config#getPageNumbers()} list (not the
+     * validated set built by {@code DocumentProcessor.getValidPageNumbers}).
+     * Safe to compare against {@code pageNumber + 1} because the surrounding
+     * loop is bounded by the document's actual page count, so out-of-range
+     * values from the raw list are never tested for membership.
+     */
+    protected final Set<Integer> selectedPageNumbers;
     protected boolean embedImages = false;
     protected String imageFormat = Config.IMAGE_FORMAT_PNG;
     protected boolean includeHeaderFooter = false;
@@ -65,6 +76,7 @@ public class MarkdownGenerator implements Closeable {
         this.markdownWriter = new FileWriter(markdownFileName, StandardCharsets.UTF_8);
         this.isImageSupported = !config.isImageOutputOff() && config.isGenerateMarkdown();
         this.markdownPageSeparator = config.getMarkdownPageSeparator();
+        this.selectedPageNumbers = new HashSet<>(config.getPageNumbers());
         this.embedImages = config.isEmbedImages();
         this.imageFormat = config.getImageFormat();
         this.includeHeaderFooter = config.isIncludeHeaderFooter();
@@ -78,6 +90,7 @@ public class MarkdownGenerator implements Closeable {
         this.markdownWriter = writer;
         this.isImageSupported = false;
         this.markdownPageSeparator = config.getMarkdownPageSeparator();
+        this.selectedPageNumbers = new HashSet<>(config.getPageNumbers());
         this.embedImages = false;
         this.imageFormat = config.getImageFormat();
         this.includeHeaderFooter = config.isIncludeHeaderFooter();
@@ -86,7 +99,9 @@ public class MarkdownGenerator implements Closeable {
     public void writeToMarkdown(List<List<IObject>> contents) {
         try {
             for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
-                writePageSeparator(pageNumber);
+                if (selectedPageNumbers.isEmpty() || selectedPageNumbers.contains(pageNumber + 1)) {
+                    writePageSeparator(pageNumber);
+                }
                 for (IObject content : contents.get(pageNumber)) {
                     if (!isSupportedContent(content)) {
                         continue;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/text/TextGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/text/TextGenerator.java
@@ -34,7 +34,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -51,6 +53,15 @@ public class TextGenerator implements Closeable {
     private final String textFileName;
     private final String lineSeparator = System.lineSeparator();
     private final String textPageSeparator;
+    /**
+     * Page numbers (1-based) selected by --pages; an empty set means all pages.
+     * Sourced from the raw {@link Config#getPageNumbers()} list (not the
+     * validated set built by {@code DocumentProcessor.getValidPageNumbers}).
+     * Safe to compare against {@code pageIndex + 1} because the surrounding
+     * loop is bounded by the document's actual page count, so out-of-range
+     * values from the raw list are never tested for membership.
+     */
+    private final Set<Integer> selectedPageNumbers;
     private final boolean includeHeaderFooter;
 
     public TextGenerator(File inputPdf, Config config) throws IOException {
@@ -58,6 +69,7 @@ public class TextGenerator implements Closeable {
         this.textFileName = config.getOutputFolder() + File.separator + cutPdfFileName.substring(0, cutPdfFileName.length() - 3) + "txt";
         this.textWriter = new FileWriter(textFileName, StandardCharsets.UTF_8);
         this.textPageSeparator = config.getTextPageSeparator();
+        this.selectedPageNumbers = new HashSet<>(config.getPageNumbers());
         this.includeHeaderFooter = config.isIncludeHeaderFooter();
     }
 
@@ -68,13 +80,16 @@ public class TextGenerator implements Closeable {
         this.textFileName = null;
         this.textWriter = writer;
         this.textPageSeparator = config.getTextPageSeparator();
+        this.selectedPageNumbers = new HashSet<>(config.getPageNumbers());
         this.includeHeaderFooter = config.isIncludeHeaderFooter();
     }
 
     public void writeToText(List<List<IObject>> contents) {
         try {
             for (int pageIndex = 0; pageIndex < contents.size(); pageIndex++) {
-                writePageSeparator(pageIndex);
+                if (selectedPageNumbers.isEmpty() || selectedPageNumbers.contains(pageIndex + 1)) {
+                    writePageSeparator(pageIndex);
+                }
                 List<IObject> pageContents = contents.get(pageIndex);
                 writeContents(pageContents, 0);
                 if (pageIndex < contents.size() - 1) {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PageSeparatorIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PageSeparatorIntegrationTest.java
@@ -238,4 +238,420 @@ class PageSeparatorIntegrationTest {
     void testConfigPageNumberConstant() {
         assertEquals("%page-number%", Config.PAGE_NUMBER_STRING, "PAGE_NUMBER_STRING constant should be correct");
     }
+
+    // --- Page Separator x --pages Filter Combination Tests ---
+    // Contract: when --pages selects a subset, separators must appear only for the selected pages
+    // and exactly once each. Assertions use occurrence counts so a stray substring in the PDF body
+    // text cannot mask a regression.
+
+    private static final int SAMPLE_PAGE_COUNT = 15;
+
+    /**
+     * Counts non-overlapping occurrences of {@code needle} in {@code haystack}.
+     * Used by separator assertions so a stray substring in extracted PDF body
+     * text cannot mask a regression. Markers used here include a trailing
+     * delimiter (e.g. {@code "<!-- Page 1 -->"}, {@code "data-page=\"1\""})
+     * so page 1 does not falsely match inside page 10..15.
+     */
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) != -1) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
+    }
+
+    private static String mdMarker(int page) {
+        return "<!-- Page " + page + " -->";
+    }
+
+    private static String textMarker(int page) {
+        return "[Page " + page + "]";
+    }
+
+    private static String htmlMarker(int page) {
+        return "data-page=\"" + page + "\"";
+    }
+
+    @Test
+    void testMarkdownPageSeparatorRespectsPagesFilter() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateMarkdown(true);
+        config.setMarkdownPageSeparator("<!-- Page %page-number% -->");
+        config.setPages("1,3");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path mdOutput = tempDir.resolve(OUTPUT_BASENAME + ".md");
+        String mdContent = Files.readString(mdOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            int expected = (page == 1 || page == 3) ? 1 : 0;
+            assertEquals(expected, countOccurrences(mdContent, mdMarker(page)),
+                "Markdown page " + page + " marker count mismatch");
+        }
+    }
+
+    @Test
+    void testTextPageSeparatorRespectsPagesFilter() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateText(true);
+        config.setTextPageSeparator("[Page %page-number%]");
+        config.setPages("1,3");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path txtOutput = tempDir.resolve(OUTPUT_BASENAME + ".txt");
+        String txtContent = Files.readString(txtOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            int expected = (page == 1 || page == 3) ? 1 : 0;
+            assertEquals(expected, countOccurrences(txtContent, textMarker(page)),
+                "Text page " + page + " marker count mismatch");
+        }
+    }
+
+    @Test
+    void testHtmlPageSeparatorRespectsPagesFilter() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateHtml(true);
+        config.setHtmlPageSeparator("<div data-page=\"%page-number%\">");
+        config.setPages("1,3");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path htmlOutput = tempDir.resolve(OUTPUT_BASENAME + ".html");
+        String htmlContent = Files.readString(htmlOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            int expected = (page == 1 || page == 3) ? 1 : 0;
+            assertEquals(expected, countOccurrences(htmlContent, htmlMarker(page)),
+                "HTML page " + page + " marker count mismatch");
+        }
+    }
+
+    // No-filter regression guard: every page must emit its separator exactly once when --pages
+    // is unset. Ensures the filter change does not regress to "select none" when the set is empty.
+
+    @Test
+    void testMarkdownPageSeparatorWithoutPagesFilterEmitsAllPages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateMarkdown(true);
+        config.setMarkdownPageSeparator("<!-- Page %page-number% -->");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path mdOutput = tempDir.resolve(OUTPUT_BASENAME + ".md");
+        String mdContent = Files.readString(mdOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            assertEquals(1, countOccurrences(mdContent, mdMarker(page)),
+                "Markdown page " + page + " marker should appear exactly once without filter");
+        }
+    }
+
+    @Test
+    void testTextPageSeparatorWithoutPagesFilterEmitsAllPages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateText(true);
+        config.setTextPageSeparator("[Page %page-number%]");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path txtOutput = tempDir.resolve(OUTPUT_BASENAME + ".txt");
+        String txtContent = Files.readString(txtOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            assertEquals(1, countOccurrences(txtContent, textMarker(page)),
+                "Text page " + page + " marker should appear exactly once without filter");
+        }
+    }
+
+    @Test
+    void testHtmlPageSeparatorWithoutPagesFilterEmitsAllPages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateHtml(true);
+        config.setHtmlPageSeparator("<div data-page=\"%page-number%\">");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path htmlOutput = tempDir.resolve(OUTPUT_BASENAME + ".html");
+        String htmlContent = Files.readString(htmlOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            assertEquals(1, countOccurrences(htmlContent, htmlMarker(page)),
+                "HTML page " + page + " marker should appear exactly once without filter");
+        }
+    }
+
+    // Boundary scenarios — lock in contract corners most likely to regress in future refactors.
+
+    @Test
+    void testMarkdownPageSeparatorLastPageOnly() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateMarkdown(true);
+        config.setMarkdownPageSeparator("<!-- Page %page-number% -->");
+        config.setPages(String.valueOf(SAMPLE_PAGE_COUNT));
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path mdOutput = tempDir.resolve(OUTPUT_BASENAME + ".md");
+        String mdContent = Files.readString(mdOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            int expected = (page == SAMPLE_PAGE_COUNT) ? 1 : 0;
+            assertEquals(expected, countOccurrences(mdContent, mdMarker(page)),
+                "Markdown page " + page + " marker count mismatch for last-page-only selection");
+        }
+    }
+
+    @Test
+    void testMarkdownPageSeparatorWithOutOfRangePages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateMarkdown(true);
+        config.setMarkdownPageSeparator("<!-- Page %page-number% -->");
+        // Mix valid + out-of-range: the in-range page must still emit; the out-of-range page must not.
+        config.setPages("1,99");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path mdOutput = tempDir.resolve(OUTPUT_BASENAME + ".md");
+        String mdContent = Files.readString(mdOutput);
+
+        assertEquals(1, countOccurrences(mdContent, mdMarker(1)), "Page 1 marker should appear once");
+        assertEquals(0, countOccurrences(mdContent, mdMarker(99)), "Out-of-range page 99 marker must not appear");
+        for (int page = 2; page <= SAMPLE_PAGE_COUNT; page++) {
+            assertEquals(0, countOccurrences(mdContent, mdMarker(page)),
+                "Markdown page " + page + " marker must not appear");
+        }
+    }
+
+    @Test
+    void testMarkdownPageSeparatorWithNonContiguousPages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateMarkdown(true);
+        config.setMarkdownPageSeparator("<!-- Page %page-number% -->");
+        config.setPages("1,4,5");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path mdOutput = tempDir.resolve(OUTPUT_BASENAME + ".md");
+        String mdContent = Files.readString(mdOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            int expected = (page == 1 || page == 4 || page == 5) ? 1 : 0;
+            assertEquals(expected, countOccurrences(mdContent, mdMarker(page)),
+                "Markdown page " + page + " marker count mismatch for non-contiguous selection");
+        }
+    }
+
+    @Test
+    void testMarkdownEmptyPageSeparatorWithPagesFilter() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateMarkdown(true);
+        // Empty separator combined with --pages: the filter must not introduce any marker.
+        config.setPages("1,3");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path mdOutput = tempDir.resolve(OUTPUT_BASENAME + ".md");
+        String mdContent = Files.readString(mdOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            assertEquals(0, countOccurrences(mdContent, mdMarker(page)),
+                "Markdown page " + page + " marker must not appear with empty separator");
+        }
+    }
+
+    // Boundary scenarios — Text format
+
+    @Test
+    void testTextPageSeparatorLastPageOnly() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateText(true);
+        config.setTextPageSeparator("[Page %page-number%]");
+        config.setPages(String.valueOf(SAMPLE_PAGE_COUNT));
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path txtOutput = tempDir.resolve(OUTPUT_BASENAME + ".txt");
+        String txtContent = Files.readString(txtOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            int expected = (page == SAMPLE_PAGE_COUNT) ? 1 : 0;
+            assertEquals(expected, countOccurrences(txtContent, textMarker(page)),
+                "Text page " + page + " marker count mismatch for last-page-only selection");
+        }
+    }
+
+    @Test
+    void testTextPageSeparatorWithOutOfRangePages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateText(true);
+        config.setTextPageSeparator("[Page %page-number%]");
+        config.setPages("1,99");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path txtOutput = tempDir.resolve(OUTPUT_BASENAME + ".txt");
+        String txtContent = Files.readString(txtOutput);
+
+        assertEquals(1, countOccurrences(txtContent, textMarker(1)), "Page 1 marker should appear once");
+        assertEquals(0, countOccurrences(txtContent, textMarker(99)), "Out-of-range page 99 marker must not appear");
+        for (int page = 2; page <= SAMPLE_PAGE_COUNT; page++) {
+            assertEquals(0, countOccurrences(txtContent, textMarker(page)),
+                "Text page " + page + " marker must not appear");
+        }
+    }
+
+    @Test
+    void testTextPageSeparatorWithNonContiguousPages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateText(true);
+        config.setTextPageSeparator("[Page %page-number%]");
+        config.setPages("1,4,5");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path txtOutput = tempDir.resolve(OUTPUT_BASENAME + ".txt");
+        String txtContent = Files.readString(txtOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            int expected = (page == 1 || page == 4 || page == 5) ? 1 : 0;
+            assertEquals(expected, countOccurrences(txtContent, textMarker(page)),
+                "Text page " + page + " marker count mismatch for non-contiguous selection");
+        }
+    }
+
+    @Test
+    void testTextEmptyPageSeparatorWithPagesFilter() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateText(true);
+        config.setPages("1,3");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path txtOutput = tempDir.resolve(OUTPUT_BASENAME + ".txt");
+        String txtContent = Files.readString(txtOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            assertEquals(0, countOccurrences(txtContent, textMarker(page)),
+                "Text page " + page + " marker must not appear with empty separator");
+        }
+    }
+
+    // Boundary scenarios — HTML format
+
+    @Test
+    void testHtmlPageSeparatorLastPageOnly() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateHtml(true);
+        config.setHtmlPageSeparator("<div data-page=\"%page-number%\">");
+        config.setPages(String.valueOf(SAMPLE_PAGE_COUNT));
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path htmlOutput = tempDir.resolve(OUTPUT_BASENAME + ".html");
+        String htmlContent = Files.readString(htmlOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            int expected = (page == SAMPLE_PAGE_COUNT) ? 1 : 0;
+            assertEquals(expected, countOccurrences(htmlContent, htmlMarker(page)),
+                "HTML page " + page + " marker count mismatch for last-page-only selection");
+        }
+    }
+
+    @Test
+    void testHtmlPageSeparatorWithOutOfRangePages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateHtml(true);
+        config.setHtmlPageSeparator("<div data-page=\"%page-number%\">");
+        config.setPages("1,99");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path htmlOutput = tempDir.resolve(OUTPUT_BASENAME + ".html");
+        String htmlContent = Files.readString(htmlOutput);
+
+        assertEquals(1, countOccurrences(htmlContent, htmlMarker(1)), "Page 1 marker should appear once");
+        assertEquals(0, countOccurrences(htmlContent, htmlMarker(99)), "Out-of-range page 99 marker must not appear");
+        for (int page = 2; page <= SAMPLE_PAGE_COUNT; page++) {
+            assertEquals(0, countOccurrences(htmlContent, htmlMarker(page)),
+                "HTML page " + page + " marker must not appear");
+        }
+    }
+
+    @Test
+    void testHtmlPageSeparatorWithNonContiguousPages() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateHtml(true);
+        config.setHtmlPageSeparator("<div data-page=\"%page-number%\">");
+        config.setPages("1,4,5");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path htmlOutput = tempDir.resolve(OUTPUT_BASENAME + ".html");
+        String htmlContent = Files.readString(htmlOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            int expected = (page == 1 || page == 4 || page == 5) ? 1 : 0;
+            assertEquals(expected, countOccurrences(htmlContent, htmlMarker(page)),
+                "HTML page " + page + " marker count mismatch for non-contiguous selection");
+        }
+    }
+
+    @Test
+    void testHtmlEmptyPageSeparatorWithPagesFilter() throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateHtml(true);
+        config.setPages("1,3");
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path htmlOutput = tempDir.resolve(OUTPUT_BASENAME + ".html");
+        String htmlContent = Files.readString(htmlOutput);
+
+        for (int page = 1; page <= SAMPLE_PAGE_COUNT; page++) {
+            assertEquals(0, countOccurrences(htmlContent, htmlMarker(page)),
+                "HTML page " + page + " marker must not appear with empty separator");
+        }
+    }
 }


### PR DESCRIPTION
## Objective

When `--pages` narrows extraction to a subset and a `--*-page-separator` is configured, users see empty separator markers for the pages that were filtered out — markdown / text / html all produce one marker per document page instead of one per selected page. The body is correctly limited, but the separator track diverges, so extracted output picks up noise that the user explicitly opted out of.

## Approach

Markdown, text, and html generators all walk `0..numberOfPages-1` and call `writePageSeparator` before each page's content. The `--pages` filter only shapes the `contents` list (excluded pages get an empty list), so the separator call runs unconditionally.

This patch reads `Config.getPageNumbers()` (1-based selected pages, already part of the public Config API) into a `Set<Integer>` in each generator and guards the `writePageSeparator` call with `selectedPageNumbers.isEmpty() || selectedPageNumbers.contains(pageNumber + 1)`. Using a `Set` keeps the per-page lookup O(1) — the guard runs once per document page. When `--pages` is absent the set is empty and behavior is unchanged. When `--pages` is set, the separator appears only at the pages the user asked for, matching the page-number tokens already emitted by `writePageSeparator`'s `%page-number%` substitution.

The guard is initialized in every constructor of each generator — Markdown and Text expose both file-output and stdout (Writer) overloads and both pick up the same filter; HtmlGenerator has a single file-output constructor.

**Considered alternative**: extending the public `writeToMarkdown` / `writeToText` / `writeToHtml` method signatures to accept `pagesToProcess` (the 0-based `Set` already built in `DocumentProcessor.getValidPageNumbers`). Rejected because it would break the most-called public method of each generator, while the `Config`-based path already exposes the same information through an existing API.

## Evidence

### Integration tests

`PageSeparatorIntegrationTest` gains 18 contract tests using count-based assertions over all 15 pages of the sample document (occurrence count, not substring presence, so unrelated body text cannot mask a regression):

- **3 base contract tests** (one per format): `--pages 1,3` + page-number separator emits markers only at pages 1 and 3.
- **3 no-filter regression guards** (one per format): every page emits its separator exactly once when `--pages` is unset.
- **4 boundary tests per format (12 total)**: last-page-only (`--pages 15`), out-of-range mix (`--pages 1,99` → page 1 emits, page 99 does not), non-contiguous selection (`--pages 1,4,5`), and empty separator combined with `--pages` (no marker emitted at any page).

Before the fix the base contract assertions fail; after the fix the full 30-test class is green.

### CLI reproduction (6-page PDF + `--pages 3-5`)

| Format   | Separator                       | Before | After |
|----------|---------------------------------|--------|-------|
| markdown | `=== %page-number% ===`         | 6      | 3     |
| text     | `--- PAGE %page-number% ---`    | 6      | 3     |
| html     | `<hr/>`                         | 6      | 3     |

After-fix markers map exactly to pages 3, 4, 5; the leading/trailing empty markers (pages 1, 2, 6) are gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selective page generation now supported across HTML, Markdown, and Text export formats.

* **Tests**
  * Added comprehensive integration tests for page filtering validation across all output formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->