### PR TITLE
fix(processors): surface clean error for corrupted or truncated PDFs

### DIFF
--- a/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
+++ b/java/opendataloader-pdf-cli/src/test/java/org/opendataloader/pdf/cli/CLIMainTest.java
@@ -74,14 +74,22 @@ class CLIMainTest {
 
     /**
      * When a directory contains a file that fails processing, run() must return
-     * non-zero, even though other files in the directory may succeed.
+     * non-zero, even though other files in the directory may succeed. The
+     * "failure" here must be a genuine processing error (unreachable hybrid
+     * backend), not a corrupt-content classification — corrupt PDFs inside a
+     * directory are silently skipped by design (see
+     * {@link #testCorruptPdfInsideDirectoryIsSilentlySkipped()}), so the test
+     * uses a parseable PDF and lets the hybrid availability check fail.
      */
     @Test
     void testDirectoryWithFailingFileReturnsNonZeroExitCode() throws IOException {
         Path dir = tempDir.resolve("docs");
         Files.createDirectory(dir);
         Path testPdf = dir.resolve("bad.pdf");
-        Files.write(testPdf, "%PDF-1.4 minimal".getBytes());
+        try (PDDocument doc = new PDDocument()) {
+            doc.addPage(new PDPage());
+            doc.save(testPdf.toFile());
+        }
 
         int exitCode = CLIMain.run(new String[]{
             "--hybrid", "docling-fast",
@@ -533,36 +541,74 @@ class CLIMainTest {
     }
 
     /**
-     * A genuinely corrupted PDF (has %PDF- header, body broken) is OUT of
-     * scope for this fix and must continue to fail via the existing SEVERE
-     * path — NOT through the new magic-number branch. This test pins that
-     * behavior by asserting (a) the user-facing magic-number error never
-     * appears, and (b) the SEVERE log line from CLIMain.processFile is
-     * actually emitted (proving the existing SEVERE path was the one taken).
+     * A PDF with a valid {@code %PDF-} header but a corrupt or truncated body
+     * must surface the friendly "corrupted or truncated content" error on
+     * stdout, exit non-zero, AND must not leak a veraPDF stack trace. The
+     * wording must also be distinct from the missing-header case so users
+     * can tell the two failure modes apart.
      */
     @Test
-    void testCorruptPdfStillFailsViaExistingPath() throws IOException {
+    void testCorruptPdfShowsCorruptedFileErrorWithoutStackTrace() throws IOException {
         Path corrupt = tempDir.resolve("corrupt.pdf");
         // Valid header, but nothing else — veraPDF will fail at parse time.
         Files.write(corrupt, "%PDF-1.4\n<garbage>".getBytes(StandardCharsets.UTF_8));
 
+        String[] stdoutHolder = new String[1];
+        int exitCode = (int) runCapturingStdout(
+            () -> CLIMain.run(new String[]{corrupt.toString()}),
+            stdoutHolder);
+
+        String out = stdoutHolder[0];
+        assertNotEquals(0, exitCode,
+            "Corrupt PDF must still fail (non-zero exit); got stdout: " + out);
+        assertTrue(out.contains("'corrupt.pdf' is not a valid PDF file (corrupted or truncated content)"),
+            "stdout must surface the friendly corrupted-content error; got: " + out);
+        assertFalse(out.contains("missing %PDF- header"),
+            "Corrupt-but-headered PDFs must NOT be misreported as missing the header; got: "
+            + out);
+        assertFalse(out.toLowerCase(java.util.Locale.ROOT).contains("verapdf"),
+            "Output must not contain 'verapdf'; got: " + out);
+        assertFalse(out.contains("java.io.IOException:"),
+            "Output must not contain 'java.io.IOException:'; got: " + out);
+        assertFalse(out.contains("\tat "),
+            "Output must not contain a Java stack trace ('\\tat '); got: " + out);
+    }
+
+    /**
+     * A corrupt-but-headered PDF inside a directory must follow the same
+     * batch-folder semantics as a non-PDF-content file: WARNING log, no
+     * {@code Error:} on stdout, exit 0. This mirrors
+     * {@link #testPdfExtensionNonPdfInsideDirectoryIsSilentlySkipped()} for
+     * the corrupted-body branch so both failure modes route through the
+     * same {@link InvalidPdfFileException} handler in CLIMain.
+     */
+    @Test
+    void testCorruptPdfInsideDirectoryIsSilentlySkipped() throws IOException {
+        Path dir = tempDir.resolve("mixed-corrupt");
+        Files.createDirectory(dir);
+        Files.write(dir.resolve("corrupt.pdf"),
+            "%PDF-1.4\n<garbage>".getBytes(StandardCharsets.UTF_8));
+        Files.write(dir.resolve("note.png"), new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47});
+
         List<LogRecord> records = new ArrayList<>();
         String[] stdoutHolder = new String[1];
         int exitCode = (int) captureLogsOf(records, () -> runCapturingStdout(
-            () -> CLIMain.run(new String[]{corrupt.toString()}),
+            () -> CLIMain.run(new String[]{dir.toString()}),
             stdoutHolder)).intValue();
 
-        assertNotEquals(0, exitCode,
-            "Corrupt PDF must still fail (non-zero exit)");
-        assertFalse(stdoutHolder[0].contains("missing %PDF- header"),
-            "Corrupt-but-headered PDFs must NOT be misreported as missing the header; got: "
-            + stdoutHolder[0]);
-        assertTrue(records.stream().anyMatch(r ->
-                r.getLevel() == Level.SEVERE
+        assertEquals(0, exitCode,
+            "Directory traversal must exit 0 even when a child is a corrupt PDF "
+            + "(silent-skip semantics); got stdout: " + stdoutHolder[0]);
+        assertFalse(stdoutHolder[0].contains("Error:"),
+            "Directory traversal must not surface 'Error:' on stdout; got: " + stdoutHolder[0]);
+        long warningMatches = records.stream().filter(r ->
+                r.getLevel() == Level.WARNING
                 && r.getMessage() != null
-                && r.getMessage().contains("Exception during processing file")),
-            "Corrupt PDF must take the SEVERE path (not the magic-number branch); got: "
-            + records);
+                && r.getMessage().contains("'corrupt.pdf'")
+                && r.getMessage().contains("corrupted or truncated")).count();
+        assertEquals(1L, warningMatches,
+            "Exactly one WARNING log must name the offending file and describe "
+            + "the corrupted-content failure; got: " + records);
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/exceptions/InvalidPdfFileException.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/exceptions/InvalidPdfFileException.java
@@ -18,12 +18,22 @@ package org.opendataloader.pdf.exceptions;
 import java.io.IOException;
 
 /**
- * Thrown when an input file does not look like a PDF (the {@code %PDF-} magic
- * number is missing from the first 1024 bytes).
+ * Thrown when an input file cannot be processed as a PDF. Two failure modes
+ * share this exception type, distinguished by message wording:
+ * <ul>
+ *   <li><em>Missing header</em> — the {@code %PDF-} magic number is absent
+ *       from the first 1024 bytes (JPEG renamed to {@code .pdf}, empty file,
+ *       arbitrary text). Detected before veraPDF is invoked.</li>
+ *   <li><em>Corrupted or truncated content</em> — the magic number is
+ *       present but the body fails to parse (interrupted download, missing
+ *       trailing xref, garbage payload). Detected when {@code new PDDocument}
+ *       throws {@link IOException}; the original veraPDF exception is
+ *       preserved via {@link #getCause()} for diagnostics.</li>
+ * </ul>
  *
  * <p>This is a checked subtype of {@link IOException} so callers that already
  * handle {@code IOException} keep compiling, while callers that want to
- * distinguish "not a PDF" from other I/O failures can catch this type
+ * distinguish "not a usable PDF" from other I/O failures can catch this type
  * specifically.
  *
  * <p>Public entry points that may surface this exception:

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -36,6 +36,7 @@ import org.verapdf.cos.COSDictionary;
 import org.verapdf.cos.COSObjType;
 import org.verapdf.cos.COSObject;
 import org.verapdf.cos.COSTrailer;
+import org.verapdf.exceptions.InvalidPasswordException;
 import org.verapdf.gf.model.impl.containers.StaticStorages;
 import org.verapdf.gf.model.impl.cos.GFCosInfo;
 import org.verapdf.gf.model.impl.sa.GFSAPDFDocument;
@@ -530,7 +531,22 @@ public class DocumentProcessor {
         LOGGER.log(Level.INFO, () -> "File name: " + pdfName);
         validatePdfMagicNumber(pdfName);
         updateStaticContainers(config);
-        PDDocument pdDocument = new PDDocument(pdfName);
+        PDDocument pdDocument;
+        try {
+            pdDocument = new PDDocument(pdfName);
+        } catch (InvalidPasswordException pw) {
+            // Encrypted PDFs are not a content-validity failure — let the
+            // password-handling branch in callers (e.g. CLIMain) take over.
+            throw pw;
+        } catch (IOException cause) {
+            // Magic number was present, so the user expected a real PDF, but
+            // veraPDF could not parse the document (truncated download, body
+            // corruption, missing xref). Surface a friendly message instead
+            // of letting the raw veraPDF IOException leak as a stack trace.
+            throw new InvalidPdfFileException(
+                "'" + displayName(pdfName) + "' is not a valid PDF file (corrupted or truncated content).",
+                cause);
+        }
         StaticResources.setDocument(pdDocument);
         GFSAPDFDocument document = new GFSAPDFDocument(pdDocument);
 //        org.verapdf.gf.model.impl.containers.StaticContainers.setFlavour(Collections.singletonList(PDFAFlavour.WCAG_2_2));
@@ -578,11 +594,19 @@ public class DocumentProcessor {
         }
         byte[] marker = "%PDF-".getBytes(StandardCharsets.US_ASCII);
         if (indexOfBytes(head, marker) < 0) {
-            Path fileName = path.getFileName();
-            String displayName = fileName != null ? fileName.toString() : pdfName;
             throw new InvalidPdfFileException(
-                "'" + displayName + "' is not a valid PDF file (missing %PDF- header).");
+                "'" + displayName(pdfName) + "' is not a valid PDF file (missing %PDF- header).");
         }
+    }
+
+    /**
+     * Path.getFileName() returns null for filesystem roots (e.g. {@code C:\}).
+     * Fall back to the original input string in that case so the user-facing
+     * error message is never empty.
+     */
+    private static String displayName(String pdfName) {
+        Path fileName = Path.of(pdfName).getFileName();
+        return fileName != null ? fileName.toString() : pdfName;
     }
 
     private static int indexOfBytes(byte[] haystack, byte[] needle) {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorMagicNumberTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorMagicNumberTest.java
@@ -25,14 +25,26 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Regression tests for PDFDLOSP-14: DocumentProcessor.preprocessing must reject
- * files whose content is not PDF with a typed InvalidPdfFileException, before
- * the veraPDF parser is invoked.
+ * Regression tests for DocumentProcessor.preprocessing: every "input is not
+ * a usable PDF" failure mode must surface as a typed InvalidPdfFileException
+ * with a user-facing message, never a raw veraPDF IOException.
+ *
+ * <p>Two failure modes are covered:
+ * <ul>
+ *   <li>Missing {@code %PDF-} header (JPEG, empty file): caught by the
+ *       magic-number guard before veraPDF is invoked. Message ends with
+ *       {@code (missing %PDF- header)}.</li>
+ *   <li>Header present but body corrupt or truncated: caught when
+ *       {@code new PDDocument(pdfName)} fails inside veraPDF. Message ends
+ *       with {@code (corrupted or truncated content)}, and the original
+ *       IOException is preserved as the cause for diagnostics.</li>
+ * </ul>
  */
 class DocumentProcessorMagicNumberTest {
 
@@ -61,12 +73,14 @@ class DocumentProcessorMagicNumberTest {
     }
 
     @Test
-    void preprocessingAcceptsHeaderAfterBomAndWhitespace() throws IOException {
+    void preprocessingClassifiesBomPrefixedTruncatedPdfAsCorrupted() throws IOException {
         Path bomPdf = tempDir.resolve("bom.pdf");
         // UTF-8 BOM + spaces + valid PDF header. The magic-number guard must
-        // accept this (1024-byte search window). It will still fail later in
-        // veraPDF because the body is incomplete — that failure must NOT be
-        // an InvalidPdfFileException, since the header IS present.
+        // accept this (1024-byte search window). veraPDF will still reject
+        // the file because the body is incomplete — but that failure must
+        // surface as InvalidPdfFileException with the "corrupted or
+        // truncated" message, not as a raw IOException and not with the
+        // missing-header wording.
         byte[] prefix = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, ' ', ' '};
         byte[] header = "%PDF-1.4\n".getBytes(StandardCharsets.US_ASCII);
         byte[] content = new byte[prefix.length + header.length];
@@ -74,14 +88,22 @@ class DocumentProcessorMagicNumberTest {
         System.arraycopy(header, 0, content, prefix.length, header.length);
         Files.write(bomPdf, content);
 
-        // Any exception thrown must NOT be InvalidPdfFileException — the
-        // magic-number guard accepted the file. veraPDF may still reject it
-        // later, but that goes through the normal IOException path.
-        Throwable thrown = assertThrows(Throwable.class,
+        InvalidPdfFileException thrown = assertThrows(
+            InvalidPdfFileException.class,
             () -> DocumentProcessor.preprocessing(bomPdf.toString(), new Config()));
-        assertTrue(!(thrown instanceof InvalidPdfFileException),
-            "Magic-number guard must accept %PDF- preceded by BOM/whitespace; "
-            + "got InvalidPdfFileException: " + thrown.getMessage());
+
+        String message = thrown.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("bom.pdf"),
+            "Message must include the file name; got: " + message);
+        assertTrue(message.contains("corrupted or truncated"),
+            "Body-corruption case must use the 'corrupted or truncated' wording, "
+            + "not the missing-header wording; got: " + message);
+        assertFalse(message.contains("missing %PDF- header"),
+            "Header IS present (just preceded by BOM/whitespace) — must not "
+            + "be misreported as missing; got: " + message);
+        assertNotNull(thrown.getCause(),
+            "Original veraPDF IOException must be preserved as cause for diagnostics");
     }
 
     @Test
@@ -91,5 +113,36 @@ class DocumentProcessorMagicNumberTest {
 
         assertThrows(InvalidPdfFileException.class,
             () -> DocumentProcessor.preprocessing(empty.toString(), new Config()));
+    }
+
+    @Test
+    void preprocessingRejectsTruncatedPdfWithInvalidPdfFileException() throws IOException {
+        // Simulates a real download that was interrupted near the end of
+        // the file: valid %PDF- header at the start, plausible body bytes,
+        // but the trailing xref table that veraPDF requires is gone.
+        Path truncated = tempDir.resolve("truncated.pdf");
+        byte[] head = "%PDF-1.6\n".getBytes(StandardCharsets.US_ASCII);
+        byte[] body = new byte[1024];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) ('a' + (i % 26));
+        }
+        byte[] content = new byte[head.length + body.length];
+        System.arraycopy(head, 0, content, 0, head.length);
+        System.arraycopy(body, 0, content, head.length, body.length);
+        Files.write(truncated, content);
+
+        InvalidPdfFileException thrown = assertThrows(
+            InvalidPdfFileException.class,
+            () -> DocumentProcessor.preprocessing(truncated.toString(), new Config()));
+
+        String message = thrown.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("truncated.pdf"),
+            "Message must include the file name; got: " + message);
+        assertTrue(message.contains("corrupted or truncated"),
+            "Truncated PDF must surface the 'corrupted or truncated' message; got: "
+            + message);
+        assertNotNull(thrown.getCause(),
+            "Original veraPDF IOException must be preserved as cause for diagnostics");
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorMagicNumberTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorMagicNumberTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,7 +103,7 @@ class DocumentProcessorMagicNumberTest {
         assertFalse(message.contains("missing %PDF- header"),
             "Header IS present (just preceded by BOM/whitespace) — must not "
             + "be misreported as missing; got: " + message);
-        assertNotNull(thrown.getCause(),
+        assertInstanceOf(IOException.class, thrown.getCause(),
             "Original veraPDF IOException must be preserved as cause for diagnostics");
     }
 
@@ -142,7 +143,7 @@ class DocumentProcessorMagicNumberTest {
         assertTrue(message.contains("corrupted or truncated"),
             "Truncated PDF must surface the 'corrupted or truncated' message; got: "
             + message);
-        assertNotNull(thrown.getCause(),
+        assertInstanceOf(IOException.class, thrown.getCause(),
             "Original veraPDF IOException must be preserved as cause for diagnostics");
     }
 }


### PR DESCRIPTION
## Objective

A PDF whose `%PDF-` header is present but whose body is corrupt or truncated (download interrupted near the end, missing trailing xref) currently surfaces a 17-line veraPDF `IOException` stack trace on stdout. The user has no way to tell whether their file is broken or whether opendataloader-pdf is.

## Approach

Wrap only the `new PDDocument(pdfName)` call in `DocumentProcessor.preprocessing` with a try-catch on `IOException` and rethrow as `InvalidPdfFileException` (introduced by the prior wrong-content fix) with a distinct message ending in `(corrupted or truncated content)`.

`InvalidPasswordException` is re-thrown as-is so the existing password-handling branch in `CLIMain` still wins.

Other failure modes (`parseStructureTreeRoot`, `parseChunks`, hybrid path) remain on the existing SEVERE path — only the header-present-body-broken case is reclassified.

Because `InvalidPdfFileException` is already routed by `CLIMain.processFile`, no CLI changes are needed: CLI-argument input prints `Error: ...` on stdout and exits 1; a corrupt file inside a directory logs WARNING and continues (preserves batch-folder semantics). The original veraPDF exception is preserved as `getCause()` so Java API consumers can still inspect the root cause for diagnostics.

## Evidence

`mvn -pl opendataloader-pdf-cli -am test` runs `DocumentProcessorMagicNumberTest` 4/4 pass and `CLIMainTest` 23/23 pass.

Manual end-to-end against the built jar:

| Scenario | Expected | Actual |
|----------|----------|--------|
| Real PDF with last 2000 bytes cut off | friendly stdout, exit 1, no stack trace | `Error: 'real_truncated.pdf' is not a valid PDF file (corrupted or truncated content).` exit 1 |
| JPEG renamed to `.pdf` | distinct missing-header wording | `Error: 'fake.pdf' is not a valid PDF file (missing %PDF- header).` exit 1 |
| Intact PDF | exit 0, JSON written | exit 0, JSON generated |
| Directory with 1 truncated + 1 intact | intact processed, truncated skipped with WARNING, exit 0 | WARNING `'truncated.pdf' ... Skipping.`, `good.json` written, exit 0 |

`npm run sync` not required — no CLI option definitions changed. Python/Node wrappers pass Java stdout and exit code through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, user-facing error messages distinguishing missing PDF header vs. “corrupted or truncated content”.
  * Password-protected PDFs rethrown appropriately; corrupt-but-headered files report friendly errors without leaking internal stack traces. Directory-contained corrupt files are now skipped with a warning and successful exit.

* **Documentation**
  * Updated exception docs to describe the two PDF failure modes and preserved underlying causes.

* **Tests**
  * Added regression tests covering corrupt-but-headered PDFs, truncated files, and directory-skip behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->