### PR TITLE
fix(auto-tagging): assign unique /ID to Note / FENote struct elements (PDF/UA-1 §7.9.1)

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -63,6 +63,11 @@ public class AutoTaggingProcessor {
     private static final int MAX_TOKENS_PER_STREAM = 100_000;
     // imageChunkCounter is per-call; tracked via the figureObject index across a document
     private static int imageChunkFigureCounter = 0;
+    // Counter for unique /ID strings on Note / FENote struct elements.
+    // PDF/UA-1 §7.9.1 and PDF 2.0 14.8.4.6 require every Note to carry
+    // an /ID entry that is unique within the document — veraPDF reports
+    // a hard failure when missing. Reset per document in tagDocument().
+    private static int footnoteCounter = 0;
 
     /**
      * Tag a PDF document in-memory without saving to disk.
@@ -81,6 +86,7 @@ public class AutoTaggingProcessor {
         annotationBBoxesMap.clear();
         currentStructParent = 0;
         imageChunkFigureCounter = 0;
+        footnoteCounter = 0;
         isPDF2_0 = pdfVersion != null ? pdfVersion == 2.0F : document.getVersion() == 2.0F;
         COSDocument cosDocument = document.getDocument();
         PDCatalog catalog = document.getCatalog();
@@ -736,6 +742,20 @@ public class AutoTaggingProcessor {
         COSObject noteObject = addStructElement(parent, cosDocument,
                 usePdf2Footnote ? TaggedPDFConstants.FENOTE : TaggedPDFConstants.NOTE,
                 footnote.getPageNumber());
+        // PDF/UA-1 §7.9.1 and PDF 2.0 14.8.4.6 require Note / FENote struct
+        // elements to carry an /ID entry that is unique within the document.
+        // The value is opaque to veraPDF — any non-empty unique string works.
+        // We use a per-document counter prefixed with "note" so the IDs are
+        // human-readable in PDF dumps. footnoteCounter is reset at the top
+        // of tagDocument(), and tagDocument is synchronized, so the counter
+        // is safe under repeated calls. US_ASCII is explicit so the byte
+        // representation does not depend on the JVM default charset — the
+        // string is pure ASCII so the choice is functionally a no-op, but
+        // it documents intent and silences SpotBugs DM_DEFAULT_ENCODING.
+        footnoteCounter++;
+        String noteId = "note-" + footnoteCounter;
+        noteObject.setKey(ASAtom.ID,
+                COSString.construct(noteId.getBytes(java.nio.charset.StandardCharsets.US_ASCII)));
         if (usePdf2Footnote) {
             noteObject.setKey(ASAtom.NS, pdf2_0Namespace);
             noteObject.setKey(ASAtom.NOTE_TYPE, COSName.construct(ASAtom.getASAtom("Footnote")));


### PR DESCRIPTION
## Objective

When the auto-tagger emits `Note` / `FENote` struct elements (currently only produced via the hancom-ai hybrid backend, which classifies footnotes through `HancomAISchemaTransformer`), the resulting tagged PDF fails veraPDF under PDF/UA-1 on clause 7.9.1: *"Note tag shall have ID entry."*

On a 200-PDF regression corpus through the hancom-ai mock backend, 8 documents tripped this rule. The same 8 documents also fall under the related PDF/UA-2 clause 8.2.5.14.1 (Note deprecated, use Aside) — a separate problem tracked independently.

## Approach

PDF/UA-1 §7.9.1 and PDF 2.0 14.8.4.6 require `Note` / `FENote` struct elements to carry an `/ID` entry unique within the document. The value is opaque to validators — any non-empty document-unique string satisfies the rule.

- New `static int footnoteCounter`, reset alongside the existing `imageChunkFigureCounter` at the top of `tagDocument()` (already `synchronized`).
- `createFootnoteStructElem` increments the counter, formats `note-<N>` with explicit `US_ASCII` charset (avoids JVM default-charset dependency, silences SpotBugs `DM_DEFAULT_ENCODING`), and writes it onto the new struct element as `/ID` before the existing PDF 2.0 namespace branch. The same `/ID` is required on `FENote` under PDF 2.0, so applying it unconditionally is correct.

**ID namespace check:** `createListStructElem` already writes `/ID` values as bare integer strings (`"42"`); `"note-N"` is lexically disjoint so no collision is possible. No other site writes `/ID` on struct elems.

## Evidence

**Single-document sanity check after the fix:**

| Input | Output Note `/ID` | veraPDF ua1 |
|---|---|---|
| `scripts/mock_server/pdfs/01030000000014.pdf` (one of the 8 previously failing docs) | `"note-1"` | 1/1 pass |

**200-document hancom-ai batch (mock backend) before / after this fix:**

| Scenario | Expected | Before | After |
|---|---|---|---|
| ua1 pass / 200 | +8 | 192 | **200** |
| ua1 §7.9.1 fail (files) | 0 | 8 | **0** |
| ua2 §8.2.5.14.1 fail (separate rule) | unchanged | 8 | 8 |
| ua2 §8.8.x destination fail | unchanged | 39 | 39 |
| ua2 pass / 200 (separate work) | unchanged | 154 | 154 |

ua1 now passes 200/200 across the entire mock corpus. The remaining ua2 failures (§8.2.5.14.1 Note→Aside mapping, §8.8.x structure-destination requirement) are out of scope here and tracked separately — they are not regressions introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PDF footnote handling by assigning unique identifiers to each footnote and note element, ensuring consistency across documents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->