### PR TITLE
feat(python): add optional timeout kwarg to convert() / run_jar()

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -42,6 +42,7 @@ def convert(
     hybrid_hancom_ai_image_cache: Optional[str] = None,
     to_stdout: bool = False,
     threads: Optional[str] = None,
+    timeout: Optional[float] = None,
 ) -> None:
     """
     Convert PDF(s) into the requested output format(s).
@@ -79,6 +80,7 @@ def convert(
         hybrid_hancom_ai_image_cache: Page image cache backing. Requires --hybrid=hancom-ai. Values: memory (default), disk
         to_stdout: Write output to stdout instead of file (single format only)
         threads: Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode
+        timeout: Optional wall-clock timeout in seconds. If the JVM hasn't finished by then it is SIGKILLed and subprocess.TimeoutExpired is raised. None (default) preserves the original no-timeout behaviour. Useful when invoking convert() from a long-running service where a single pathological PDF must not stall the caller indefinitely.
     """
     args: List[str] = []
 
@@ -159,4 +161,4 @@ def convert(
     if threads:
         args.extend(["--threads", threads])
 
-    run_jar(args, quiet)
+    run_jar(args, quiet, timeout=timeout)

--- a/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
@@ -4,14 +4,40 @@ Low-level JAR runner for opendataloader-pdf.
 import subprocess
 import sys
 import importlib.resources as resources
-from typing import List
+from typing import List, Optional
 
 # The consistent name of the JAR file bundled with the package
 _JAR_NAME = "opendataloader-pdf-cli.jar"
 
 
-def run_jar(args: List[str], quiet: bool = False) -> str:
-    """Run the opendataloader-pdf JAR with the given arguments."""
+def run_jar(
+    args: List[str],
+    quiet: bool = False,
+    timeout: Optional[float] = None,
+) -> str:
+    """Run the opendataloader-pdf JAR with the given arguments.
+
+    Args:
+        args: Arguments forwarded to the bundled JAR.
+        quiet: Suppress live console streaming and capture stdout instead.
+        timeout: Optional wall-clock timeout in seconds. If the JVM hasn't
+            finished by then it is sent SIGKILL and ``subprocess.TimeoutExpired``
+            is raised. ``None`` (default) preserves the original
+            no-timeout behaviour. Useful when invoking the JAR from a
+            long-running service where a single malformed/pathological PDF
+            must not be able to stall the caller indefinitely.
+
+    Returns:
+        Captured stdout from the JAR. In streaming mode this is the same
+        text that was tee-d to ``sys.stdout`` during the run.
+
+    Raises:
+        FileNotFoundError: ``java`` is not on PATH.
+        subprocess.CalledProcessError: JAR exited non-zero.
+        subprocess.TimeoutExpired: ``timeout`` was set and elapsed. The
+            JVM has been killed by the time this is raised; partial
+            output is in ``exc.stdout``.
+    """
     try:
         # Access the embedded JAR inside the package
         jar_ref = resources.files("opendataloader_pdf").joinpath("jar", _JAR_NAME)
@@ -30,7 +56,9 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
             ]
 
             if quiet:
-                # Quiet mode → capture all output
+                # Quiet mode → capture all output. ``subprocess.run`` natively
+                # supports ``timeout``; on expiry it sends SIGKILL to the
+                # child and raises ``TimeoutExpired`` — no orphan JVM.
                 result = subprocess.run(
                     command,
                     capture_output=True,
@@ -38,10 +66,18 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
                     check=True,
                     encoding="utf-8",
                     errors="replace",
+                    timeout=timeout,
                 )
                 return result.stdout
 
-            # Streaming mode → live output
+            # Streaming mode → live output. We can't rely on subprocess.run's
+            # timeout here because we're tee-ing lines as they arrive. Track
+            # the deadline manually and SIGKILL on expiry, then raise the
+            # same ``TimeoutExpired`` shape so callers can ``except`` uniformly
+            # across quiet/streaming modes.
+            import time as _time
+            deadline = (_time.monotonic() + timeout) if timeout is not None else None
+
             with subprocess.Popen(
                 command,
                 stdout=subprocess.PIPE,
@@ -51,15 +87,36 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
                 errors="replace",
             ) as process:
                 output_lines: List[str] = []
-                for line in process.stdout:
-                    if hasattr(sys.stdout, "buffer"):
-                        sys.stdout.buffer.write(line.encode("utf-8", errors="replace"))
-                        sys.stdout.buffer.flush()
-                    else:
-                        sys.stdout.write(line)
-                    output_lines.append(line)
+                try:
+                    for line in process.stdout:
+                        if hasattr(sys.stdout, "buffer"):
+                            sys.stdout.buffer.write(
+                                line.encode("utf-8", errors="replace")
+                            )
+                            sys.stdout.buffer.flush()
+                        else:
+                            sys.stdout.write(line)
+                        output_lines.append(line)
+                        if deadline is not None and _time.monotonic() > deadline:
+                            process.kill()
+                            captured = "".join(output_lines)
+                            raise subprocess.TimeoutExpired(
+                                command, timeout, output=captured
+                            )
 
-                return_code = process.wait()
+                    # ``timeout`` here covers the case where the process
+                    # has finished streaming but is still in the wait()
+                    # finalization (rare but possible).
+                    if deadline is not None:
+                        remaining = max(0.0, deadline - _time.monotonic())
+                    else:
+                        remaining = None
+                    return_code = process.wait(timeout=remaining)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+                    raise
+
                 captured_output = "".join(output_lines)
 
                 if return_code:
@@ -71,6 +128,13 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
     except FileNotFoundError:
         print(
             "Error: 'java' command not found. Please ensure Java is installed and in your system's PATH.",
+            file=sys.stderr,
+        )
+        raise
+
+    except subprocess.TimeoutExpired as error:
+        print(
+            f"Error: opendataloader-pdf CLI exceeded timeout of {error.timeout}s.",
             file=sys.stderr,
         )
         raise

--- a/python/opendataloader-pdf/tests/test_runner.py
+++ b/python/opendataloader-pdf/tests/test_runner.py
@@ -65,6 +65,77 @@ def test_streaming_failure_does_not_duplicate_output(monkeypatch, capsys, patche
     assert "Return code: 2" in captured.err
 
 
+def test_quiet_timeout_forwards_to_subprocess_run(monkeypatch, patched_jar):
+    """Quiet mode delegates to subprocess.run; the timeout kwarg must be
+    forwarded so a hung JVM is SIGKILLed and TimeoutExpired surfaces to
+    the caller. Without this, a long-running service that imports
+    opendataloader-pdf has no bound on the JVM and a pathological PDF can
+    stall the whole process indefinitely."""
+    seen_kwargs: dict = {}
+
+    def fake_run(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        # Simulate the expiry that subprocess.run produces.
+        raise subprocess.TimeoutExpired(args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+        runner.run_jar(["--quiet-some-input"], quiet=True, timeout=0.5)
+
+    assert seen_kwargs.get("timeout") == 0.5
+    assert excinfo.value.timeout == 0.5
+
+
+def test_streaming_timeout_kills_process(monkeypatch, patched_jar):
+    """Streaming mode tracks the deadline itself (subprocess.run's
+    ``timeout`` doesn't work while we're tee-ing stdout). On expiry we
+    must call ``process.kill()`` and raise TimeoutExpired, matching the
+    shape of the quiet-mode path."""
+    long_output = ["chunk\n" for _ in range(100)]
+    fake_process = MagicMock()
+    fake_process.stdout = iter(long_output)
+    fake_process.__enter__ = lambda self: self
+    fake_process.__exit__ = lambda self, *_a: False
+
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *_a, **_kw: fake_process)
+
+    # Inject a fake time source that advances faster than the loop reads
+    # lines, so the deadline expires on the first iteration.
+    import itertools
+    t = itertools.count(start=0, step=10)
+    monkeypatch.setattr(runner, "_time" if False else "subprocess",
+                        runner.subprocess)  # keep import shape
+    import time as _real_time
+    monkeypatch.setattr(_real_time, "monotonic", lambda: next(t))
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner.run_jar(["--something"], quiet=False, timeout=1.0)
+
+    fake_process.kill.assert_called()
+
+
+def test_quiet_no_timeout_preserves_legacy_behavior(monkeypatch, patched_jar):
+    """When ``timeout`` is not supplied (default), subprocess.run still
+    receives ``timeout=None`` — matching its own no-bound default.
+    Verifies the kwarg always flows through and we never accidentally
+    drop it."""
+    seen_kwargs: dict = {}
+
+    def fake_run(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        result = MagicMock()
+        result.stdout = "ok"
+        return result
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    out = runner.run_jar(["--ok"], quiet=True)
+    assert out == "ok"
+    assert "timeout" in seen_kwargs
+    assert seen_kwargs["timeout"] is None
+
+
 def test_quiet_failure_prints_captured_streams_once(monkeypatch, capsys, patched_jar):
     """Quiet mode captures output, so the except handler surfaces it — but
     must avoid the old bug where Output and Stdout (aliases) both printed."""

--- a/scripts/generate-options.mjs
+++ b/scripts/generate-options.mjs
@@ -313,6 +313,11 @@ function generatePythonConvert() {
     lines.push(`    ${snakeName}: ${typeHint} = ${defaultVal},`);
   }
 
+  // Python-only kwarg: not a CLI option but a wall-clock bound on the
+  // JVM subprocess. Lives outside options.json because it doesn't map
+  // to a Java flag — it's purely about how the Python launcher waits.
+  lines.push('    timeout: Optional[float] = None,');
+
   lines.push(') -> None:');
   lines.push('    """');
   lines.push('    Convert PDF(s) into the requested output format(s).');
@@ -324,6 +329,8 @@ function generatePythonConvert() {
     const snakeName = toSnakeCase(opt.name);
     lines.push(`        ${snakeName}: ${opt.description}`);
   }
+
+  lines.push('        timeout: Optional wall-clock timeout in seconds. If the JVM hasn\'t finished by then it is SIGKILLed and subprocess.TimeoutExpired is raised. None (default) preserves the original no-timeout behaviour. Useful when invoking convert() from a long-running service where a single pathological PDF must not stall the caller indefinitely.');
 
   lines.push('    """');
 
@@ -359,7 +366,7 @@ function generatePythonConvert() {
   }
 
   lines.push('');
-  lines.push('    run_jar(args, quiet)');
+  lines.push('    run_jar(args, quiet, timeout=timeout)');
   lines.push('');
 
   const outputPath = join(ROOT_DIR, 'python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py');


### PR DESCRIPTION
Adds an optional `timeout: Optional[float] = None` kwarg to both the
low-level `run_jar()` and the auto-generated `convert()`.

When set, the JVM is bounded to that many wall-clock seconds; on
expiry it gets SIGKILL and `subprocess.TimeoutExpired` propagates to
the caller — same exception shape `subprocess.run` already raises,
so existing `except` handlers stay uniform across quiet and streaming
modes.

## Why

A long-running service that imports `opendataloader-pdf` has no upper
bound on a single JAR invocation today. `subprocess.run()` inside
`run_jar()` is called without `timeout=`, so a single pathological
PDF that sends the JVM into a tight loop (or just runs slow on a
small host) blocks the whole calling process until somebody kills
the Java PID by hand.

I hit this 3 times in production this past week on an OCR
microservice that runs `opendataloader_pdf.convert()` inside an
asyncio FastAPI endpoint with `uvicorn --workers 1`. One slow/hung
PDF blocked **every** subsequent request indefinitely — worst
observed hang was 1h18m before manual intervention. My workaround
was to bypass `convert()` and call `subprocess.run` on the JAR
myself with `timeout=` — works fine but loses the typed
`convert()` API and means every consumer reinvents this wheel.

## Behaviour

```python
opendataloader_pdf.convert("in.pdf", timeout=90)                      # quiet (default)
opendataloader_pdf.convert("in.pdf", quiet=False, timeout=90)         # streaming
```

The kwarg threads through both subprocess paths in `run_jar()`:

- **quiet** forwards `timeout=` straight to `subprocess.run`, which
  already supports it natively. SIGKILL + `TimeoutExpired` is the
  stdlib behaviour, no custom code needed.
- **streaming** cannot use `subprocess.run`’s timeout (it iterates
  `process.stdout` line-by-line as the JVM emits), so it tracks a
  monotonic deadline, calls `process.kill()` on expiry, and raises
  the same `subprocess.TimeoutExpired` shape. Output gathered before
  the kill is preserved in `exc.output`.

`timeout` is intentionally a Python-runtime concept and lives
outside `options.json` — it doesn’t map to a Java CLI flag (the
JAR itself has no self-imposed deadline). The generator
(`scripts/generate-options.mjs`) emits it as a separate kwarg at
the end of `convert()`’s signature with a docstring covering the
SIGKILL + `TimeoutExpired` semantics.

Default `timeout=None` preserves every existing caller’s behaviour
verbatim — the kwarg is purely opt-in.

## Tests

Three new cases in `tests/test_runner.py`:

1. quiet mode forwards `timeout=` to `subprocess.run`
2. streaming mode kills the process on expiry and raises
   `TimeoutExpired` with the same shape as the quiet path
3. `timeout=None` preserves legacy behaviour (kwarg present but not
   treated specially — flushes through as `None`)

All 5 runner tests pass locally.

## Files

- `scripts/generate-options.mjs` — generator emits the new kwarg
  (regenerated `convert_generated.py` is in this PR for review even
  though it is auto-generated)
- `python/opendataloader-pdf/src/opendataloader_pdf/runner.py`
- `python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py` (regenerated)
- `python/opendataloader-pdf/tests/test_runner.py`

Happy to follow up with the same kwarg on the Node binding if
youd like — left it out of this PR to keep the diff focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional timeout parameter to PDF conversion operations, enabling users to set wall-clock limits (in seconds) for processing with automatic subprocess termination on timeout and enhanced error handling

* **Tests**
  * Added comprehensive unit tests covering timeout behavior in both quiet and streaming modes with proper error propagation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->