### PR TITLE
fix(image-output): make embedded mode self-contained

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -134,7 +134,7 @@ public class CLIOptions {
     private static final String IMAGE_FORMAT_DESC = "Output format for extracted images. Values: png, jpeg. Default: png";
 
     private static final String IMAGE_DIR_LONG_OPTION = "image-dir";
-    private static final String IMAGE_DIR_DESC = "Directory for extracted images";
+    private static final String IMAGE_DIR_DESC = "Directory for extracted images (applies only with --image-output external)";
 
     // ===== Pages =====
     private static final String PAGES_LONG_OPTION = "pages";

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
@@ -42,6 +42,7 @@ public class StaticLayoutContainers {
     private static final ThreadLocal<Boolean> embedImages = new ThreadLocal<>();
     private static final ThreadLocal<String> imageFormat = new ThreadLocal<>();
     private static final ThreadLocal<Map<Integer, Double>> replacementCharRatios = ThreadLocal.withInitial(ConcurrentHashMap::new);
+    private static final ThreadLocal<Map<String, byte[]>> embeddedImageBytes = ThreadLocal.withInitial(ConcurrentHashMap::new);
 
     public static void clearContainers() {
         currentContentId.set(1L);
@@ -54,6 +55,7 @@ public class StaticLayoutContainers {
         embedImages.set(false);
         imageFormat.set(Config.IMAGE_FORMAT_PNG);
         replacementCharRatios.get().clear();
+        embeddedImageBytes.get().clear();
     }
 
     public static long getCurrentContentId() {
@@ -155,5 +157,38 @@ public class StaticLayoutContainers {
 
     public static double getReplacementCharRatio(int pageNumber) {
         return replacementCharRatios.get().getOrDefault(pageNumber, 0.0);
+    }
+
+    public static void cacheEmbeddedImageBytes(String absolutePath, byte[] bytes) {
+        embeddedImageBytes.get().put(normalizeImageKey(absolutePath), bytes);
+    }
+
+    public static byte[] getEmbeddedImageBytes(String absolutePath) {
+        return embeddedImageBytes.get().get(normalizeImageKey(absolutePath));
+    }
+
+    public static boolean hasEmbeddedImageBytes(String absolutePath) {
+        return embeddedImageBytes.get().containsKey(normalizeImageKey(absolutePath));
+    }
+
+    // Map-level accessors are used by DocumentProcessor.propagateState so worker threads
+    // share the main thread's cache instance. Today the cache is only touched on the main
+    // thread, but propagating it eliminates a silent-data-loss trap if generators ever
+    // run on workers — matches the CLAUDE.md ThreadLocal-propagation gotcha.
+    public static Map<String, byte[]> getEmbeddedImageBytesMap() {
+        return embeddedImageBytes.get();
+    }
+
+    public static void setEmbeddedImageBytesMap(Map<String, byte[]> map) {
+        embeddedImageBytes.set(map);
+    }
+
+    // Image paths flow through String.format with File.separator (cache write side) and
+    // through File.getPath() (cache read side via Base64ImageUtils.toDataUri). The two
+    // forms can differ on Windows when the user passes forward-slash output paths
+    // (e.g. /tmp/x). Collapse both forms to a single canonical key so writers and readers
+    // agree on cache identity.
+    private static String normalizeImageKey(String path) {
+        return path == null ? null : new File(path).getPath();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -258,6 +258,7 @@ public class DocumentProcessor {
         final var headings = StaticLayoutContainers.getHeadings();
         final long contentId = StaticLayoutContainers.getCurrentContentId();
         final boolean useStructTree = StaticLayoutContainers.isUseStructTree();
+        final var embeddedImageBytesMap = StaticLayoutContainers.getEmbeddedImageBytesMap();
 
         // Runnable that propagates ThreadLocal state to the current (worker) thread
         final Runnable propagateState = () -> {
@@ -273,6 +274,7 @@ public class DocumentProcessor {
             StaticLayoutContainers.setHeadings(headings);
             StaticLayoutContainers.setCurrentContentId(contentId);
             StaticLayoutContainers.setIsUseStructTree(useStructTree);
+            StaticLayoutContainers.setEmbeddedImageBytesMap(embeddedImageBytesMap);
         };
 
         // Pre-fetch all page artifacts on main thread (document access is ThreadLocal)

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/Base64ImageUtils.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/Base64ImageUtils.java
@@ -15,6 +15,8 @@
  */
 package org.opendataloader.pdf.utils;
 
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -48,13 +50,25 @@ public final class Base64ImageUtils {
      */
     public static String toDataUri(File imageFile, String format) {
         try {
-            long fileSize = imageFile.length();
-            if (fileSize > MAX_EMBEDDED_IMAGE_SIZE) {
+            // Embedded mode keeps encoded image bytes in memory keyed by the path
+            // generators expect — no disk roundtrip in production.
+            byte[] fileContent = StaticLayoutContainers.getEmbeddedImageBytes(imageFile.getPath());
+            if (fileContent == null) {
+                // Disk fallback: runs in external mode (where files exist on disk) and
+                // also serves unit tests that prepare PNG files directly and bypass
+                // the in-memory pipeline (see ImageSerializerTest, MarkdownGenerator tests).
+                long fileSize = imageFile.length();
+                if (fileSize > MAX_EMBEDDED_IMAGE_SIZE) {
+                    LOGGER.log(Level.WARNING, "Image too large to embed ({0} bytes, max {1} bytes): {2}",
+                        new Object[]{fileSize, MAX_EMBEDDED_IMAGE_SIZE, imageFile.getName()});
+                    return null;
+                }
+                fileContent = Files.readAllBytes(imageFile.toPath());
+            } else if (fileContent.length > MAX_EMBEDDED_IMAGE_SIZE) {
                 LOGGER.log(Level.WARNING, "Image too large to embed ({0} bytes, max {1} bytes): {2}",
-                    new Object[]{fileSize, MAX_EMBEDDED_IMAGE_SIZE, imageFile.getName()});
+                    new Object[]{(long) fileContent.length, MAX_EMBEDDED_IMAGE_SIZE, imageFile.getName()});
                 return null;
             }
-            byte[] fileContent = Files.readAllBytes(imageFile.toPath());
             String base64 = Base64.getEncoder().encodeToString(fileContent);
             String mimeType = getMimeType(format);
             return String.format("data:%s;base64,%s", mimeType, base64);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/ImagesUtils.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/ImagesUtils.java
@@ -32,6 +32,7 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainer
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -47,6 +48,10 @@ public class ImagesUtils {
     }
 
     public void createImagesDirectory(String path) {
+        // Embedded mode is self-contained: no external image directory is created.
+        if (StaticLayoutContainers.isEmbedImages()) {
+            return;
+        }
         File directory = new File(path);
         if (!directory.exists()) {
             directory.mkdirs();
@@ -116,18 +121,31 @@ public class ImagesUtils {
 
     private void createImageFile(BoundingBox imageBox, String fileName, String imageFormat) {
         try {
-            File outputFile = new File(fileName);
             BufferedImage targetImage = contrastRatioConsumer != null ? contrastRatioConsumer.getPageSubImage(imageBox) : null;
             if (targetImage == null) {
                 return;
             }
-            ImageIO.write(targetImage, imageFormat, outputFile);
+            if (StaticLayoutContainers.isEmbedImages()) {
+                // Embedded mode: encode in memory and cache for downstream base64 inlining;
+                // no disk write — output is a single self-contained file.
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                ImageIO.write(targetImage, imageFormat, buffer);
+                StaticLayoutContainers.cacheEmbeddedImageBytes(fileName, buffer.toByteArray());
+            } else {
+                File outputFile = new File(fileName);
+                ImageIO.write(targetImage, imageFormat, outputFile);
+            }
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Unable to create image files: " + e.getMessage());
+            // Same catch covers both branches — encoding-to-buffer (embedded)
+            // and writing-to-disk (external). Keep the message neutral.
+            LOGGER.log(Level.WARNING, "Unable to encode image: " + e.getMessage());
         }
     }
 
     public static boolean isImageFileExists(String fileName) {
+        if (StaticLayoutContainers.isEmbedImages() && StaticLayoutContainers.hasEmbeddedImageBytes(fileName)) {
+            return true;
+        }
         File outputFile = new File(fileName);
         return outputFile.exists();
     }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/EmbedImagesIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/EmbedImagesIntegrationTest.java
@@ -37,6 +37,7 @@ class EmbedImagesIntegrationTest {
 
     private static final String SAMPLE_PDF_WITH_IMAGES = "../../samples/pdf/1901.03003.pdf";
     private static final String SAMPLE_PDF_BASENAME = "1901.03003";
+    private static final String SAMPLE_PDF_IMAGES_DIR = SAMPLE_PDF_BASENAME + "_images";
     private static final String BASE64_DATA_URI_PREFIX = "data:image/png;base64,";
     private static final String BASE64_JPEG_PREFIX = "data:image/jpeg;base64,";
 
@@ -82,14 +83,16 @@ class EmbedImagesIntegrationTest {
         assertTrue(Files.exists(jsonOutput), "JSON output should exist");
 
         String jsonContent = Files.readString(jsonOutput);
-        // Check for Base64 data URI in JSON output
-        if (jsonContent.contains("\"type\" : \"image\"")) {
-            assertTrue(
-                jsonContent.contains(BASE64_DATA_URI_PREFIX) || jsonContent.contains(BASE64_JPEG_PREFIX),
-                "JSON should contain Base64 data URI for images when embedImages is true"
-            );
-            assertTrue(jsonContent.contains("\"format\""), "JSON should contain format field");
-        }
+        assertTrue(jsonContent.contains("\"type\" : \"image\""),
+            "Sample PDF should produce at least one image entry");
+        assertTrue(
+            jsonContent.contains(BASE64_DATA_URI_PREFIX) || jsonContent.contains(BASE64_JPEG_PREFIX),
+            "JSON should contain Base64 data URI for images when embedImages is true");
+        assertTrue(jsonContent.contains("\"format\""), "JSON should contain format field");
+
+        Path imagesDir = tempDir.resolve(SAMPLE_PDF_IMAGES_DIR);
+        assertFalse(Files.exists(imagesDir),
+            "Embedded mode must be self-contained: external image directory should not be created");
     }
 
     @Test
@@ -116,13 +119,14 @@ class EmbedImagesIntegrationTest {
         assertTrue(Files.exists(htmlOutput), "HTML output should exist");
 
         String htmlContent = Files.readString(htmlOutput);
-        // Check for Base64 data URI in img src
-        if (htmlContent.contains("<img")) {
-            assertTrue(
-                htmlContent.contains("src=\"data:image/"),
-                "HTML img tags should use Base64 data URI when embedImages is true"
-            );
-        }
+        assertTrue(htmlContent.contains("<img"),
+            "Sample PDF should produce at least one <img> tag");
+        assertTrue(htmlContent.contains("src=\"data:image/"),
+            "HTML img tags should use Base64 data URI when embedImages is true");
+
+        Path imagesDir = tempDir.resolve(SAMPLE_PDF_IMAGES_DIR);
+        assertFalse(Files.exists(imagesDir),
+            "Embedded mode must be self-contained: external image directory should not be created");
     }
 
     @Test
@@ -149,13 +153,14 @@ class EmbedImagesIntegrationTest {
         assertTrue(Files.exists(mdOutput), "Markdown output should exist");
 
         String mdContent = Files.readString(mdOutput);
-        // Check for Base64 data URI in markdown image syntax
-        if (mdContent.contains("![")) {
-            assertTrue(
-                mdContent.contains("](data:image/"),
-                "Markdown images should use Base64 data URI when embedImages is true"
-            );
-        }
+        assertTrue(mdContent.contains("!["),
+            "Sample PDF should produce at least one markdown image block");
+        assertTrue(mdContent.contains("](data:image/"),
+            "Markdown images should use Base64 data URI when embedImages is true");
+
+        Path imagesDir = tempDir.resolve(SAMPLE_PDF_IMAGES_DIR);
+        assertFalse(Files.exists(imagesDir),
+            "Embedded mode must be self-contained: external image directory should not be created");
     }
 
     @Test
@@ -180,11 +185,14 @@ class EmbedImagesIntegrationTest {
         assertTrue(Files.exists(jsonOutput), "JSON output should exist");
 
         String jsonContent = Files.readString(jsonOutput);
-        // When embedImages is false, should use source field with file path
-        if (jsonContent.contains("\"type\" : \"image\"")) {
-            assertTrue(jsonContent.contains("\"source\""), "JSON should contain source field for file path");
-            assertFalse(jsonContent.contains("\"data\" : \"data:image"), "JSON should not contain Base64 data");
-        }
+        assertTrue(jsonContent.contains("\"type\" : \"image\""),
+            "Sample PDF should produce at least one image entry");
+        assertTrue(jsonContent.contains("\"source\""), "JSON should contain source field for file path");
+        assertFalse(jsonContent.contains("\"data\" : \"data:image"), "JSON should not contain Base64 data");
+
+        Path imagesDir = tempDir.resolve(SAMPLE_PDF_IMAGES_DIR);
+        assertTrue(Files.exists(imagesDir),
+            "External mode must extract images to disk: image directory should be created");
     }
 
     @Test
@@ -210,8 +218,14 @@ class EmbedImagesIntegrationTest {
         assertTrue(Files.exists(jsonOutput), "JSON output should exist");
 
         String jsonContent = Files.readString(jsonOutput);
-        if (jsonContent.contains("\"type\" : \"image\"") && jsonContent.contains("\"data\"")) {
-            assertTrue(jsonContent.contains("\"format\" : \"jpeg\""), "Format should be jpeg");
-        }
+        assertTrue(jsonContent.contains("\"type\" : \"image\""),
+            "Sample PDF should produce at least one image entry");
+        assertTrue(jsonContent.contains(BASE64_JPEG_PREFIX),
+            "JSON should contain JPEG Base64 data URI when imageFormat is jpeg");
+        assertTrue(jsonContent.contains("\"format\" : \"jpeg\""), "Format field should be jpeg");
+
+        Path imagesDir = tempDir.resolve(SAMPLE_PDF_IMAGES_DIR);
+        assertFalse(Files.exists(imagesDir),
+            "Embedded mode must be self-contained: external image directory should not be created");
     }
 }

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -24,7 +24,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--html-page-separator <value>', 'Separator between pages in HTML output. Use %page-number% for page numbers. Default: none');
   program.option('--image-output <value>', 'Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external');
   program.option('--image-format <value>', 'Output format for extracted images. Values: png, jpeg. Default: png');
-  program.option('--image-dir <value>', 'Directory for extracted images');
+  program.option('--image-dir <value>', 'Directory for extracted images (applies only with --image-output external)');
   program.option('--pages <value>', 'Pages to extract (e.g., "1,3,5-7"). Default: all pages');
   program.option('--include-header-footer', 'Include page headers and footers in output');
   program.option('--detect-strikethrough', 'Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -39,7 +39,7 @@ export interface ConvertOptions {
   imageOutput?: string;
   /** Output format for extracted images. Values: png, jpeg. Default: png */
   imageFormat?: string;
-  /** Directory for extracted images */
+  /** Directory for extracted images (applies only with --image-output external) */
   imageDir?: string;
   /** Pages to extract (e.g., "1,3,5-7"). Default: all pages */
   pages?: string;

--- a/options.json
+++ b/options.json
@@ -142,7 +142,7 @@
       "type": "string",
       "required": false,
       "default": null,
-      "description": "Directory for extracted images"
+      "description": "Directory for extracted images (applies only with --image-output external)"
     },
     {
       "name": "pages",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -169,7 +169,7 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "type": "string",
         "required": False,
         "default": None,
-        "description": "Directory for extracted images",
+        "description": "Directory for extracted images (applies only with --image-output external)",
     },
     {
         "name": "pages",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -65,7 +65,7 @@ def convert(
         html_page_separator: Separator between pages in HTML output. Use %page-number% for page numbers. Default: none
         image_output: Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external
         image_format: Output format for extracted images. Values: png, jpeg. Default: png
-        image_dir: Directory for extracted images
+        image_dir: Directory for extracted images (applies only with --image-output external)
         pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages
         include_header_footer: Include page headers and footers in output
         detect_strikethrough: Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)


### PR DESCRIPTION
## Objective
When using `--image-output embedded`, users expect a single self-contained
markdown/html/json file with Base64 data URIs inlined. The current behavior
also creates an external `<basename>_images/` folder with extracted PNG
files, duplicating the same images on disk — contradicting the option's
documented intent of "Base64 data URIs".

## Approach
Replace the write-then-read pipeline with an in-memory byte cache when
embedded is selected:

- `ImagesUtils` encodes `BufferedImage` to `byte[]` via
  `ByteArrayOutputStream` and stores it in a ThreadLocal cache.
- `Base64ImageUtils.toDataUri` and `ImagesUtils.isImageFileExists`
  consult the cache first. The disk fallback covers external mode and
  unit tests that prepare PNG files directly.
- Cache keys are normalized via `File.getPath()` at both write and read
  so mixed-slash CLI inputs (e.g. a forward-slash output dir on Windows)
  hit consistently.
- Generator and serializer call sites stay path-based — the fix is
  contained to the image pipeline.
- External and off modes have their observable behavior preserved
  (verified by integration tests).
- The new ThreadLocal map is added to `DocumentProcessor.propagateState`
  so worker threads share the main thread's cache instance. Today's cache
  access is main-thread only, so this is behaviorally a no-op — it
  preserves the future-safety property without further work if output
  generation is ever parallelized.

Memory: cached raw bytes and the encoded base64 string are briefly
co-resident during encoding; total memory is bounded by the existing
per-image `MAX_EMBEDDED_IMAGE_SIZE` cap (10 MB) multiplied by image count.

Also clarify `--image-dir`'s external-only applicability in its
description — this auto-propagates to web docs and Python/Node wrapper
bindings via `npm run sync`, guiding users away from the contradictory
combination without adding code-level rejection.

### Behavior change
Automation scripts that relied on the `<basename>_images/` folder being
created alongside the embedded-mode output need to switch to
`--image-output external` if those files are required.

## Evidence
Ran the CLI on `samples/pdf/1901.03003.pdf` (multi-image) and
`samples/pdf/chinese_scan.pdf` (scanned):

| Scenario | Expected | Actual |
|----------|----------|--------|
| `embedded` — multi-image PDF | .md only, base64 inlined, no _images/ | 2.0 MB .md with 20 base64 images, no _images/ folder |
| `external` — multi-image PDF | .md + _images/ with PNG refs | 55 KB .md with 20 file refs + _images/ with 20 PNGs |
| `off` — multi-image PDF | .md only, no image references | 54 KB .md, no image markdown, no _images/ folder |
| `embedded` — scanned PDF | .md only, base64 inlined | 88 KB .md with 1 base64 image, no _images/ folder |
| `external` — scanned PDF | .md + _images/ with PNG | 50 B .md + _images/ with 1 PNG |

`EmbedImagesIntegrationTest` asserts the contract for all five cases:
embedded variants (JSON, HTML, Markdown, JPEG) must inline Base64 AND
produce no external image directory; the external variant must extract
files to disk. These strengthened assertions fail on the previous code
and pass after the fix.

## Test plan
- [x] `mvn -pl opendataloader-pdf-core test` — `EmbedImagesIntegrationTest` 5/5, `ImageSerializerTest` 5/5, `Base64ImageUtilsTest` 13/13
- [x] CLI evidence on multi-image PDF and scanned PDF across all three image-output modes
- [x] `npm run sync` regenerates `options.json` and Python/Node wrapper bindings for the `--image-dir` description change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for embedding images directly in output as Base64 data URIs instead of storing them externally.

* **Documentation**
  * Clarified that the `--image-dir` option applies only when `--image-output` is set to `external`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->