### PR TITLE
fix(tagged-pdf): emit "Created" info log after saving (PDFDLOSP-26)

### DIFF
--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/FormatLogRegressionTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/FormatLogRegressionTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.cli;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for PDFDLOSP-26: every {@code --format} value must emit
+ * exactly one INFO-level "Created &lt;path&gt;" log line after writing its
+ * output. Tagged-PDF previously skipped this log because
+ * {@code AutoTaggingProcessor.createTaggedPDF()} had no {@code Logger}.
+ */
+class FormatLogRegressionTest {
+
+    @TempDir
+    Path tempDir;
+
+    @ParameterizedTest(name = "--format {0} emits exactly one Created log")
+    @ValueSource(strings = {"json", "text", "html", "pdf", "markdown", "tagged-pdf"})
+    void formatEmitsExactlyOneCreatedLog(String format) throws IOException {
+        Path pdf = createMinimalPdf(tempDir.resolve("in.pdf"));
+        Path outDir = tempDir.resolve(format);
+        Files.createDirectories(outDir);
+
+        List<LogRecord> records = new ArrayList<>();
+        int exitCode = captureAllLogsOf(records, () -> CLIMain.run(new String[]{
+            "--format", format,
+            "--output", outDir.toString(),
+            pdf.toString()
+        }));
+
+        assertEquals(0, exitCode, () ->
+            "Exit code must be 0 for --format " + format + "; records: " + summarize(records));
+
+        long createdCount = records.stream()
+            .filter(r -> r.getLevel() == Level.INFO)
+            .filter(r -> r.getMessage() != null && r.getMessage().contains("Created"))
+            .count();
+
+        assertEquals(1L, createdCount, () ->
+            "Exactly one INFO 'Created ...' log expected for --format " + format
+            + "; got " + createdCount + ". Records: " + summarize(records));
+    }
+
+    private static Path createMinimalPdf(Path target) throws IOException {
+        try (PDDocument document = new PDDocument()) {
+            document.addPage(new PDPage());
+            document.save(target.toFile());
+        }
+        return target;
+    }
+
+    /**
+     * Captures every {@link LogRecord} emitted by any logger under the
+     * {@code org.opendataloader.pdf} hierarchy. Attaching to the root logger
+     * would also include third-party noise; attaching to the package root
+     * picks up CLIMain plus every generator/processor in core (JUL records
+     * propagate to parent handlers).
+     *
+     * <p>JUL is global; this assumes sequential test execution
+     * (JUnit 5 + Surefire default).
+     */
+    private static <T> T captureAllLogsOf(List<LogRecord> sink, Callable<T> action) {
+        Logger logger = Logger.getLogger("org.opendataloader.pdf");
+        Level priorLevel = logger.getLevel();
+        boolean priorUseParent = logger.getUseParentHandlers();
+        Handler capture = new Handler() {
+            @Override public void publish(LogRecord record) { sink.add(record); }
+            @Override public void flush() { }
+            @Override public void close() { }
+        };
+        capture.setLevel(Level.ALL);
+        logger.addHandler(capture);
+        logger.setLevel(Level.ALL);
+        logger.setUseParentHandlers(false);
+        try {
+            return action.call();
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        } finally {
+            logger.removeHandler(capture);
+            logger.setLevel(priorLevel);
+            logger.setUseParentHandlers(priorUseParent);
+        }
+    }
+
+    private static String summarize(List<LogRecord> records) {
+        StringBuilder sb = new StringBuilder("[");
+        for (LogRecord r : records) {
+            sb.append('(').append(r.getLevel()).append(": ").append(r.getMessage()).append(") ");
+        }
+        return sb.append(']').toString();
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -36,8 +36,12 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.utils.StreamInfo;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class AutoTaggingProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(AutoTaggingProcessor.class.getCanonicalName());
 
     private static final Map<OperatorStreamKey, Map<Integer, Set<StreamInfo>>> operatorIndexesToStreamInfosMap = new LinkedHashMap<>();
     private static final Map<OperatorStreamKey, List<COSObject>> structParents = new LinkedHashMap<>();
@@ -103,6 +107,7 @@ public class AutoTaggingProcessor {
         String outputFileName = outputFolder + File.separator +
             inputPDF.getName().substring(0, inputPDF.getName().length() - 4) + "_tagged.pdf";
         document.saveAs(outputFileName);
+        LOGGER.log(Level.INFO, "Created {0}", outputFileName);
     }
 
     private static void updatePages(PDDocument document, COSDocument cosDocument) throws IOException {


### PR DESCRIPTION
## Summary
- `AutoTaggingProcessor.createTaggedPDF()` saves the tagged PDF via `document.saveAs(...)` but, unlike the five peer generators (JsonWriter, PDFWriter, TextGenerator, HtmlGenerator, MarkdownGenerator), emits no completion log. As a result `--format tagged-pdf` finishes on whichever mid-pipeline warning happened to fire last (e.g. `List without detected level`), so callers and QA automation have no clean signal that the artifact was actually written.
- Add a `Logger` field to `AutoTaggingProcessor` and emit `LOGGER.log(Level.INFO, "Created {0}", outputFileName)` immediately after `saveAs()`, matching the existing peer pattern (`JsonWriter.java:92`, `PDFWriter.java:84`, etc.).
- Add a parameterized CLI regression test asserting exactly one INFO `Created ...` record for every `--format` value (json, text, html, pdf, markdown, tagged-pdf). The test attaches its capture handler to the `org.opendataloader.pdf` logger so generator/processor logs are included.

No CLI option changes — `npm run sync` / `options.json` / Python·Node bindings are unaffected.

## Why
Discovered while regression-verifying PDFDLOSP-6: QA treats the `"Created <path>"` log as a success signal for each `--format` invocation. Tagged-pdf was the only format silently dropping it.

Negative-tested by temporarily reverting just the new `LOGGER.log` call: the parameterized test fails only for `tagged-pdf` (`expected 1 but was 0`) while the other five formats pass, confirming the assertion captures the original regression.

## Test plan
- [x] `mvn -pl opendataloader-pdf-cli -Dtest=FormatLogRegressionTest test` — 6/6 pass
- [x] `mvn -pl opendataloader-pdf-cli test` — 28/28 pass (22 existing CLIMainTest + 6 new)
- [x] `mvn -pl opendataloader-pdf-core test` — all green
- [x] Negative test: with the fix line removed, only `tagged-pdf` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test suite validating all output format configurations (JSON, text, HTML, PDF, Markdown, tagged-PDF) correctly handle single-page PDF inputs and produce expected logging output.

* **Improvements**
  * Enhanced tagged PDF creation with detailed logging to provide better visibility into file generation and aid in operational monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->