### PR TITLE
feat(json): emit per-node ai_score + pdfua_tag, fix paragraph/table metadata holes

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/ElementMetadata.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/ElementMetadata.java
@@ -25,8 +25,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class ElementMetadata {
 
-    /** DLA confidence (0.0~1.0). */
-    private double confidence = 1.0;
+    /** DLA AI score (0.0~1.0). Negative sentinel means "not provided". */
+    private double aiScore = -1.0;
 
     /** Original Hancom AI label (0~17), -1 if not applicable. */
     private int sourceLabel = -1;
@@ -58,12 +58,12 @@ public class ElementMetadata {
     /** Stream vs OCR text similarity score (auto mode only). */
     private Double streamOcrSimilarity;
 
-    public double getConfidence() {
-        return confidence;
+    public double getAiScore() {
+        return aiScore;
     }
 
-    public ElementMetadata setConfidence(double confidence) {
-        this.confidence = confidence;
+    public ElementMetadata setAiScore(double aiScore) {
+        this.aiScore = aiScore;
         return this;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -151,6 +151,17 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     }
 
     @Override
+    public void rekeyMetadata(Map<Long, Long> oldToNew) {
+        if (oldToNew == null || oldToNew.isEmpty() || elementMetadataMap.isEmpty()) return;
+        Map<Long, ElementMetadata> rebuilt = new LinkedHashMap<>(elementMetadataMap.size());
+        for (Map.Entry<Long, ElementMetadata> entry : elementMetadataMap.entrySet()) {
+            Long mapped = oldToNew.get(entry.getKey());
+            rebuilt.put(mapped != null ? mapped : entry.getKey(), entry.getValue());
+        }
+        elementMetadataMap = rebuilt;
+    }
+
+    @Override
     public Map<Integer, List<OcrWordInfo>> getOcrWordsByPage() {
         return Collections.unmodifiableMap(ocrWordsByPage);
     }
@@ -456,17 +467,23 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 break;
         }
 
-        // Map confidence to correctSemanticScore (only for SemanticNode subtypes)
-        if (iobj instanceof SemanticNode) {
-            double confidence = obj.has("confidence") ? obj.get("confidence").asDouble(1.0) : 1.0;
-            ((SemanticNode) iobj).setCorrectSemanticScore(confidence);
+        // Hancom AI DLA reports each object's overall detection score in the
+        // "confidence" field (numeric, 0..1). The per-word "score" entries
+        // inside "words" are OCR confidences, not object scores.
+        double aiScore = -1.0;
+        if (obj.has("confidence")) {
+            aiScore = obj.get("confidence").asDouble(-1.0);
+        }
+
+        // Map AI score to correctSemanticScore (only for SemanticNode subtypes)
+        if (iobj instanceof SemanticNode && aiScore >= 0.0) {
+            ((SemanticNode) iobj).setCorrectSemanticScore(aiScore);
         }
 
         // Produce ElementMetadata for this IObject
         if (iobj != null && iobj.getRecognizedStructureId() != null) {
-            double confidence = obj.has("confidence") ? obj.get("confidence").asDouble(1.0) : 1.0;
             ElementMetadata meta = new ElementMetadata()
-                .setConfidence(confidence)
+                .setAiScore(aiScore)
                 .setSourceLabel(label);
 
             if (label == LABEL_PARA_TITLE || label == LABEL_REGION_TITLE) {
@@ -711,7 +728,10 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         }
 
         // Produce ElementMetadata for the table
+        double tableAiScore = tableEntry.has("confidence")
+            ? tableEntry.get("confidence").asDouble(-1.0) : -1.0;
         ElementMetadata tableMeta = new ElementMetadata()
+            .setAiScore(tableAiScore)
             .setSourceLabel(tableEntry.has("label") ? tableEntry.get("label").asInt() : LABEL_TABLE);
         if (tsr != null) {
             ElementMetadata.TsrMetadata tsrMeta = new ElementMetadata.TsrMetadata();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridSchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridSchemaTransformer.java
@@ -81,6 +81,20 @@ public interface HybridSchemaTransformer {
     }
 
     /**
+     * Re-key the in-memory {@link ElementMetadata} map after the host
+     * pipeline renumbered structure IDs. {@code oldToNew} maps the
+     * transformer-assigned ID to the post-{@code setIDs} ID for IObjects
+     * the caller just renumbered; entries for unmapped IDs are left alone.
+     *
+     * <p>Backends that don't expose mutable metadata should leave the
+     * default no-op; their downstream metadata lookups will continue to
+     * miss.
+     */
+    default void rekeyMetadata(Map<Long, Long> oldToNew) {
+        // no-op
+    }
+
+    /**
      * Returns per-page OCR word data collected during the last {@link #transform} call.
      * Keys are 0-indexed page numbers. Each list contains word-level OCR data with
      * text and bounding box in PDF coordinate space.

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonName.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonName.java
@@ -65,7 +65,8 @@ public class JsonName {
     public static final String IMAGE_FORMAT = "format";
     public static final String FORMULA_TYPE = "formula";
     public static final String DESCRIPTION = "description";
-    public static final String CONFIDENCE = "confidence";
+    public static final String AI_SCORE = "ai_score";
+    public static final String PDFUA_TAG = "pdfua_tag";
     public static final String SOURCE_LABEL = "source label";
     public static final String HYBRID = "hybrid";
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/SemanticTextNodeSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/SemanticTextNodeSerializer.java
@@ -35,6 +35,7 @@ public class SemanticTextNodeSerializer extends StdSerializer<SemanticTextNode> 
         jsonGenerator.writeStartObject();
         SerializerUtil.writeEssentialInfo(jsonGenerator, textNode, textNode.getSemanticType().toString().toLowerCase());
         SerializerUtil.writeTextInfo(jsonGenerator, textNode);
+        SerializerUtil.writeMetadataIfPresent(jsonGenerator, textNode);
         jsonGenerator.writeEndObject();
     }
 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/SerializerUtil.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/SerializerUtil.java
@@ -20,6 +20,7 @@ import org.opendataloader.pdf.hybrid.ElementMetadata;
 import org.opendataloader.pdf.json.JsonName;
 import org.opendataloader.pdf.utils.TextNodeUtils;
 import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.SemanticHeading;
 import org.verapdf.wcag.algorithms.entities.SemanticTextNode;
 
 import java.io.IOException;
@@ -52,8 +53,8 @@ public class SerializerUtil {
         ElementMetadata meta = metadata.get(object.getRecognizedStructureId());
         if (meta == null) return;
 
-        if (meta.getConfidence() != 1.0) {
-            gen.writeNumberField(JsonName.CONFIDENCE, meta.getConfidence());
+        if (meta.getAiScore() >= 0.0) {
+            gen.writeNumberField(JsonName.AI_SCORE, meta.getAiScore());
         }
         if (meta.getSourceLabel() >= 0) {
             gen.writeNumberField(JsonName.SOURCE_LABEL, meta.getSourceLabel());
@@ -121,6 +122,10 @@ public class SerializerUtil {
 
     public static void writeEssentialInfo(JsonGenerator jsonGenerator, IObject object, String type) throws IOException {
         jsonGenerator.writeStringField(JsonName.TYPE, type);
+        String pdfuaTag = pdfuaTagFor(type, object);
+        if (pdfuaTag != null) {
+            jsonGenerator.writeStringField(JsonName.PDFUA_TAG, pdfuaTag);
+        }
         Long id = object.getRecognizedStructureId();
         if (id != null && id != 0L) {
             jsonGenerator.writeNumberField(JsonName.ID, id);
@@ -135,6 +140,51 @@ public class SerializerUtil {
         jsonGenerator.writePOJO(object.getRightX());
         jsonGenerator.writePOJO(object.getTopY());
         jsonGenerator.writeEndArray();
+    }
+
+    /**
+     * Maps an extraction JSON `type` (plus heading level when relevant) to the
+     * PDF/UA structure tag that AutoTaggingProcessor will emit for the node.
+     * Returns null when the node has no canonical PDF/UA tag (e.g. text chunks
+     * that live below the structure-element granularity).
+     */
+    static String pdfuaTagFor(String type, IObject object) {
+        if (type == null) {
+            return null;
+        }
+        switch (type) {
+            case JsonName.HEADING_TYPE:
+                if (object instanceof SemanticHeading) {
+                    int level = ((SemanticHeading) object).getHeadingLevel();
+                    if (level >= 1 && level <= 6) {
+                        return "H" + level;
+                    }
+                }
+                // Fallback for unleveled headings. PDF/UA-2 deprecates the
+                // plain "H" tag in favor of H1..H6; emit it only because we
+                // cannot infer a level. Downstream remediation may upgrade
+                // this when more context is available.
+                return "H";
+            case JsonName.PARAGRAPH_TYPE:
+                return "P";
+            case JsonName.IMAGE_CHUNK_TYPE:
+                return "Figure";
+            case JsonName.FORMULA_TYPE:
+                return "Formula";
+            case JsonName.LIST_TYPE:
+                return "L";
+            case JsonName.LIST_ITEM_TYPE:
+                return "LI";
+            case JsonName.TABLE_TYPE:
+                return "Table";
+            case JsonName.TABLE_CELL_TYPE:
+                return "TD";
+            default:
+                // header/footer/footnote/caption/line/text-chunk/text-block
+                // either become Artifact or are not promoted to their own
+                // PDF/UA structure element. Leave the tag unset for now.
+                return null;
+        }
     }
 
     public static void writeTextInfo(JsonGenerator jsonGenerator, SemanticTextNode textNode) throws IOException {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -679,7 +679,15 @@ public class HybridDocumentProcessor {
                     if (page0 < transformedContents.size()) {
                         List<IObject> pageContents = transformedContents.get(page0);
                         TextProcessor.replaceUndefinedCharacters(pageContents, config.getReplaceInvalidChars());
+                        // Capture transformer-assigned IDs before setIDs rewrites them
+                        // so ElementMetadata keyed by the original ID can be migrated
+                        // to the renumbered structure ID.
+                        List<Long> oldIds = new ArrayList<>(pageContents.size());
+                        for (IObject obj : pageContents) {
+                            oldIds.add(obj.getRecognizedStructureId());
+                        }
                         DocumentProcessor.setIDs(pageContents);
+                        rekeyMetadata(transformer, oldIds, pageContents);
                         results.put(page0, pageContents);
                     } else {
                         results.put(page0, new ArrayList<>());
@@ -714,6 +722,26 @@ public class HybridDocumentProcessor {
      */
     private static HybridClient getClient(Config config) {
         return HybridClientFactory.getOrCreate(config.getHybrid(), config.getHybridConfig());
+    }
+
+    /**
+     * Migrate ElementMetadata entries from transformer-assigned IDs onto the
+     * structure IDs that {@code setIDs} just renumbered each IObject with.
+     * Without this, the metadata map keeps pointing at the throwaway IDs the
+     * transformer minted and downstream metadata lookups all miss.
+     */
+    private static void rekeyMetadata(HybridSchemaTransformer transformer,
+                                       List<Long> oldIds, List<IObject> pageContents) {
+        Map<Long, Long> oldToNew = new java.util.HashMap<>(pageContents.size());
+        for (int i = 0; i < pageContents.size(); i++) {
+            Long oldId = oldIds.get(i);
+            Long newId = pageContents.get(i).getRecognizedStructureId();
+            if (oldId == null || newId == null || oldId.equals(newId)) continue;
+            oldToNew.put(oldId, newId);
+        }
+        if (!oldToNew.isEmpty()) {
+            transformer.rekeyMetadata(oldToNew);
+        }
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/ElementMetadataTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/ElementMetadataTest.java
@@ -40,7 +40,7 @@ public class ElementMetadataTest {
     @Test
     void onlyNonDefaultFieldsAppearInJson() throws Exception {
         ElementMetadata meta = new ElementMetadata()
-                .setConfidence(0.85)
+                .setAiScore(0.85)
                 .setSourceLabel(3)
                 .setHeadingInferenceMethod("bbox-height")
                 .setBboxHeightPx(24.5);
@@ -48,7 +48,7 @@ public class ElementMetadataTest {
         String json = mapper.writeValueAsString(meta);
         JsonNode node = mapper.readTree(json);
 
-        assertEquals(0.85, node.get("confidence").asDouble(), 0.001);
+        assertEquals(0.85, node.get("aiScore").asDouble(), 0.001);
         assertEquals(3, node.get("sourceLabel").asInt());
         assertEquals("bbox-height", node.get("headingInferenceMethod").asText());
         assertEquals(24.5, node.get("bboxHeightPx").asDouble(), 0.001);
@@ -121,14 +121,14 @@ public class ElementMetadataTest {
     @Test
     void fluentSettersReturnSameInstance() {
         ElementMetadata meta = new ElementMetadata();
-        ElementMetadata returned = meta.setConfidence(0.5).setSourceLabel(2);
+        ElementMetadata returned = meta.setAiScore(0.5).setSourceLabel(2);
         assertTrue(meta == returned);
     }
 
     @Test
     void roundTripDeserialization() throws Exception {
         ElementMetadata original = new ElementMetadata()
-                .setConfidence(0.92)
+                .setAiScore(0.92)
                 .setSourceLabel(7)
                 .setWordMatchMethod("bbox-intersection")
                 .setMatchedWordCount(5);
@@ -136,7 +136,7 @@ public class ElementMetadataTest {
         String json = mapper.writeValueAsString(original);
         ElementMetadata deserialized = mapper.readValue(json, ElementMetadata.class);
 
-        assertEquals(original.getConfidence(), deserialized.getConfidence(), 0.001);
+        assertEquals(original.getAiScore(), deserialized.getAiScore(), 0.001);
         assertEquals(original.getSourceLabel(), deserialized.getSourceLabel());
         assertEquals(original.getWordMatchMethod(), deserialized.getWordMatchMethod());
         assertEquals(original.getMatchedWordCount(), deserialized.getMatchedWordCount());

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformerTest.java
@@ -489,6 +489,8 @@ public class HancomAISchemaTransformerTest {
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("label", label);
         obj.put("ocrtext", text);
+        // Hancom AI DLA reports each object's overall detection confidence
+        // in the "confidence" field (numeric, 0..1).
         obj.put("confidence", 0.95);
 
         ArrayNode bbox = obj.putArray("bbox");
@@ -501,7 +503,7 @@ public class HancomAISchemaTransformerTest {
     }
 
     /**
-     * Creates an object node with a specific confidence value.
+     * Creates an object node with a specific AI score value.
      */
     private ObjectNode createObjectWithConfidence(int label, String text, double left, double top,
                                                    double right, double bottom, double confidence) {
@@ -1074,11 +1076,11 @@ public class HancomAISchemaTransformerTest {
         assertThat(result.get(0).get(0)).isInstanceOf(SemanticPicture.class);
     }
 
-    // --- Task 8: confidence → correctSemanticScore ---
+    // --- Task 8: AI score → correctSemanticScore ---
 
     @Test
-    void confidence_mappedToCorrectSemanticScore() {
-        // object with confidence 0.85 → correctSemanticScore = 0.85
+    void aiScore_mappedToCorrectSemanticScore() {
+        // object with score 0.85 → correctSemanticScore = 0.85
         ObjectNode obj = createObjectWithConfidence(2, "Test paragraph", 100, 100, 500, 130, 0.85);
         ObjectNode json = createHancomAIJson(obj);
 
@@ -1090,11 +1092,12 @@ public class HancomAISchemaTransformerTest {
     }
 
     @Test
-    void confidence_defaultsTo1WhenMissing() {
-        // object without confidence field → correctSemanticScore = 1.0
+    void aiScore_defaultsTo1WhenMissing() {
+        // object without score field → correctSemanticScore stays at the
+        // factory default (1.0); ElementMetadata.aiScore stays at sentinel.
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("label", 2);
-        obj.put("ocrtext", "No confidence field");
+        obj.put("ocrtext", "No score field");
         ArrayNode bbox = obj.putArray("bbox");
         bbox.add(100); bbox.add(100); bbox.add(500); bbox.add(130);
 
@@ -1108,8 +1111,8 @@ public class HancomAISchemaTransformerTest {
     }
 
     @Test
-    void confidence_appliedToHeading() {
-        // heading with confidence 0.72 → correctSemanticScore = 0.72
+    void aiScore_appliedToHeading() {
+        // heading with score 0.72 → correctSemanticScore = 0.72
         ObjectNode obj = createObjectWithConfidence(0, "Title", 100, 50, 500, 100, 0.72);
         ObjectNode json = createHancomAIJson(obj);
 
@@ -1384,7 +1387,7 @@ public class HancomAISchemaTransformerTest {
         assertThat(metadata).containsKey(iobj.getRecognizedStructureId());
 
         ElementMetadata meta = metadata.get(iobj.getRecognizedStructureId());
-        assertThat(meta.getConfidence()).isEqualTo(0.88);
+        assertThat(meta.getAiScore()).isEqualTo(0.88);
         assertThat(meta.getSourceLabel()).isEqualTo(2);
         assertThat(meta.getHeadingInferenceMethod()).isNull();
     }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/json/serializers/ElementMetadataSerializerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/json/serializers/ElementMetadataSerializerTest.java
@@ -61,14 +61,14 @@ class ElementMetadataSerializerTest {
         long id = 42L;
         Map<Long, ElementMetadata> metadata = new HashMap<>();
         metadata.put(id, new ElementMetadata()
-                .setConfidence(0.85)
+                .setAiScore(0.85)
                 .setSourceLabel(3));
         SerializerUtil.setElementMetadata(metadata);
 
         SemanticHeading heading = createHeading(id);
         String json = objectMapper.writeValueAsString(heading);
 
-        assertTrue(json.contains("\"confidence\":0.85"), "Should contain confidence field");
+        assertTrue(json.contains("\"ai_score\":0.85"), "Should contain ai_score field");
         assertTrue(json.contains("\"source label\":3"), "Should contain source label field");
     }
 
@@ -78,23 +78,23 @@ class ElementMetadataSerializerTest {
         SemanticHeading heading = createHeading(42L);
         String json = objectMapper.writeValueAsString(heading);
 
-        assertFalse(json.contains("\"confidence\""), "Should not contain confidence without metadata");
+        assertFalse(json.contains("\"ai_score\""), "Should not contain ai_score without metadata");
         assertFalse(json.contains("\"source label\""), "Should not contain source label without metadata");
     }
 
     @Test
-    void testConfidenceOmittedWhenDefault() throws JsonProcessingException {
+    void testAiScoreOmittedWhenUnset() throws JsonProcessingException {
         long id = 10L;
         Map<Long, ElementMetadata> metadata = new HashMap<>();
+        // No setAiScore() — leaves the sentinel default (-1.0)
         metadata.put(id, new ElementMetadata()
-                .setConfidence(1.0)
                 .setSourceLabel(5));
         SerializerUtil.setElementMetadata(metadata);
 
         SemanticHeading heading = createHeading(id);
         String json = objectMapper.writeValueAsString(heading);
 
-        assertFalse(json.contains("\"confidence\""), "confidence=1.0 should be omitted");
+        assertFalse(json.contains("\"ai_score\""), "ai_score should be omitted when not provided");
         assertTrue(json.contains("\"source label\":5"), "source label should still appear");
     }
 
@@ -103,14 +103,14 @@ class ElementMetadataSerializerTest {
         long id = 11L;
         Map<Long, ElementMetadata> metadata = new HashMap<>();
         metadata.put(id, new ElementMetadata()
-                .setConfidence(0.5)
+                .setAiScore(0.5)
                 .setSourceLabel(-1));
         SerializerUtil.setElementMetadata(metadata);
 
         SemanticHeading heading = createHeading(id);
         String json = objectMapper.writeValueAsString(heading);
 
-        assertTrue(json.contains("\"confidence\":0.5"));
+        assertTrue(json.contains("\"ai_score\":0.5"));
         assertFalse(json.contains("\"source label\""), "sourceLabel=-1 should be omitted");
     }
 
@@ -211,26 +211,26 @@ class ElementMetadataSerializerTest {
     @Test
     void testNoMetadataForUnknownId() throws JsonProcessingException {
         Map<Long, ElementMetadata> metadata = new HashMap<>();
-        metadata.put(99L, new ElementMetadata().setConfidence(0.5));
+        metadata.put(99L, new ElementMetadata().setAiScore(0.5));
         SerializerUtil.setElementMetadata(metadata);
 
         SemanticHeading heading = createHeading(1L); // different ID
         String json = objectMapper.writeValueAsString(heading);
 
-        assertFalse(json.contains("\"confidence\""), "Should not write metadata for unmatched ID");
+        assertFalse(json.contains("\"ai_score\""), "Should not write metadata for unmatched ID");
     }
 
     @Test
     void testClearElementMetadataRemovesState() throws JsonProcessingException {
         long id = 42L;
         Map<Long, ElementMetadata> metadata = new HashMap<>();
-        metadata.put(id, new ElementMetadata().setConfidence(0.5));
+        metadata.put(id, new ElementMetadata().setAiScore(0.5));
         SerializerUtil.setElementMetadata(metadata);
         SerializerUtil.clearElementMetadata();
 
         SemanticHeading heading = createHeading(id);
         String json = objectMapper.writeValueAsString(heading);
 
-        assertFalse(json.contains("\"confidence\""), "After clear, metadata should not be written");
+        assertFalse(json.contains("\"ai_score\""), "After clear, metadata should not be written");
     }
 }


### PR DESCRIPTION
## Objective
Reviewers reading the extraction JSON cannot tell what the AI model's confidence in each detected element was, and they cannot tell which PDF/UA structure tag a node will end up as without re-running the auto-tagger. On top of that, paragraphs and tables silently lost their hybrid metadata because the per-node id was renumbered after the transformer ran — so even the existing `confidence` field was unusable in practice.

## Approach
- Rename `confidence` → `ai_score`. Default to `-1.0` (sentinel) so the field is suppressed for native-pipeline nodes instead of the old `1.0` default that collided with real scores of 1.0.
- Read the raw key Hancom AI actually emits — `confidence` on the DLA object — and carry it through for tables too (previously the table-only metadata path never set the score).
- Emit `pdfua_tag` alongside `type` for every node: `H1..H6`, `P`, `Figure`, `Formula`, `L`, `LI`, `Table`, `TD`. The unleveled `H` is a documented fallback only.
- Plug the rekey hole: when `HybridDocumentProcessor` renumbers IObject ids via `setIDs`, ask the transformer (new `rekeyMetadata` default method on `HybridSchemaTransformer`) to move its metadata map onto the new ids. Without this every downstream metadata lookup missed.
- Plug the serializer hole: `SemanticTextNodeSerializer` (the fallback used for paragraphs, since `ParagraphSerializer` is not registered) never called `writeMetadataIfPresent`. Added the call so paragraphs actually emit their metadata.

## Evidence
Built the core jar with `mvn -pl opendataloader-pdf-core install -DskipTests`, then ran a hybrid hancom-ai conversion of the sample PDF in the pdfua mock-server suite (`scripts/mock_server/pdfs/01030000000078.pdf`). All eight nodes in the corrected extraction JSON now carry `ai_score` and `pdfua_tag`:

| Scenario | Expected | Actual |
|----------|----------|--------|
| heading node | `ai_score`, `pdfua_tag`, `source label` all present | `ai_score=0.993`, `pdfua_tag=H2`, `source label=4` |
| image node | `ai_score`, `pdfua_tag=Figure` | `ai_score=0.999`, `pdfua_tag=Figure` |
| paragraphs (5 nodes) | every paragraph emits `ai_score` and `pdfua_tag=P` | `ai_score` 0.638…0.9998, `pdfua_tag=P` for all 5 |
| table node | `ai_score`, `pdfua_tag=Table` | `ai_score=0.997`, `pdfua_tag=Table` |
| native pipeline (no hybrid) | `ai_score` omitted | unit test `testAiScoreOmittedWhenUnset` covers this |

## Test plan
- [x] `mvn -pl opendataloader-pdf-core test -Dtest='ElementMetadataSerializerTest,ElementMetadataTest,HancomAISchemaTransformerTest'`
- [x] hybrid hancom-ai conversion via mock server emits `ai_score` and `pdfua_tag` on all node types
- [ ] Downstream Python bindings / MCP readers will need to update for the `confidence` → `ai_score` rename; flagged separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * JSON exports now include AI confidence scores for individual document elements and PDF/UA structure tags, enabling better accessibility compliance tracking and comprehensive semantic data quality analysis.

* **Refactor**
  * Enhanced document processing pipeline with improved structure ID tracking and metadata remapping capabilities, ensuring consistent and reliable data handling across all transformation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->