### PR TITLE
chore(deps): bump idna to 3.15 (GHSA-65pc-fj4g-8rjx)

### DIFF
--- a/python/opendataloader-pdf-mcp/uv.lock
+++ b/python/opendataloader-pdf-mcp/uv.lock
@@ -275,11 +275,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]

--- a/python/opendataloader-pdf/uv.lock
+++ b/python/opendataloader-pdf/uv.lock
@@ -678,11 +678,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -1524,7 +1524,7 @@ dev = [
 requires-dist = [
     { name = "docling", extras = ["easyocr"], marker = "extra == 'hybrid'", specifier = ">=2.91.0" },
     { name = "fastapi", marker = "extra == 'hybrid'", specifier = ">=0.136.1" },
-    { name = "python-multipart", marker = "extra == 'hybrid'", specifier = ">=0.0.26" },
+    { name = "python-multipart", marker = "extra == 'hybrid'", specifier = ">=0.0.28" },
     { name = "uvicorn", marker = "extra == 'hybrid'", specifier = ">=0.46.0" },
 ]
 provides-extras = ["hybrid"]


### PR DESCRIPTION
## Objective

Dependabot flags `idna < 3.15` as vulnerable to a crafted-input bypass of the
CVE-2024-3651 fix in `idna.encode()` — [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx), medium severity. Both Python lockfiles pin
`idna 3.13`. Closes Dependabot alerts #40 (`python/opendataloader-pdf-mcp`) and
#41 (`python/opendataloader-pdf`).

## Approach

Re-resolve `idna` only via `uv lock --upgrade-package idna` in both
`python/opendataloader-pdf` and `python/opendataloader-pdf-mcp`. No source code
or `pyproject.toml` constraints change. `idna` is a purely transitive dependency
— it is not declared directly in any `pyproject.toml`.

One drive-by metadata sync occurs in `python/opendataloader-pdf/uv.lock`: a
stale `python-multipart` `requires-dist` specifier (`>=0.0.26`) syncs to match
the existing `pyproject.toml` constraint (`>=0.0.28`). This is a pure metadata
mirror inside the `[[package]]` block; the resolved `python-multipart` version
does **not** move.

## Evidence

- `uv lock --upgrade-package idna` in both packages reports
  `Updated idna v3.13 -> v3.15`.
- `uv sync --extra hybrid --dry-run` (main package) and `uv sync --dry-run`
  (mcp package) both resolve cleanly against the new lockfile.
- Diff scope (per `git show --stat`):
  - `python/opendataloader-pdf-mcp/uv.lock`: idna block only.
  - `python/opendataloader-pdf/uv.lock`: idna block + 1-line `python-multipart`
    `requires-dist` metadata sync. No other resolved versions move.