### PR TITLE
fix(hybrid/docling): collapse spanning cells so docling tables pass PDF/UA §7.2

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingSchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/DoclingSchemaTransformer.java
@@ -480,8 +480,15 @@ public class DoclingSchemaTransformer implements HybridSchemaTransformer {
             double rowTop = tableBbox.getTopY() - (row * rowHeight);
             double rowBottom = rowTop - rowHeight;
             borderRow.setBoundingBox(new BoundingBox(pageIndex, tableBbox.getLeftX(), rowBottom, tableBbox.getRightX(), rowTop));
+            table.getRows()[row] = borderRow;
+        }
 
+        for (int row = 0; row < numRows; row++) {
             for (int col = 0; col < numCols; col++) {
+                // Slot already covered by a spanning cell from an earlier
+                // iteration — do not overwrite with a fresh placeholder.
+                if (table.getRows()[row].getCells()[col] != null) continue;
+
                 String key = row + "," + col;
                 JsonNode cellNode = cellMap.get(key);
 
@@ -498,23 +505,40 @@ public class DoclingSchemaTransformer implements HybridSchemaTransformer {
                     }
                 }
 
-                TableBorderCell cell = new TableBorderCell(row, col, rowSpan, colSpan, 0L);
+                // Clamp spans to the declared table bounds. Docling occasionally
+                // emits col_span/row_span values that, combined with the start
+                // index, run past the table; let the spanning area be exactly
+                // what stays inside the grid. Math.max(1, ...) defends against
+                // malformed zero or negative span values that would otherwise
+                // leave the slot unfilled.
+                int effectiveColSpan = Math.max(1, Math.min(colSpan, numCols - col));
+                int effectiveRowSpan = Math.max(1, Math.min(rowSpan, numRows - row));
+
+                TableBorderCell cell = new TableBorderCell(row, col, effectiveRowSpan, effectiveColSpan, 0L);
                 double cellLeft = tableBbox.getLeftX() + (col * colWidth);
-                double cellRight = cellLeft + (colSpan * colWidth);
+                double cellRight = cellLeft + (effectiveColSpan * colWidth);
                 double cellTop = tableBbox.getTopY() - (row * rowHeight);
-                double cellBottom = cellTop - (rowSpan * rowHeight);
+                double cellBottom = cellTop - (effectiveRowSpan * rowHeight);
                 cell.setBoundingBox(new BoundingBox(pageIndex, cellLeft, cellBottom, cellRight, cellTop));
 
-                // Add cell content if present
                 if (!cellText.isEmpty()) {
                     SemanticParagraph content = createParagraph(cellText, cell.getBoundingBox());
                     cell.addContentObject(content);
                 }
 
-                borderRow.getCells()[col] = cell;
+                // Mark every slot covered by this cell's span with the same
+                // instance so AutoTaggingProcessor.addTableRow skips the
+                // duplicates. Without this Docling produces redundant
+                // 1x1 placeholders next to spanning cells, breaking
+                // PDF/UA-1 §7.2 (test 43) / PDF/UA-2 §8.2.5.26 "Table rows
+                // shall have the same number of columns (taking into account
+                // column spans)".
+                for (int r = row; r < row + effectiveRowSpan; r++) {
+                    for (int c = col; c < col + effectiveColSpan; c++) {
+                        table.getRows()[r].getCells()[c] = cell;
+                    }
+                }
             }
-
-            table.getRows()[row] = borderRow;
         }
 
         result.get(pageIndex).add(table);


### PR DESCRIPTION
## Objective
When the docling-fast backend produces a table with merged cells (colspan>1 or rowspan>1), every header row containing a merged cell fails veraPDF rule **PDF/UA-1 §7.2 (test 43)** / **PDF/UA-2 §8.2.5.26** — *\"Table rows shall have the same number of columns (taking into account column spans)\"*. In a 200-PDF benchmark, 9 documents fail for this reason. The other backends (heuristic, hancom-ai) are unaffected because they emit cells differently.

## Approach
Docling reports the merged cell at its top-left start position **and** emits redundant empty 1×1 placeholder cells at every slot the merged cell already covers. The previous loop in \`DoclingSchemaTransformer.addTable\` wrote each cell into the grid independently, so those placeholders survived and inflated the row's effective column count past the declared \`numCols\`.

Mirror what \`HancomAISchemaTransformer\` already does for the same backend pathology: in a raster-order pass, fill every slot inside a spanning cell's area with the *same* cell instance so \`AutoTaggingProcessor.addTableRow\`'s identity check (start-row/col vs current slot) skips them. Clamp spans to the declared table bounds defensively with \`Math.max(1, Math.min(span, dim - idx))\`.

## Evidence
200-PDF batch with \`--hybrid docling-fast --conformance ua1,ua2\`:

| Scenario | Expected | Before | After |
|----------|----------|--------|-------|
| ua1 veraPDF pass | 200 / 200 | 191 / 200 | **200 / 200** |
| ua2 veraPDF pass | 200 / 200 | 191 / 200 | **200 / 200** |
| §7.2 test 43 failed checks across batch | 0 | 9 | **0** |
| Wall clock (200 docs) | — | ~3m27s | ~3m13s |

Other backends unchanged:
| Backend | ua1 | ua2 |
|---------|-----|-----|
| heuristic | 200/200 | 200/200 |
| hancom-ai (mock) | 200/200 | 200/200 |
| docling-fast | **200/200** | **200/200** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table rendering for cells spanning multiple rows and columns to correctly represent cell positions across the full grid.
  * Improved handling of malformed table span values by clamping spans to declared table boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendataloader-project/opendataloader-pdf/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->