### PR TITLE
feat(hybrid): expose DLA raw object_id on ElementMetadata for downstream consumers

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/ElementMetadata.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/ElementMetadata.java
@@ -31,6 +31,17 @@ public class ElementMetadata {
     /** Original Hancom AI label (0~17), -1 if not applicable. */
     private int sourceLabel = -1;
 
+    /**
+     * The hybrid backend's per-page detection id for this element — the
+     * same value that surfaces as {@code object_id} in the raw DLA JSON
+     * and as {@code scored_items[].id} in the evidence report. Carrying
+     * it through to the corrected extraction tree lets downstream
+     * tooling line up a reading-ordered node with the original detection
+     * row without re-matching by bbox. Negative sentinel ({@code -1})
+     * means "not provided" — e.g. native pipeline output.
+     */
+    private int dlaObjectId = -1;
+
     /** Heading inference method: "bbox-height" or "fixed". */
     private String headingInferenceMethod;
 
@@ -73,6 +84,15 @@ public class ElementMetadata {
 
     public ElementMetadata setSourceLabel(int sourceLabel) {
         this.sourceLabel = sourceLabel;
+        return this;
+    }
+
+    public int getDlaObjectId() {
+        return dlaObjectId;
+    }
+
+    public ElementMetadata setDlaObjectId(int dlaObjectId) {
+        this.dlaObjectId = dlaObjectId;
         return this;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -482,9 +482,15 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
         // Produce ElementMetadata for this IObject
         if (iobj != null && iobj.getRecognizedStructureId() != null) {
+            // Carry the raw DLA detection id so downstream tooling (evidence
+            // report) can line a reading-ordered node back to its DLA row
+            // without re-matching by bbox. Same field the FIGURE branch
+            // already reads — pulled out here so every label gets it.
+            int rawObjectId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
             ElementMetadata meta = new ElementMetadata()
                 .setAiScore(aiScore)
-                .setSourceLabel(label);
+                .setSourceLabel(label)
+                .setDlaObjectId(rawObjectId);
 
             if (label == LABEL_PARA_TITLE || label == LABEL_REGION_TITLE) {
                 double pixelHeight = bboxNode.get(3).asDouble() - bboxNode.get(1).asDouble();
@@ -730,9 +736,12 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         // Produce ElementMetadata for the table
         double tableAiScore = tableEntry.has("confidence")
             ? tableEntry.get("confidence").asDouble(-1.0) : -1.0;
+        int tableRawObjectId = tableEntry.has("object_id")
+            ? tableEntry.get("object_id").asInt() : -1;
         ElementMetadata tableMeta = new ElementMetadata()
             .setAiScore(tableAiScore)
-            .setSourceLabel(tableEntry.has("label") ? tableEntry.get("label").asInt() : LABEL_TABLE);
+            .setSourceLabel(tableEntry.has("label") ? tableEntry.get("label").asInt() : LABEL_TABLE)
+            .setDlaObjectId(tableRawObjectId);
         if (tsr != null) {
             ElementMetadata.TsrMetadata tsrMeta = new ElementMetadata.TsrMetadata();
             tsrMeta.setNumCells(tsr.has("num_cells") ? tsr.get("num_cells").asInt() : 0);


### PR DESCRIPTION
## Objective
Downstream tools (the pdfua evidence report) want to line up a reading-ordered element with the original DLA detection row it came from — the same `object_id` users see in the AI Evidence per-object table. Without a shared identifier the only option was bbox re-matching, which is fragile across page rotation and the small bbox drift TSR-table cells pick up.

## Approach
Carry the hybrid backend's per-page `object_id` through to the sidecar `ElementMetadata` map that core already keeps keyed by `RecognizedStructureId`. The transformer was already reading `object_id` in one branch (the FIGURE caption lookup), so this is a one-line extension — read it once at the top of `transformObject` and stamp every metadata entry. The table-entry path stamps it from the table entry's own `object_id`. `rekeyMetadata` already migrates entries to their final global ids, so consumers see the right key without doing any rekeying themselves.

This is a **sidecar-only** change. The corrected extraction JSON is not touched — `SerializerUtil.writeMetadataIfPresent` writes a curated list of fields and `dlaObjectId` is not in it. Consumers reach the new field via `HybridDocumentProcessor.getLastElementMetadata()`, the same static hook pdfua already uses for hybrid timings / raw JSON.

## Evidence
Built with `mvn -DskipTests install`, then rebuilt pdfua (`mvn clean package -Pdev`) and ran the hybrid mock pipeline against `opendataloader-pdfua/scripts/mock_server/pdfs/01030000000078.pdf`:

| Scenario | Expected | Actual |
|----------|----------|--------|
| extraction.json kids unchanged | no new `dla_object_id` field | `grep` on first kid: no field present |
| `ElementMetadata.getDlaObjectId()` reachable | new public getter | `javap` on installed jar shows `getDlaObjectId()` / `setDlaObjectId(int)` |
| pdfua reads `structureId→dlaObjectId` map | values match DLA `scored_items.id` | extraction kid id=73 (H2, bbox `[412,296,1647,348]`) maps to DLA scored_items.id=5 (RegionTitle, same bbox) |
| hybrid pipeline output unaffected | 1/1 verapdf pass on remediated UA1 PDF | 1/1 success, 1/1 verapdf pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced detection identification tracking to improve element traceability and alignment across document processing and extraction workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->