### PR TITLE
fix(json): apply --include-header-footer to JSON output

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonWriter.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonWriter.java
@@ -31,6 +31,7 @@ import org.verapdf.tools.StaticResources;
 import org.opendataloader.pdf.hybrid.ElementMetadata;
 import org.opendataloader.pdf.json.serializers.SerializerUtil;
 import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.SemanticHeaderOrFooter;
 import org.verapdf.wcag.algorithms.entities.content.LineArtChunk;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 
@@ -63,6 +64,13 @@ public class JsonWriter {
     public static void writeToJson(File inputPDF, String outputFolder, List<List<IObject>> contents,
                                    Map<Long, ElementMetadata> elementMetadata,
                                    Map<String, Object> hybridInfo) throws IOException {
+        writeToJson(inputPDF, outputFolder, contents, elementMetadata, hybridInfo, false);
+    }
+
+    public static void writeToJson(File inputPDF, String outputFolder, List<List<IObject>> contents,
+                                   Map<Long, ElementMetadata> elementMetadata,
+                                   Map<String, Object> hybridInfo,
+                                   boolean includeHeaderFooter) throws IOException {
         StaticLayoutContainers.resetImageIndex();
         String jsonFileName = outputFolder + File.separator + inputPDF.getName().substring(0, inputPDF.getName().length() - 3) + "json";
         try (JsonGenerator jsonGenerator = getJsonGenerator(jsonFileName)) {
@@ -78,9 +86,13 @@ public class JsonWriter {
                 jsonGenerator.writeArrayFieldStart(JsonName.KIDS);
                 for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
                     for (IObject content : contents.get(pageNumber)) {
-                        if (!(content instanceof LineArtChunk)) {
-                            jsonGenerator.writePOJO(content);
+                        if (content instanceof LineArtChunk) {
+                            continue;
                         }
+                        if (!includeHeaderFooter && content instanceof SemanticHeaderOrFooter) {
+                            continue;
+                        }
+                        jsonGenerator.writePOJO(content);
                     }
                 }
                 jsonGenerator.writeEndArray();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -495,7 +495,8 @@ public class DocumentProcessor {
             pdfWriter.updatePDF(inputPDF, config.getPassword(), config.getOutputFolder(), contents);
         }
         if (config.isGenerateJSON()) {
-            JsonWriter.writeToJson(inputPDF, config.getOutputFolder(), contents, elementMetadata);
+            JsonWriter.writeToJson(inputPDF, config.getOutputFolder(), contents, elementMetadata,
+                    null, config.isIncludeHeaderFooter());
         }
         if (config.isGenerateMarkdown()) {
             try (MarkdownGenerator markdownGenerator = MarkdownGeneratorFactory.getMarkdownGenerator(inputPDF,

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/IncludeHeaderFooterJsonIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/IncludeHeaderFooterJsonIntegrationTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.processors.DocumentProcessor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the contract: --include-header-footer must affect JSON output the
+ * same way it affects markdown/text/html. When disabled (default), JSON must
+ * not contain header/footer elements; when enabled, it must.
+ */
+class IncludeHeaderFooterJsonIntegrationTest {
+
+    private static final String SAMPLE_PDF =
+        "../../samples/pdf/pdfua-1-reference-suite-1-1/PDFUA-Ref-2-04_Presentation.pdf";
+    private static final String OUTPUT_BASENAME = "PDFUA-Ref-2-04_Presentation";
+
+    @TempDir
+    Path withFlagDir;
+
+    @TempDir
+    Path withoutFlagDir;
+
+    private File samplePdf;
+
+    @BeforeEach
+    void setUp() {
+        samplePdf = new File(SAMPLE_PDF);
+        assertTrue(samplePdf.exists(), "Sample PDF not found at " + samplePdf.getAbsolutePath());
+    }
+
+    @Test
+    void jsonOutputRespectsIncludeHeaderFooterFlag() throws IOException {
+        int countWithFlag = runAndCountHeaderFooter(withFlagDir, true);
+        int countWithoutFlag = runAndCountHeaderFooter(withoutFlagDir, false);
+
+        assertTrue(countWithFlag > 0,
+            "Sample PDF must have at least one detected header/footer for this " +
+            "test to be meaningful; got " + countWithFlag + ". " +
+            "If detection regressed, pick a different fixture PDF.");
+        assertEquals(0, countWithoutFlag,
+            "JSON output must not contain header/footer elements when " +
+            "--include-header-footer is disabled (default). " +
+            "Got " + countWithoutFlag + " element(s).");
+    }
+
+    private int runAndCountHeaderFooter(Path outputDir, boolean includeHeaderFooter) throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(outputDir.toString());
+        config.setGenerateJSON(true);
+        config.setIncludeHeaderFooter(includeHeaderFooter);
+
+        DocumentProcessor.processFile(samplePdf.getAbsolutePath(), config);
+
+        Path jsonOutput = outputDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output missing at " + jsonOutput);
+
+        JsonNode root = new ObjectMapper().readTree(Files.readString(jsonOutput));
+        return countHeaderFooterTypes(root);
+    }
+
+    private static int countHeaderFooterTypes(JsonNode node) {
+        if (node == null) {
+            return 0;
+        }
+        int count = 0;
+        if (node.isObject()) {
+            JsonNode type = node.get("type");
+            if (type != null) {
+                String typeName = type.asText();
+                if ("header".equals(typeName) || "footer".equals(typeName)) {
+                    count++;
+                }
+            }
+            java.util.Iterator<JsonNode> iter = node.elements();
+            while (iter.hasNext()) {
+                count += countHeaderFooterTypes(iter.next());
+            }
+        } else if (node.isArray()) {
+            for (JsonNode child : node) {
+                count += countHeaderFooterTypes(child);
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## Objective

When running `--format json`, `--include-header-footer` has no effect. The same PDF produces byte-identical JSON whether the flag is set or not, while the other three formats (markdown, text, html) honor it correctly. Users relying on JSON for downstream ingestion receive page headers/footers (page numbers, running titles, etc.) regardless of intent.

## Approach

Apply the flag in the JSON writer the same way the other three generators already do — skip header/footer entries when the flag is disabled.

Default behavior changes for JSON: headers/footers are now excluded by default, included only when `--include-header-footer` is set. Pipelines that relied on the prior "always included" JSON output must now pass the flag explicitly.

## Evidence

Built both pre-fix (`origin/main`) and post-fix worktrees, processed `samples/pdf/pdfua-1-reference-suite-1-1/PDFUA-Ref-2-04_Presentation.pdf` with the flag toggled, and compared SHA-256 of every output file.

| Scenario | Expected | Actual |
|----------|----------|--------|
| Pre-fix, json on vs off | bug — hashes equal | equal (`a94a8f7a…99a5fffb` both) |
| Post-fix, json on vs off | hashes differ | differ (`a94a8f7a…99a5fffb` vs `a12b4342…24393127`) |
| Post-fix, md/text/html on vs off | hashes differ each | differ each (identical to pre-fix hashes) |

`IncludeHeaderFooterJsonIntegrationTest` verifies the contract directly: the chosen fixture yields 15 header/footer entries with the flag enabled and zero with it disabled. Full core test suite (663 tests) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable option to include or exclude header/footer information in JSON output (defaults to excluding headers and footers).

* **Tests**
  * Added integration test to validate header/footer inclusion behavior in JSON generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->