### PR TITLE
fix(html): escape &, <, > in extracted text so HTML output stays well-formed

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
@@ -528,12 +528,37 @@ public class HtmlGenerator implements Closeable {
             if (!style.isEmpty()) {
                 String styleAttribute = String.format(HtmlSyntax.HTML_STYLE_ATTRIBUTE, style.trim());
                 stringBuilder.append(String.format(HtmlSyntax.HTML_SPAN_START_TAG, styleAttribute));
-                stringBuilder.append(chunk.getValue());
+                stringBuilder.append(escapeHtmlText(chunk.getValue()));
                 stringBuilder.append(HtmlSyntax.HTML_SPAN_CLOSE_TAG);
             } else {
-                stringBuilder.append(chunk.getValue());
+                stringBuilder.append(escapeHtmlText(chunk.getValue()));
             }
         }
+    }
+
+    /**
+     * Escapes the HTML special characters that are unsafe in element text content.
+     * Without this, PDF text containing {@code &}, {@code <}, or {@code >} would be
+     * emitted verbatim, producing malformed HTML: {@code <...>} is parsed as markup
+     * (and dropped by renderers) and a bare {@code &} starts an invalid entity
+     * reference, corrupting the extracted text.
+     *
+     * <p>{@code &} is replaced first so that the entities introduced for {@code <}
+     * and {@code >} are not double-escaped. Quotes are intentionally left untouched:
+     * they are legal in element text and only need escaping inside attribute values,
+     * which are handled separately by {@link #escapeHtmlAttribute(String)}.
+     *
+     * @param value the text content to escape
+     * @return the escaped text, or the input unchanged if it is null
+     */
+    static String escapeHtmlText(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;");
     }
 
     private static String getTextStyle(TextChunk chunk) {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/html/HtmlGeneratorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/html/HtmlGeneratorTest.java
@@ -191,6 +191,52 @@ class HtmlGeneratorTest {
     }
 
     @Test
+    void testSpecialCharactersAreHtmlEscaped() {
+        // PDF text containing HTML-special characters must be escaped so the
+        // generated HTML stays well-formed. Without escaping, '<tag>' would be
+        // interpreted as markup (and dropped by renderers) and a bare '&' would
+        // form an invalid entity reference, corrupting the extracted text.
+        TextChunk chunk = new TextChunk(new BoundingBox(0, 0, 10, 20, 30),
+            "a <b> & c", 12, 100.0);
+        chunk.setFontWeight(400.0);
+        TextLine line = new TextLine(chunk);
+        StringBuilder sb = new StringBuilder();
+
+        HtmlGenerator.getTextFromLineForHTML(line, sb);
+
+        assertEquals("a &lt;b&gt; &amp; c", sb.toString());
+    }
+
+    @Test
+    void testSpecialCharactersAreEscapedInsideStyledSpan() {
+        // The escaping must apply to the chunk text only, not to the surrounding
+        // <span> markup that carries the style attribute.
+        TextChunk chunk = createChunk("x < y & z", false, true, false, 400.0, 12.0);
+        TextLine line = new TextLine(chunk);
+        StringBuilder sb = new StringBuilder();
+
+        HtmlGenerator.getTextFromLineForHTML(line, sb);
+
+        assertEquals("<span style=\"font-style: italic;\">x &lt; y &amp; z</span>",
+            sb.toString());
+    }
+
+    @Test
+    void testAmpersandIsEscapedExactlyOnce() {
+        // '&' must be escaped first; otherwise already-escaped sequences such as
+        // an explicit '&lt;' in the source would be double-escaped to '&amp;lt;'.
+        TextChunk chunk = new TextChunk(new BoundingBox(0, 0, 10, 20, 30),
+            "&lt; & &amp;", 12, 100.0);
+        chunk.setFontWeight(400.0);
+        TextLine line = new TextLine(chunk);
+        StringBuilder sb = new StringBuilder();
+
+        HtmlGenerator.getTextFromLineForHTML(line, sb);
+
+        assertEquals("&amp;lt; &amp; &amp;amp;", sb.toString());
+    }
+
+    @Test
     void testStyleOrderIsStable() {
         TextChunk chunk = new TextChunk(new BoundingBox(0,0,10,20,30), "order", 12, 100.0);
         chunk.setIsStrikethroughText();


### PR DESCRIPTION
## Summary

`HtmlGenerator.getTextFromLineForHTML(...)` writes each `TextChunk`'s text into the HTML output **without escaping HTML special characters**. PDF text containing `&`, `<`, or `>` is emitted verbatim, producing malformed HTML.

This is the single funnel for all text-bearing HTML elements — paragraphs, headings, list items, TOC entries, figure captions, and table cells all reach the output through `GeneratorUtils.getTextFromLines/getTextFromTextNode` → `getTextFromLineForHTML` — so the corruption affects every one of them.

## Reproduction

A PDF whose text contains `<`, `>`, or `&` (e.g. source code, math like `a < b`, `Tom & Jerry`) produces broken HTML:

- `<note>` in the PDF is parsed by browsers as an unknown tag and **disappears** from the rendered output.
- A bare `&` starts an invalid entity reference, so text after it can be mis-rendered.

Minimal unit-level repro (a chunk whose value is `a <b> & c`):

```java
TextChunk chunk = new TextChunk(new BoundingBox(0, 0, 10, 20, 30), "a <b> & c", 12, 100.0);
TextLine line = new TextLine(chunk);
StringBuilder sb = new StringBuilder();
HtmlGenerator.getTextFromLineForHTML(line, sb);
// before fix: sb = "a <b> & c"   (raw, breaks the HTML)
// after fix:  sb = "a &lt;b&gt; &amp; c"
```

## Root cause

In `getTextFromLineForHTML`, `chunk.getValue()` was appended directly:

```java
stringBuilder.append(chunk.getValue());          // styled span branch
...
stringBuilder.append(chunk.getValue());          // plain branch
```

Interestingly, the class already escapes HTML attribute values via `escapeHtmlAttribute(...)` (used for `<img src=...>`), but the equivalent escaping was missing for element **text content**.

## Fix

Add a small `static` `escapeHtmlText` helper and apply it at the two append sites. It escapes the three characters that are unsafe in element text and replaces `&` first so the entities introduced for `<`/`>` are not double-escaped:

```java
static String escapeHtmlText(String value) {
    if (value == null) {
        return null;
    }
    return value
        .replace("&", "&amp;")
        .replace("<", "&lt;")
        .replace(">", "&gt;");
}
```

Quotes are intentionally left untouched — they are legal in element text and only need escaping inside attribute values, which `escapeHtmlAttribute` already handles. The surrounding `<span style="...">` markup is not passed through the escaper, only the chunk text is.

## Tests

Three regression tests added to `HtmlGeneratorTest` (which already exercises `getTextFromLineForHTML`):

- `testSpecialCharactersAreHtmlEscaped` — bare `&`, `<`, `>`.
- `testSpecialCharactersAreEscapedInsideStyledSpan` — escaping applies to the text but not the `<span>` markup.
- `testAmpersandIsEscapedExactlyOnce` — guards the replace order against double-escaping.

All three **fail before** this change and **pass after**:

```
# before fix
[ERROR] HtmlGeneratorTest.testSpecialCharactersAreHtmlEscaped:207 expected: <a &lt;b&gt; &amp; c> but was: <a <b> & c>
[ERROR] HtmlGeneratorTest.testSpecialCharactersAreEscapedInsideStyledSpan:220 expected: <<span style="font-style: italic;">x &lt; y &amp; z</span>> but was: <<span style="font-style: italic;">x < y & z</span>>
[ERROR] HtmlGeneratorTest.testAmpersandIsEscapedExactlyOnce:236 expected: <&amp;lt; &amp; &amp;amp;> but was: <&lt; & &amp;>
[ERROR] Tests run: 41, Failures: 3

# after fix
[INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0
```

The full `opendataloader-pdf-core` test suite passes after the change (711 tests, 0 failures). Existing HTML/Markdown snapshot tests are unaffected because the escaped characters do not appear in their fixtures.

## Scope

Only HTML output is changed. Markdown output (where `<`/`>`/`&` are largely literal) is intentionally left alone to keep this fix focused on the clear correctness defect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML generation to properly escape special characters in extracted PDF text, preventing formatting issues and ensuring safe, correct rendering of output.

* **Tests**
  * Added comprehensive unit tests verifying HTML character escaping functionality across multiple scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->