### PR TITLE
fix: preserve table header (TH) semantics in JSON output

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonName.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/JsonName.java
@@ -50,6 +50,7 @@ public class JsonName {
     public static final String ROW_NUMBER = "row number";
     public static final String COLUMN_SPAN = "column span";
     public static final String ROW_SPAN = "row span";
+    public static final String IS_HEADER = "is_header";
     public static final String NUMBER_OF_ROWS = "number of rows";
     public static final String NUMBER_OF_COLUMNS = "number of columns";
     public static final String NUMBER_OF_PAGES = "number of pages";

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/TableCellSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/TableCellSerializer.java
@@ -40,6 +40,9 @@ public class TableCellSerializer extends StdSerializer<TableBorderCell> {
         jsonGenerator.writeNumberField(JsonName.COLUMN_NUMBER, cell.getColNumber() + 1);
         jsonGenerator.writeNumberField(JsonName.ROW_SPAN, cell.getRowSpan());
         jsonGenerator.writeNumberField(JsonName.COLUMN_SPAN, cell.getColSpan());
+        if (cell.getRowNumber() == 0) {
+            jsonGenerator.writeBooleanField(JsonName.IS_HEADER, true);
+        }
         jsonGenerator.writeArrayFieldStart(JsonName.KIDS);
         for (IObject content : cell.getContents()) {
             if (!(content instanceof LineArtChunk)) {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/json/serializers/LineArtSerializerTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/json/serializers/LineArtSerializerTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.opendataloader.pdf.json.JsonName;
 import org.opendataloader.pdf.json.ObjectMapperHolder;
 import org.verapdf.wcag.algorithms.entities.content.LineArtChunk;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
@@ -62,5 +63,22 @@ class LineArtSerializerTest {
                 "TableBorderCell kids must be empty when its only child is a LineArtChunk");
         assertFalse(json.contains("lineChunks"),
                 "LineArtChunk POJO fields must not appear in serialized output");
+    }
+
+    @Test
+    void tableCellSerializerMarksFirstRowCellsAsHeaders() throws JsonProcessingException {
+        ObjectMapper objectMapper = ObjectMapperHolder.getObjectMapper();
+        TableBorderCell headerCell = new TableBorderCell(0, 0, 1, 1, 0L);
+        headerCell.setBoundingBox(new BoundingBox(0, 0.0, 0.0, 100.0, 100.0));
+        TableBorderCell bodyCell = new TableBorderCell(1, 0, 1, 1, 0L);
+        bodyCell.setBoundingBox(new BoundingBox(0, 0.0, 0.0, 100.0, 100.0));
+
+        JsonNode headerNode = objectMapper.readTree(objectMapper.writeValueAsString(headerCell));
+        JsonNode bodyNode = objectMapper.readTree(objectMapper.writeValueAsString(bodyCell));
+
+        assertTrue(headerNode.path(JsonName.IS_HEADER).asBoolean(),
+                "First-row table cells must be serialized as headers");
+        assertFalse(bodyNode.has(JsonName.IS_HEADER),
+                "Body table cells must not include is_header");
     }
 }


### PR DESCRIPTION
## Summary

Preserves table header semantics in the JSON output so the JSON and HTML paths agree on which cells are headers.

## Why

A tagged PDF table with real TH cells serialized every cell as `"pdfua_tag": "TD"` with no header indicator, even though the HTML output of the same run correctly emitted `<th>`. Issue #549 reports that this makes the JSON output unsuitable for table accessibility validation, because a consumer cannot tell header cells from body cells.

## Description

JSON output now preserves table header semantics so the JSON and HTML paths agree on which cells are headers. `TableCellSerializer.serialize()` emits an additive `is_header: true` field on first-row cells, mirroring the `isHeader = rowNumber == 0` heuristic `HtmlGenerator.writeTable()` already uses to emit `<th>`. The field name is a new `IS_HEADER` constant in `JsonName.java`, and the existing `pdfua_tag` field is left as-is so current consumers are not broken.

Before this change, a tagged PDF table with real TH cells serialized every cell as `"pdfua_tag": "TD"` with no header indicator, which made the JSON output unsuitable for table accessibility validation even though the HTML output of the same run emitted `<th>` (issue #549).

**Issue resolved by this Pull Request:**
Resolves #549

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

`LineArtSerializerTest.tableCellSerializerMarksFirstRowCellsAsHeaders` confirms first-row cells carry `is_header: true` and body cells omit the field. Covered by the new test in this PR; full suite runs in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Table cells in the first row are now automatically identified and marked as headers in the generated output, improving data structure clarity.

* **Tests**
  * Added test coverage to validate header cell identification in the first row versus body cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->