### PR TITLE
feat(hybrid): expose raw response + reference environment + client wall-clock for downstream tooling

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -67,6 +67,7 @@ public class HancomAIClient implements HybridClient {
     private static final String SDK_ENDPOINT = "/hocr/sdk";
     private static final String PDF2IMG_ENDPOINT = "/support/pdf2img";
     private static final String PING_ENDPOINT = "/ping";
+    private static final String HEALTH_ENDPOINT = "/health";
     private static final int HEALTH_CHECK_TIMEOUT_MS = 3000;
     private static final String DEFAULT_FILENAME = "document.pdf";
     private static final MediaType MEDIA_TYPE_PDF = MediaType.parse("application/pdf");
@@ -135,6 +136,28 @@ public class HancomAIClient implements HybridClient {
         this.baseUrl = baseUrl;
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public JsonNode fetchHealth() {
+        OkHttpClient healthClient = httpClient.newBuilder()
+            .connectTimeout(HEALTH_CHECK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .readTimeout(HEALTH_CHECK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .build();
+        Request request = new Request.Builder()
+            .url(baseUrl + HEALTH_ENDPOINT)
+            .get()
+            .build();
+        try (Response response = healthClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) return null;
+            ResponseBody body = response.body();
+            if (body == null) return null;
+            return objectMapper.readTree(body.string());
+        } catch (IOException e) {
+            LOGGER.log(Level.FINE,
+                "Hancom AI /health unavailable: {0}", e.getMessage());
+            return null;
+        }
     }
 
     @Override
@@ -330,7 +353,8 @@ public class HancomAIClient implements HybridClient {
                     }
 
                     int objIdForCaption = fig.has("object_id") ? fig.get("object_id").asInt() : -1;
-                    String caption = callImageCaptioning(croppedPng, pageNum, objIdForCaption);
+                    CaptionResult captionResult = callImageCaptioning(croppedPng, pageNum, objIdForCaption);
+                    String caption = captionResult != null ? captionResult.caption : null;
 
                     ObjectNode capNode = objectMapper.createObjectNode();
                     capNode.put("page_number", pageNum);
@@ -339,6 +363,9 @@ public class HancomAIClient implements HybridClient {
                     bboxArr.add(left).add(top).add(right).add(bottom);
                     capNode.set("bbox", bboxArr);
                     capNode.put("caption", caption != null ? caption : "");
+                    if (captionResult != null && captionResult.confidence != null) {
+                        capNode.put("confidence", captionResult.confidence);
+                    }
                     captions.add(capNode);
 
                     LOGGER.log(Level.FINE, "Captioned figure page={0} bbox=[{1},{2},{3},{4}]: {5}",
@@ -467,10 +494,20 @@ public class HancomAIClient implements HybridClient {
                     dlaBbox.add(left).add(top).add(right).add(bottom);
                     entry.set("dla_bbox", dlaBbox);
 
-                    // Extract TSR page result
+                    // Extract TSR page result. The HOCR envelope wraps results
+                    // as RESULT=[[page]], so the page node is where any
+                    // top-level self-score lands.
                     List<JsonNode> tsrPages = extractPages(tsrResult);
                     if (!tsrPages.isEmpty()) {
-                        entry.set("tsr", tsrPages.get(0));
+                        JsonNode tsrPage = tsrPages.get(0);
+                        JsonNode conf = tsrPage.get("confidence");
+                        if (conf != null && conf.isNumber()) {
+                            // doubleValue() returns the numeric value directly;
+                            // asDouble() has a silent 0.0 fallback we don't want
+                            // even though the isNumber() guard makes it unreachable.
+                            entry.put("confidence", conf.doubleValue());
+                        }
+                        entry.set("tsr", tsrPage);
                     } else {
                         entry.set("tsr", objectMapper.createObjectNode());
                     }
@@ -637,7 +674,17 @@ public class HancomAIClient implements HybridClient {
     /**
      * Sends a cropped image to IMAGE_CAPTIONING and returns the caption text.
      */
-    private String callImageCaptioning(byte[] pngBytes, int pageNum, int objectId) throws IOException {
+    /** Image-captioning result: caption text + the model's self-reported confidence. */
+    static final class CaptionResult {
+        final String caption;
+        final Double confidence;
+        CaptionResult(String caption, Double confidence) {
+            this.caption = caption;
+            this.confidence = confidence;
+        }
+    }
+
+    private CaptionResult callImageCaptioning(byte[] pngBytes, int pageNum, int objectId) throws IOException {
         String requestId = "odl-" + sourcePdfShaShort + "-p" + pageNum + "-o" + objectId + "-caption";
         MultipartBody body = new MultipartBody.Builder()
             .setType(MultipartBody.FORM)
@@ -668,7 +715,11 @@ public class HancomAIClient implements HybridClient {
             JsonNode page = result.get(0);
             if (page.isArray() && page.size() > 0) page = page.get(0);
 
-            return page.has("caption") ? page.get("caption").asText("") : null;
+            String caption = page.has("caption") ? page.get("caption").asText("") : null;
+            JsonNode confNode = page.get("confidence");
+            Double confidence = confNode != null && confNode.isNumber()
+                ? confNode.doubleValue() : null;
+            return new CaptionResult(caption, confidence);
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -62,22 +62,24 @@ import java.util.regex.Pattern;
  *
  * <h2>Label Mapping (DLA integer labels → IObject types)</h2>
  * <pre>
- *   0  → Title (SemanticHeading level 1)
- *   1  → Heading (SemanticHeading level 2)
- *   2  → Paragraph (SemanticParagraph)
- *   3  → List item (SemanticParagraph)
- *   4  → Subheading (SemanticHeading level 3)
- *   6  → Author/Meta (SemanticParagraph)
- *   7  → Regionlist (Table/List region, handled via TABLE_STRUCTURE_RECOGNITION or as list)
- *   8  → TableName (SemanticCaption linked to nearest Table)
- *   9  → Table (handled via TABLE_STRUCTURE_RECOGNITION)
- *  10  → Figure (SemanticPicture)
- *  11  → FigureName (SemanticCaption linked to nearest Figure)
- *  12  → Formula (SemanticFormula)
- *  13  → Footnote (SemanticFootnote → FENote)
- *  14  → Page header (filtered)
- *  15  → Page footer (filtered)
- *  17  → Page number (filtered)
+ *   0  → DocTitle    (SemanticHeading level 1)
+ *   1  → ParaTitle   (SemanticHeading level 2)
+ *   2  → ParaText    (SemanticParagraph)
+ *   3  → ListText    (SemanticParagraph)
+ *   4  → RegionTitle (SemanticHeading level 3)
+ *   5  → Date        (currently passed through as paragraph text)
+ *   6  → OtherText   (SemanticParagraph)
+ *   7  → Regionlist  (Table/List region, handled via TABLE_STRUCTURE_RECOGNITION or as list)
+ *   8  → TableName   (SemanticCaption linked to nearest Table)
+ *   9  → Table       (handled via TABLE_STRUCTURE_RECOGNITION)
+ *  10  → Figure      (SemanticPicture)
+ *  11  → FigureName  (SemanticCaption linked to nearest Figure)
+ *  12  → Equation    (SemanticFormula)
+ *  13  → Footnote    (SemanticFootnote → FENote)
+ *  14  → PageHeader  (filtered)
+ *  15  → PageFooter  (filtered)
+ *  16  → Number      (currently passed through as paragraph text)
+ *  17  → PageNumber  (filtered)
  * </pre>
  *
  * <h2>Coordinate System</h2>
@@ -92,21 +94,27 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     private static final String BACKEND_TYPE = "hancom-ai";
 
     // DLA label constants
-    private static final int LABEL_TITLE = 0;
-    private static final int LABEL_HEADING = 1;
-    private static final int LABEL_PARAGRAPH = 2;
-    private static final int LABEL_LIST_ITEM = 3;
-    private static final int LABEL_SUBHEADING = 4;
-    private static final int LABEL_AUTHOR = 6;
+    // DLA label codes — authoritative table from the hancom-ai backend
+    // (0-indexed). Names mirror the backend's classification labels so
+    // grepping the codebase for "ParaText" or "DocTitle" matches what the
+    // model actually reports.
+    private static final int LABEL_DOC_TITLE = 0;
+    private static final int LABEL_PARA_TITLE = 1;
+    private static final int LABEL_PARA_TEXT = 2;
+    private static final int LABEL_LIST_TEXT = 3;
+    private static final int LABEL_REGION_TITLE = 4;
+    private static final int LABEL_DATE = 5;
+    private static final int LABEL_OTHER_TEXT = 6;
     private static final int LABEL_REGIONLIST = 7;
     private static final int LABEL_TABLE_NAME = 8;
     private static final int LABEL_TABLE = 9;
     private static final int LABEL_FIGURE = 10;
     private static final int LABEL_FIGURE_NAME = 11;
-    private static final int LABEL_FORMULA = 12;
+    private static final int LABEL_EQUATION = 12;
     private static final int LABEL_FOOTNOTE = 13;
     private static final int LABEL_PAGE_HEADER = 14;
     private static final int LABEL_PAGE_FOOTER = 15;
+    private static final int LABEL_NUMBER = 16;
     private static final int LABEL_PAGE_NUMBER = 17;
 
     // DPI conversion: API renders at 300 DPI, PDF uses 72 DPI
@@ -377,18 +385,18 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
         IObject iobj;
         switch (label) {
-            case LABEL_TITLE:
+            case LABEL_DOC_TITLE:
                 iobj = createHeading(text, bbox, 1);
                 break;
-            case LABEL_HEADING:
-            case LABEL_SUBHEADING: {
+            case LABEL_PARA_TITLE:
+            case LABEL_REGION_TITLE: {
                 double pixelHeight = bboxNode.get(3).asDouble() - bboxNode.get(1).asDouble();
                 int level = headingHeightToLevel.getOrDefault(pixelHeight, 2);
                 iobj = createHeading(text, bbox, level);
                 break;
             }
 
-            case LABEL_LIST_ITEM:
+            case LABEL_LIST_TEXT:
                 iobj = text.isEmpty() ? null : createListItem(text, bbox);
                 break;
 
@@ -401,8 +409,16 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 iobj = text.isEmpty() ? null : createFootnote(text, bbox);
                 break;
 
-            case LABEL_PARAGRAPH:
-            case LABEL_AUTHOR:
+            case LABEL_PARA_TEXT:
+            case LABEL_OTHER_TEXT:
+            case LABEL_DATE:
+            case LABEL_NUMBER:
+                // Date and Number are textual annotations on the page
+                // (e.g. "March 2024", "€42.00") — distinct from LABEL_PAGE_NUMBER
+                // which carries the page-number footer/header. Listing them as
+                // explicit cases keeps the routing intent visible and prevents
+                // future silent misrouting if the default branch behavior
+                // changes.
                 iobj = text.isEmpty() ? null : createParagraph(text, bbox);
                 break;
 
@@ -431,7 +447,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 break;
             }
 
-            case LABEL_FORMULA:
+            case LABEL_EQUATION:
                 iobj = createFormula(text, bbox);
                 break;
 
@@ -453,11 +469,11 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 .setConfidence(confidence)
                 .setSourceLabel(label);
 
-            if (label == LABEL_HEADING || label == LABEL_SUBHEADING) {
+            if (label == LABEL_PARA_TITLE || label == LABEL_REGION_TITLE) {
                 double pixelHeight = bboxNode.get(3).asDouble() - bboxNode.get(1).asDouble();
                 meta.setHeadingInferenceMethod("bbox-height")
                     .setBboxHeightPx(pixelHeight);
-            } else if (label == LABEL_TITLE) {
+            } else if (label == LABEL_DOC_TITLE) {
                 meta.setHeadingInferenceMethod("fixed");
             } else if (label == LABEL_FIGURE) {
                 int objectId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
@@ -960,7 +976,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
             for (JsonNode obj : objects) {
                 int label = obj.has("label") ? obj.get("label").asInt() : -1;
-                if (label != LABEL_HEADING && label != LABEL_SUBHEADING) continue;
+                if (label != LABEL_PARA_TITLE && label != LABEL_REGION_TITLE) continue;
 
                 JsonNode bboxNode = obj.get("bbox");
                 if (bboxNode == null || !bboxNode.isArray() || bboxNode.size() < 4) continue;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClient.java
@@ -39,6 +39,18 @@ import java.util.concurrent.CompletableFuture;
 public interface HybridClient {
 
     /**
+     * Optional: fetch the backend's {@code /health} (or equivalent) payload
+     * for reference-environment metadata (hardware, model identifiers,
+     * backend version). Best-effort — returns {@code null} when the backend
+     * has no such endpoint or the call fails. The default returns
+     * {@code null}; implementations that have a health endpoint should
+     * override.
+     */
+    default com.fasterxml.jackson.databind.JsonNode fetchHealth() {
+        return null;
+    }
+
+    /**
      * Output formats that can be requested from the hybrid backend.
      */
     enum OutputFormat {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -66,6 +66,7 @@ import java.util.Objects;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -95,6 +96,16 @@ public class HybridDocumentProcessor {
     private static volatile JsonNode lastHybridTimings;
 
     /**
+     * Cumulative client-side wall-clock for {@code client.convert(...)} calls during
+     * the most recent {@link #processDocument} run. Includes network RTT, JSON
+     * (de)serialization, and any queueing — i.e. the time the user actually waited
+     * on the backend. May exceed the server-reported {@code total_ms} (which
+     * counts only on-GPU work) and is the truer figure for SLA / throughput
+     * reasoning. {@code null} when no backend chunks were attempted.
+     */
+    private static volatile Long lastHybridClientMs;
+
+    /**
      * Stores element metadata from the most recent hybrid backend processing.
      * Reset at the start of each {@code processDocument} call.
      */
@@ -107,9 +118,61 @@ public class HybridDocumentProcessor {
      */
     private static volatile Map<Integer, List<OcrWordInfo>> lastOcrWordsByPage;
 
+    /**
+     * Stores the raw merged JSON returned by the hybrid backend's most recent
+     * {@code HybridResponse.getJson()}. Downstream tools (e.g. opendataloader-pdfua
+     * evidence reports) need per-module raw outputs to file as L2 evidence.
+     *
+     * <p>Single-threaded by contract: this static is overwritten on each
+     * {@code processDocument} call, so concurrent invocations would race. Callers
+     * that need per-document raw JSON must serialize {@code processDocument}
+     * invocations (or wrap with their own ThreadLocal).
+     *
+     * <p>Multi-chunk documents (&gt;{@link #BACKEND_CHUNK_SIZE} backend pages) currently
+     * keep only the last chunk's JSON. Single-chunk documents capture the full
+     * response.
+     */
+    private static volatile JsonNode lastHybridRawJson;
+
+    /**
+     * Snapshot of the hybrid backend's {@code /health} response taken at the
+     * start of the most recent {@link #processDocument} call. Downstream
+     * tools surface this so server-side timings can be interpreted against
+     * the hardware that produced them. {@code null} if hybrid was off or
+     * the backend did not provide a health endpoint.
+     */
+    private static volatile JsonNode lastHybridHealth;
+
     /** Returns the hybrid server timings from the most recent {@link #processDocument} call. */
     public static JsonNode getLastHybridTimings() {
         return lastHybridTimings;
+    }
+
+    /**
+     * Returns cumulative client-side wall-clock for hybrid backend calls during
+     * the most recent {@link #processDocument} call, or {@code null} if hybrid
+     * was off or the backend was never invoked. Always measured client-side, so
+     * mock and real backends are directly comparable on the same scale.
+     */
+    public static Long getLastHybridClientMs() {
+        return lastHybridClientMs;
+    }
+
+    /**
+     * Returns the raw merged hybrid backend JSON from the most recent
+     * {@link #processDocument} call, or {@code null} if hybrid was not used.
+     */
+    public static JsonNode getLastHybridRawJson() {
+        return lastHybridRawJson;
+    }
+
+    /**
+     * Returns the hybrid backend's reported {@code /health} payload
+     * (hardware + models + version) from the most recent processing run,
+     * or {@code null} if hybrid was off or the backend didn't report one.
+     */
+    public static JsonNode getLastHybridHealth() {
+        return lastHybridHealth;
     }
 
     /** Returns the element metadata from the most recent {@link #processDocument} call. */
@@ -172,6 +235,9 @@ public class HybridDocumentProcessor {
         lastHybridTimings = null; // Reset for this processing run
         lastElementMetadata = null;
         lastOcrWordsByPage = null;
+        lastHybridRawJson = null;
+        lastHybridHealth = null;
+        lastHybridClientMs = null;
 
         int totalPages = StaticContainers.getDocument().getNumberOfPages();
         LOGGER.log(Level.INFO, "Starting hybrid processing for {0} pages", totalPages);
@@ -509,6 +575,17 @@ public class HybridDocumentProcessor {
         // Get or create cached client
         HybridClient client = getClient(config);
 
+        // Best-effort: snapshot backend health (hardware, models, version)
+        // so downstream tooling can interpret server timings against the
+        // environment that produced them. Narrow catch to Exception so
+        // JVM-fatal errors (OutOfMemoryError etc.) still propagate.
+        try {
+            lastHybridHealth = client.fetchHealth();
+        } catch (Exception e) {
+            lastHybridHealth = null;
+            LOGGER.log(Level.FINE, "fetchHealth failed", e);
+        }
+
         // Read PDF bytes
         byte[] pdfBytes = Files.readAllBytes(Path.of(inputPdfName));
 
@@ -543,12 +620,30 @@ public class HybridDocumentProcessor {
 
             try {
                 HybridRequest request = HybridRequest.forPages(pdfBytes, chunkPages1Indexed, outputFormats);
-                HybridResponse response = client.convert(request);
+                long convertStartNs = System.nanoTime();
+                HybridResponse response;
+                try {
+                    response = client.convert(request);
+                } finally {
+                    // Accumulate client wall-clock for this convert call whether
+                    // it succeeded, failed with IOException, or otherwise unwound
+                    // — the user waited that long regardless of outcome, and
+                    // that's what this metric exists to measure (SLA / throughput).
+                    // nanoTime() is monotonic; safe against wall-clock jumps
+                    // (NTP / DST / manual changes).
+                    long convertElapsedMs = TimeUnit.NANOSECONDS.toMillis(
+                        System.nanoTime() - convertStartNs);
+                    lastHybridClientMs = (lastHybridClientMs == null ? 0L : lastHybridClientMs)
+                        + convertElapsedMs;
+                }
 
                 // Capture hybrid server pipeline timings (last chunk wins for now;
                 // in single-chunk documents this is exact)
                 if (response.getTimings() != null) {
                     lastHybridTimings = response.getTimings();
+                }
+                if (response.getJson() != null) {
+                    lastHybridRawJson = response.getJson();
                 }
 
                 // Collect failed pages (convert from 1-indexed to 0-indexed)

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HealthCheckTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HealthCheckTest.java
@@ -15,6 +15,7 @@
  */
 package org.opendataloader.pdf.hybrid;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -169,6 +170,73 @@ class HealthCheckTest {
         } finally {
             client.shutdown();
         }
+    }
+
+    // -- fetchHealth() on HancomAIClient ------------------------------------
+    //
+    // checkAvailability() above is the fail-fast probe used before the run
+    // starts; fetchHealth() is the best-effort snapshot captured during the
+    // run for downstream tooling to attach to its evidence report. It must
+    // never throw — a null return is the documented signal that the backend
+    // doesn't expose /health or returned something unreadable.
+
+    @Test
+    void testHancomFetchHealthReturnsParsedJsonOnSuccess() throws IOException {
+        server.start();
+        server.enqueue(new MockResponse()
+            .setBody("{\"hardware\":{\"cpu\":\"Xeon\"},\"backend_version\":\"v1\"}")
+            .addHeader("Content-Type", "application/json"));
+
+        String baseUrl = stripTrailingSlash(server.url("").toString());
+        HancomAIClient client = new HancomAIClient(
+            baseUrl, new OkHttpClient(), new ObjectMapper());
+
+        JsonNode health = client.fetchHealth();
+        assertNotNull(health, "expected parsed /health JSON");
+        assertEquals("Xeon", health.path("hardware").path("cpu").asText());
+        assertEquals("v1", health.path("backend_version").asText());
+    }
+
+    @Test
+    void testHancomFetchHealthReturnsNullOnNotFound() throws IOException {
+        server.start();
+        server.enqueue(new MockResponse().setResponseCode(404));
+
+        String baseUrl = stripTrailingSlash(server.url("").toString());
+        HancomAIClient client = new HancomAIClient(
+            baseUrl, new OkHttpClient(), new ObjectMapper());
+
+        assertNull(client.fetchHealth(),
+            "non-2xx response should be treated as 'no health' (null), not throw");
+    }
+
+    @Test
+    void testHancomFetchHealthReturnsNullOnNonJsonBody() throws IOException {
+        server.start();
+        server.enqueue(new MockResponse()
+            .setBody("not json at all")
+            .addHeader("Content-Type", "text/plain"));
+
+        String baseUrl = stripTrailingSlash(server.url("").toString());
+        HancomAIClient client = new HancomAIClient(
+            baseUrl, new OkHttpClient(), new ObjectMapper());
+
+        assertNull(client.fetchHealth(),
+            "unparseable body should be treated as 'no health' (null), not throw");
+    }
+
+    @Test
+    void testHancomFetchHealthReturnsNullWhenServerDown() throws IOException {
+        int unusedPort;
+        try (ServerSocket s = new ServerSocket(0)) {
+            unusedPort = s.getLocalPort();
+        }
+
+        HancomAIClient client = new HancomAIClient(
+            "http://localhost:" + unusedPort, new OkHttpClient(), new ObjectMapper());
+
+        assertNull(client.fetchHealth(),
+            "connection failure should be treated as 'no health' (null), not throw");
     }
 
     private static String stripTrailingSlash(String url) {


### PR DESCRIPTION
## Summary

- Expose three new static volatiles + getters on `HybridDocumentProcessor`: `lastHybridRawJson`, `lastHybridHealth`, `lastHybridClientMs`
- Add `HybridClient.fetchHealth()` default method; `HancomAIClient` overrides it (GET `/health`)
- Copy top-level `confidence` from TSR + IMAGE_CAPTIONING through merged JSON so downstream can surface per-table / per-caption self-scores
- Rename DLA label constants to the authoritative hancom-ai names, add codes 5 (Date) and 16 (Number)

Required by opendataloader-pdfua [`feat/evidence-report-series`](https://github.com/opendataloader-project/opendataloader-pdfua/pull/55) — the new evidence-report needs all three hooks to persist per-module raw responses, reference hardware, and honest SLA-grade timings.

## Why client wall-clock alongside server-reported timings

`HybridResponse.getTimings()` reports on-GPU work the server self-reports. Downstream tooling reasoning about SLA / throughput needs the figure the *user* actually waited on — network RTT, JSON (de)serialization, queueing. `lastHybridClientMs` accumulates around each `client.convert(...)` in a `try-finally`, so failures (timeouts, 5xx) are accounted too. Real-server and mock-fixture runs are now directly comparable on the same client-side scale, which the server-reported `total_ms` isn't (fixture-replay servers return canned timings).

## Test plan

- [x] `mvn install -DskipTests` from `java/` — BUILD SUCCESS
- [x] Single-threaded-per-process contract preserved (same volatile-static pattern as the existing `lastHybridTimings`)
- [x] `fetchHealth()` default returns null; other `HybridClient` implementations (Docling, Hancom) inherit unchanged
- [x] No production / test code pins the old DLA label constants by string
- [x] Two rounds of independent senior review (✅ ready to merge)
- [ ] CI pipeline (will run on PR push)

## Notes

- Single squashed commit. Rebased onto current `main`.
- Multi-chunk documents: `lastHybridClientMs` accumulates across chunks; `lastHybridRawJson` and `lastHybridTimings` keep last-chunk-wins (existing contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional health-check support for hybrid AI backends (best-effort, non-fatal)
  * Image captioning now returns optional model confidence per figure
  * Table extraction includes optional confidence per table entry
  * Telemetry extended to record client-side processing time, last backend response, and last backend health snapshot

* **Tests**
  * Added health-check tests covering success, missing health, non-JSON responses, and unreachable server cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->