### PR TITLE
fix(auto-tagging): tag backend-detected figures that have no Java ImageChunk

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -5,6 +5,7 @@ import org.opendataloader.pdf.autotagging.OperatorStreamKey;
 import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticFootnote;
 import org.opendataloader.pdf.entities.SemanticFormula;
+import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.exceptions.EncryptedTaggedPdfNotSupportedException;
 import org.verapdf.as.ASAtom;
 import org.verapdf.as.io.ASMemoryInStream;
@@ -696,6 +697,17 @@ public class AutoTaggingProcessor {
             createFormulaStructElem((SemanticFormula) object, parentStructElem, cosDocument);
         } else if (object instanceof ImageChunk) {
             createFigureStructElem((ImageChunk) object, parentStructElem, cosDocument);
+        } else if (object instanceof SemanticPicture) {
+            // A backend-detected figure that never matched a Java-extracted
+            // ImageChunk stays a SemanticPicture (see HybridDocumentProcessor
+            // enrichBackendResults). Without this branch it would fall through
+            // untagged, so the page's figure gets no /Figure element at all.
+            // Tag it from its bounding box + alt; it carries no StreamInfo, so
+            // there is no marked-content child to attach. The image's own
+            // content-stream operators are still wrapped as /Artifact by
+            // ChunksWriter (no matching StreamInfo), so the page has no
+            // untagged content — this only adds the missing /Figure + /Alt.
+            createFigureStructElem((SemanticPicture) object, parentStructElem, cosDocument);
         }
     }
 
@@ -770,6 +782,28 @@ public class AutoTaggingProcessor {
 
     private static void createFigureStructElem(ImageChunk image, COSObject parent, COSDocument cosDocument) {
         createFigureStructElemReturning(image, parent, cosDocument);
+    }
+
+    /**
+     * Figure struct element for a backend-detected picture that has no matching
+     * Java ImageChunk (so no StreamInfo / marked content). Mirrors the
+     * ImageChunk path: /BBox layout attribute + non-empty /Alt (falling back to
+     * the synthetic "image N" text when the backend gave no description). No
+     * MCID child is attached because a SemanticPicture carries no content
+     * stream operators. Any linked caption is still attached.
+     */
+    private static void createFigureStructElem(SemanticPicture picture, COSObject parent, COSDocument cosDocument) {
+        COSObject figureObject = addStructElement(parent, cosDocument,
+                TaggedPDFConstants.FIGURE, picture.getPageNumber());
+        double[] bbox = {picture.getLeftX(), picture.getBottomY(),
+                picture.getRightX(), picture.getTopY()};
+        addAttributeToStructElem(figureObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
+        // PDF/UA requires every Figure to carry a non-empty /Alt; setStringEntry
+        // falls back to the synthetic "image N" text when the description is
+        // empty, matching the ImageChunk path.
+        setStringEntry(picture.sanitizeDescription(), figureObject, IMAGE_REPLACEMENT_TEXT, ASAtom.ALT, true);
+        cosDocument.addChangedObject(figureObject);
+        addCaptionIfPresent(picture, figureObject, cosDocument);
     }
 
     private static COSObject createFigureStructElemReturning(ImageChunk image, COSObject parent, COSDocument cosDocument) {


### PR DESCRIPTION
## Objective
Some PDFs converted through the hybrid AI backend come out with a figure on the page that has **no Figure tag in the structure tree at all**. The image appears in the JSON/Markdown/HTML output and even gets an AI alt-text caption, but the tagged PDF has no `/Figure` and no `/Alt` for it — so a screen-reader user never learns the image is there.

## Root cause
When the backend classifies a region as a figure but **no Java-extracted `ImageChunk` overlaps it** (`HybridDocumentProcessor.enrichBackendResults` finds no match, or the page yielded no Java image chunks at all), the region is kept as a `SemanticPicture` — it has a bounding box and the AI caption, but no content-stream / MCID info. `AutoTaggingProcessor.createStructElem` only handled `instanceof ImageChunk`, so a `SemanticPicture` fell through **untagged**. (JSON/MD/HTML serialize `SemanticPicture` directly, which is why only the struct tree was affected.)

## Approach
Add a `SemanticPicture` branch to `createStructElem` that creates the Figure from its bounding box + alt text — the same `/BBox` layout attribute and non-empty `/Alt` the `ImageChunk` path emits, minus the marked-content child (a `SemanticPicture` carries no stream operators to link). This makes good on what the hybrid pipeline's own comment already assumed: *"downstream PDF struct-tree tagging tolerates a missing StreamInfo (the figure is tagged from its bounding box)."*

## Evidence
Ran the full 200-PDF benchmark batch against the bundled mock Hancom AI backend (`--hybrid hancom-ai --hybrid-mode full`).

| Scenario | Before | After |
|----------|--------|-------|
| doc `01030000000078` ua1/ua2 | `/Figure=0`, `/Alt=0` (figure only in JSON/HTML + ai-raw caption) | `/Figure=1`, `/Alt=1` |
| Figure-bearing docs still missing `/Figure` | a subset (incl. 78) | **0 of 100** |
| Batch | 200/200 success, 200/200 veraPDF pass | 200/200 success, 200/200 veraPDF pass |
| Control doc `01030000000005` (already tagged) | `/Figure=2` | `/Figure=2` (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pictures in PDFs are now properly tagged as figures with layout info, receive meaningful alternative descriptions (with a sensible fallback), and keep linked captions—improving accessibility and document structure integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->