### PR TITLE
fix(hybrid): route crops/page images to the current document, not the first

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -190,6 +190,12 @@ public class HancomAIClient implements HybridClient {
         this.sourcePdfShaShort = sha256ShortHex(pdfBytes);
         LOGGER.log(Level.INFO, "Hancom AI: processing PDF ({0} bytes)", pdfBytes.length);
 
+        // Crop / page-image destination travels with the request, not the
+        // cached client's config, so the per-document target is correct even
+        // when the client is reused across documents (and is concurrency-safe
+        // since nothing shared is mutated).
+        CropOutput cropOutput = request.getCropOutput();
+
         try (PageImageCache pageImageCache = createPageImageCache()) {
             ObjectNode merged = objectMapper.createObjectNode();
             ObjectNode timingsNode = objectMapper.createObjectNode();
@@ -209,7 +215,7 @@ public class HancomAIClient implements HybridClient {
 
             // Step 2: Table Structure — crop each Table region from page image, send to TSR individually
             long tsrStartMs = System.currentTimeMillis();
-            ArrayNode tsrResults = recognizeTableStructures(pdfBytes, dlaOcrResult, pageImageCache);
+            ArrayNode tsrResults = recognizeTableStructures(pdfBytes, dlaOcrResult, pageImageCache, cropOutput);
             long tsrMs = System.currentTimeMillis() - tsrStartMs;
             merged.set("TABLE_STRUCTURE_RECOGNITION", tsrResults);
 
@@ -223,7 +229,7 @@ public class HancomAIClient implements HybridClient {
 
             // Step 3: Figure captioning — pdf2img → crop figures → caption each
             long captionStartMs = System.currentTimeMillis();
-            ArrayNode figureCaptions = captionFigures(pdfBytes, dlaOcrResult, pageImageCache);
+            ArrayNode figureCaptions = captionFigures(pdfBytes, dlaOcrResult, pageImageCache, cropOutput);
             long captionMs = System.currentTimeMillis() - captionStartMs;
             merged.set("FIGURE_CAPTIONS", figureCaptions);
 
@@ -231,7 +237,7 @@ public class HancomAIClient implements HybridClient {
             // DLA bboxes are expressed against. TSR/FIGURE fetches already save
             // their pages; this pass fills only pages that were not otherwise
             // rendered.
-            saveDlaPageImages(pdfBytes, dlaOcrResult, pageImageCache);
+            saveDlaPageImages(pdfBytes, dlaOcrResult, pageImageCache, cropOutput);
 
             ObjectNode captionTiming = objectMapper.createObjectNode();
             captionTiming.put("total_ms", captionMs);
@@ -282,7 +288,7 @@ public class HancomAIClient implements HybridClient {
      * @return ArrayNode of {page_number, object_id, bbox, caption}
      */
     private ArrayNode captionFigures(byte[] pdfBytes, JsonNode dlaResult,
-                                     PageImageCache pageImageCache) {
+                                     PageImageCache pageImageCache, CropOutput cropOutput) {
         ArrayNode captions = objectMapper.createArrayNode();
 
         // Extract pages from DLA result
@@ -323,7 +329,7 @@ public class HancomAIClient implements HybridClient {
             BufferedImage pageImage;
             try {
                 pageImage = pageImageCache.getOrFetch(pageNum,
-                    idx -> fetchPageImage(pdfBytes, idx));
+                    idx -> fetchPageImage(pdfBytes, idx, cropOutput));
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to get page {0} image: {1}",
                     new Object[]{pageNum, e.getMessage()});
@@ -353,9 +359,9 @@ public class HancomAIClient implements HybridClient {
                     byte[] croppedPng = imageToPng(cropped);
 
                     // Save crop if configured
-                    if (config.isSaveCrops() && config.getCropOutputDir() != null) {
+                    if (cropOutput.active()) {
                         int objId = fig.has("object_id") ? fig.get("object_id").asInt() : -1;
-                        saveCropFile(config.getCropOutputDir(), pageNum, objId, "figure", croppedPng);
+                        saveCropFile(cropOutput.directory(), pageNum, objId, "figure", croppedPng);
                     }
 
                     int objIdForCaption = fig.has("object_id") ? fig.get("object_id").asInt() : -1;
@@ -400,11 +406,12 @@ public class HancomAIClient implements HybridClient {
      * @param pdfBytes the original PDF bytes (needed for pdf2img)
      * @param dlaResult the DLA+OCR result containing detected objects
      * @param pageImageCache shared cache for page images
+     * @param cropOutput per-document destination for saved table crops
      * @return ArrayNode of per-table results:
      *         [{page_number, object_id, label, dla_bbox, tsr: {cells, num_cells, html, ...}}]
      */
     private ArrayNode recognizeTableStructures(byte[] pdfBytes, JsonNode dlaResult,
-                                                PageImageCache pageImageCache) {
+                                                PageImageCache pageImageCache, CropOutput cropOutput) {
         ArrayNode results = objectMapper.createArrayNode();
 
         // In list-only mode, LABEL_REGIONLIST is always rendered as a list and
@@ -443,7 +450,7 @@ public class HancomAIClient implements HybridClient {
             BufferedImage pageImage;
             try {
                 pageImage = pageImageCache.getOrFetch(pageNum,
-                    idx -> fetchPageImage(pdfBytes, idx));
+                    idx -> fetchPageImage(pdfBytes, idx, cropOutput));
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to get page {0} image for TSR: {1}",
                     new Object[]{pageNum, e.getMessage()});
@@ -479,9 +486,9 @@ public class HancomAIClient implements HybridClient {
                     byte[] cropPng = imageToPng(crop);
 
                     // Save crop if configured
-                    if (config.isSaveCrops() && config.getCropOutputDir() != null) {
+                    if (cropOutput.active()) {
                         int objectId = obj.has("object_id") ? obj.get("object_id").asInt() : -1;
-                        saveCropFile(config.getCropOutputDir(), pageNum, objectId, "table", cropPng);
+                        saveCropFile(cropOutput.directory(), pageNum, objectId, "table", cropPng);
                     }
 
                     // Call TSR with crop image
@@ -603,15 +610,15 @@ public class HancomAIClient implements HybridClient {
      * capture is enabled.
      */
     private void saveDlaPageImages(byte[] pdfBytes, JsonNode dlaResult,
-                                   PageImageCache pageImageCache) {
-        if (!config.isSaveCrops() || config.getCropOutputDir() == null) return;
+                                   PageImageCache pageImageCache, CropOutput cropOutput) {
+        if (!cropOutput.active()) return;
 
         for (JsonNode page : extractPages(dlaResult)) {
             int pageNum = page.has("page_number") ? page.get("page_number").asInt() : -1;
             if (pageNum < 0) continue;
-            if (isPageImageFileSaved(config.getCropOutputDir(), pageNum)) continue;
+            if (isPageImageFileSaved(cropOutput.directory(), pageNum)) continue;
             try {
-                pageImageCache.getOrFetch(pageNum, idx -> fetchPageImage(pdfBytes, idx));
+                pageImageCache.getOrFetch(pageNum, idx -> fetchPageImage(pdfBytes, idx, cropOutput));
             } catch (IOException e) {
                 LOGGER.log(Level.FINE, "Failed to save DLA page image for page "
                     + pageNum, e);
@@ -660,7 +667,8 @@ public class HancomAIClient implements HybridClient {
     /**
      * Fetches a page image from the pdf2img endpoint.
      */
-    private BufferedImage fetchPageImage(byte[] pdfBytes, int pageIndex) throws IOException {
+    private BufferedImage fetchPageImage(byte[] pdfBytes, int pageIndex, CropOutput cropOutput)
+            throws IOException {
         MultipartBody body = new MultipartBody.Builder()
             .setType(MultipartBody.FORM)
             .addFormDataPart("REQUEST_ID",
@@ -717,8 +725,8 @@ public class HancomAIClient implements HybridClient {
             if (image == null) {
                 throw new IOException("pdf2img PAGE_PNG_DATA is not a readable image");
             }
-            if (config.isSaveCrops() && config.getCropOutputDir() != null) {
-                savePageImageFile(config.getCropOutputDir(), pageIndex, pngBytes);
+            if (cropOutput.active()) {
+                savePageImageFile(cropOutput.directory(), pageIndex, pngBytes);
             }
             return image;
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridClient.java
@@ -51,6 +51,49 @@ public interface HybridClient {
     }
 
     /**
+     * Per-document destination for crop / page-image artifacts.
+     *
+     * <p>Clients are cached and reused across documents
+     * ({@link HybridClientFactory#getOrCreate}), so the {@link HybridConfig}
+     * captured at construction reflects only the <em>first</em> document and
+     * cannot be the source of truth for where the <em>current</em> document's
+     * crops belong. This value travels with each {@link HybridRequest}
+     * instead, so the destination tracks the document being processed without
+     * any shared mutable state — safe even if convert calls run concurrently.
+     *
+     * <p>{@code enabled} controls whether crop / page-image artifacts are
+     * written; {@code directory} is the destination for this document (or
+     * {@code null} when none).
+     */
+    final class CropOutput {
+        /** Sentinel meaning "do not write crops for this request". */
+        public static final CropOutput DISABLED = new CropOutput(false, null);
+
+        private final boolean enabled;
+        private final String directory;
+
+        public CropOutput(boolean enabled, String directory) {
+            this.enabled = enabled;
+            this.directory = directory;
+        }
+
+        /** Whether crop / page-image artifacts should be written. */
+        public boolean enabled() {
+            return enabled;
+        }
+
+        /** Destination directory, or {@code null} when none is set. */
+        public String directory() {
+            return directory;
+        }
+
+        /** True when crops should be written and a destination is set. */
+        public boolean active() {
+            return enabled && directory != null;
+        }
+    }
+
+    /**
      * Output formats that can be requested from the hybrid backend.
      */
     enum OutputFormat {
@@ -83,6 +126,7 @@ public interface HybridClient {
         private final byte[] pdfBytes;
         private final Set<Integer> pageNumbers;
         private final Set<OutputFormat> outputFormats;
+        private final CropOutput cropOutput;
 
         /**
          * Creates a new HybridRequest.
@@ -93,11 +137,37 @@ public interface HybridClient {
          */
         public HybridRequest(byte[] pdfBytes, Set<Integer> pageNumbers,
                              Set<OutputFormat> outputFormats) {
+            this(pdfBytes, pageNumbers, outputFormats, CropOutput.DISABLED);
+        }
+
+        private HybridRequest(byte[] pdfBytes, Set<Integer> pageNumbers,
+                              Set<OutputFormat> outputFormats, CropOutput cropOutput) {
             this.pdfBytes = pdfBytes != null ? Arrays.copyOf(pdfBytes, pdfBytes.length) : null;
             this.pageNumbers = pageNumbers != null ? pageNumbers : Collections.emptySet();
             this.outputFormats = outputFormats != null && !outputFormats.isEmpty()
                 ? EnumSet.copyOf(outputFormats)
                 : EnumSet.allOf(OutputFormat.class);
+            this.cropOutput = cropOutput != null ? cropOutput : CropOutput.DISABLED;
+        }
+
+        /**
+         * Returns a copy of this request with the given crop-output destination.
+         * Lets the caller attach a per-document crop target without mutating the
+         * cached client. The original request is unchanged.
+         *
+         * @param cropOutput where to write crops / page images for this document
+         * @return a new request carrying {@code cropOutput}
+         */
+        public HybridRequest withCropOutput(CropOutput cropOutput) {
+            return new HybridRequest(pdfBytes, pageNumbers, outputFormats, cropOutput);
+        }
+
+        /**
+         * Per-document crop / page-image destination. Never {@code null};
+         * defaults to {@link CropOutput#DISABLED}.
+         */
+        public CropOutput getCropOutput() {
+            return cropOutput;
         }
 
         /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -690,7 +690,8 @@ public class HybridDocumentProcessor {
             }
 
             try {
-                HybridRequest request = HybridRequest.forPages(pdfBytes, chunkPages1Indexed, outputFormats);
+                HybridRequest request = HybridRequest.forPages(pdfBytes, chunkPages1Indexed, outputFormats)
+                    .withCropOutput(cropOutputFor(config));
                 long convertStartNs = System.nanoTime();
                 HybridResponse response;
                 try {
@@ -793,6 +794,22 @@ public class HybridDocumentProcessor {
      */
     private static HybridClient getClient(Config config) {
         return HybridClientFactory.getOrCreate(config.getHybrid(), config.getHybridConfig());
+    }
+
+    /**
+     * Resolve the per-document crop / page-image destination from the config.
+     *
+     * <p>The cached client cannot hold this — it is reused across documents and
+     * its config reflects only the first one. Carrying it on the per-document
+     * {@link HybridClient.HybridRequest} keeps the destination correct (and
+     * needs no shared mutable state) for the document being processed.
+     */
+    private static HybridClient.CropOutput cropOutputFor(Config config) {
+        HybridConfig hc = config.getHybridConfig();
+        if (hc == null || !hc.isSaveCrops() || hc.getCropOutputDir() == null) {
+            return HybridClient.CropOutput.DISABLED;
+        }
+        return new HybridClient.CropOutput(true, hc.getCropOutputDir());
     }
 
     /**


### PR DESCRIPTION
## Objective
When converting a folder of PDFs with the hybrid AI backend (`--hybrid hancom-ai`) and evidence reports enabled, every document's per-table and per-figure crop images — and the DLA page images — get written into the **first** document's output folder. As a result the first document accumulates hundreds of orphaned crops that aren't its own, and every other document's evidence report shows no crop images at all.

## Approach
The backend client is cached and reused across documents (`HybridClientFactory.getOrCreate`, keyed by backend type), and it captured the **first** document's crop output directory at construction. Subsequent documents reused that frozen destination.

Carry the crop / page-image destination on each per-document request (`HybridRequest.CropOutput`) instead of on the cached client — the destination now travels with the work, so it always matches the document being processed. This needs no shared mutable state, so it stays correct even if conversions ever run concurrently. `HancomAIClient.convert` reads it from the request and threads it through the crop/page-image save sites; `DoclingFastServerClient` / `HancomClient` don't emit crops and are unaffected.

## Evidence
Ran the full 200-PDF benchmark batch against the bundled mock Hancom AI server with `--hybrid hancom-ai --conformance ua1,ua2 --evidence-report full`, and inspected the per-document `extraction/ai-raw/` layout. Also opened a document's `evidence-report.html` in a browser to confirm the TSR/FIGURE sections render the crops.

| Scenario | Expected | Actual |
|----------|----------|--------|
| Docs with table (TSR) crops | distributed across all docs that have tables | 52 docs, 73 PNGs (before: orphaned in 1 doc) |
| Docs with figure crops | distributed across all docs that have figures | 100 docs, 166 PNGs (before: orphaned in 1 doc) |
| Docs with DLA page images | 200/200 | 200/200 (before: 1/200) |
| Orphaned `extraction/crops/` folders | 0 | 0 (before: 1, holding 36 foreign crops) |
| TSR/FIGURE sections in evidence-report.html | crop image renders beside its data | renders (table crop with cell overlay, figure crop with caption) |
| Batch result | 200/200 success, veraPDF pass | 200/200 success, 200/200 veraPDF pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Added per-document control over artifact output destinations for page images and debug files.
  * Fixed issue where artifact output settings could persist across documents, ensuring proper isolation between processing jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->