### PR TITLE
fix: detect strikethroughs from line arts

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/StrikethroughProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/StrikethroughProcessor.java
@@ -16,36 +16,36 @@
 package org.opendataloader.pdf.processors;
 
 import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.content.LineArtChunk;
 import org.verapdf.wcag.algorithms.entities.content.LineChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 
 import java.util.*;
 
 /**
- * Detects strikethrough text by finding horizontal lines that pass through
- * the vertical center of text chunks. Marks affected TextChunks by setting
- * their isStrikethroughText field to true.
+ * Detects strikethrough text by finding horizontal line or line-art rules that
+ * pass through the vertical center of text chunks. Marks affected TextChunks by
+ * setting their isStrikethroughText field to true.
  *
  * Filters to avoid false positives:
- * 1. Stroke-to-text-height ratio (rejects thick background fills/borders)
- * 2. Line-to-text width ratio (rejects lines wider than text)
+ * 1. Rule-to-text-height ratio (rejects thick background fills/borders)
+ * 2. Rule-to-text width ratio (rejects rules wider than text)
  * 3. Vertical center alignment
  * 4. Horizontal overlap requirement
- * 5. Multi-chunk matching (structural separator detection)
+ * 5. Multi-chunk matching using the combined text width
  */
 public class StrikethroughProcessor {
 
     private static final double VERTICAL_CENTER_TOLERANCE = 0.2;
     private static final double MIN_HORIZONTAL_OVERLAP_RATIO = 0.8;
     private static final double MAX_LINE_TO_TEXT_WIDTH_RATIO = 1.5;
-    private static final int MAX_TEXT_CHUNKS_PER_LINE = 1;
 
-    // Maximum ratio of line stroke thickness to text height.
-    // Real strikethrough lines are thin (~0.04x textHeight) or at most text-height
-    // filled rectangles (~1.0x). Lines thicker than text (>1.3x) are background
-    // fills, table cell shading, or structural borders.
-    private static final double MAX_STROKE_TO_TEXT_HEIGHT_RATIO = 1.3;
+    // Real strikethrough marks are thin rules. Text-height rectangles commonly
+    // come from glyph bounds, filled artifacts, backgrounds, or table artwork.
+    private static final double MAX_RULE_THICKNESS = 2.0;
+    private static final double MAX_RULE_TO_TEXT_HEIGHT_RATIO = 0.25;
 
     /**
      * Detects strikethrough lines among page contents and sets affected
@@ -56,33 +56,48 @@ public class StrikethroughProcessor {
      * @return the page contents (modified in place)
      */
     public static List<IObject> processStrikethroughs(List<IObject> pageContents, int pageNumber) {
+        if (pageContents == null) {
+            return null;
+        }
         SortedSet<LineChunk> horizontalLines = StaticContainers.getLinesCollection() != null ?
             StaticContainers.getLinesCollection().getHorizontalLines(pageNumber) : Collections.emptySortedSet();
-        List<TextChunk> textChunks = new ArrayList<>();
+        List<HorizontalRuleCandidate> horizontalRules = new ArrayList<>();
 
+        for (LineChunk lineChunk : horizontalLines) {
+             HorizontalRuleCandidate rule = HorizontalRuleCandidate.fromLineChunk(lineChunk);
+            if (rule != null) {
+                horizontalRules.add(rule);
+            }
+        }
+
+        List<TextChunk> textChunks = new ArrayList<>();
         for (IObject content : pageContents) {
-            if (content instanceof TextChunk) {
+            if (content instanceof LineArtChunk) {
+                HorizontalRuleCandidate rule = HorizontalRuleCandidate.fromLineArtChunk((LineArtChunk) content);
+                if (rule != null) {
+                    horizontalRules.add(rule);
+                }
+            } else if (content instanceof TextChunk) {
                 textChunks.add((TextChunk) content);
             }
         }
 
-        if (horizontalLines.isEmpty() || textChunks.isEmpty()) {
+        if (horizontalRules.isEmpty() || textChunks.isEmpty()) {
             return pageContents;
         }
 
-        for (LineChunk line : horizontalLines) {
-
+        for (HorizontalRuleCandidate rule : horizontalRules) {
             List<TextChunk> matchingChunks = new ArrayList<>();
             for (TextChunk textChunk : textChunks) {
                 if (textChunk.isWhiteSpaceChunk() || textChunk.isEmpty()) {
                     continue;
                 }
-                if (isStrikethroughLine(line, textChunk)) {
+                if (isStrikethroughRule(rule, textChunk)) {
                     matchingChunks.add(textChunk);
                 }
             }
 
-            if (!matchingChunks.isEmpty() && matchingChunks.size() <= MAX_TEXT_CHUNKS_PER_LINE) {
+            if (isValidMatch(rule, matchingChunks)) {
                 for (TextChunk chunk : matchingChunks) {
                     if (!chunk.getIsStrikethroughText()) {
                         chunk.setIsStrikethroughText();
@@ -98,21 +113,46 @@ public class StrikethroughProcessor {
      * Determines whether a horizontal line is a strikethrough for the given text chunk.
      */
     static boolean isStrikethroughLine(LineChunk line, TextChunk textChunk) {
+        HorizontalRuleCandidate rule = HorizontalRuleCandidate.fromLineChunk(line);
+        return rule != null && isStrikethroughRule(rule, textChunk) && isValidMatch(rule, Collections.singletonList(textChunk));
+    }
+
+    /**
+     * Determines whether a line-art rectangle is a strikethrough for the given text chunk.
+     */
+    static boolean isStrikethroughLineArt(LineArtChunk lineArt, TextChunk textChunk) {
+        HorizontalRuleCandidate rule = HorizontalRuleCandidate.fromLineArtChunk(lineArt);
+        // Line-art rectangles are also used for table/background artwork, so
+        // apply the width-ratio guard even for direct single-chunk checks.
+        return rule != null && isStrikethroughRule(rule, textChunk) && isValidMatch(rule, List.of(textChunk));
+    }
+
+    private static boolean isHorizontalLineArt(LineArtChunk lineArt) {
+        BoundingBox bbox = lineArt.getBoundingBox();
+        return bbox != null && bbox.getWidth() > bbox.getHeight();
+    }
+
+    private static boolean isStrikethroughRule(HorizontalRuleCandidate rule, TextChunk textChunk) {
+        if (rule == null || textChunk == null) {
+            return false;
+        }
+
         double textHeight = textChunk.getHeight();
 
         if (textHeight <= 0) {
             return false;
         }
 
-        // Reject lines whose stroke thickness exceeds the text height
-        double strokeToHeightRatio = line.getWidth() / textHeight;
-        if (strokeToHeightRatio > MAX_STROKE_TO_TEXT_HEIGHT_RATIO) {
+        // LineChunk thickness is stroke width; LineArtChunk thickness is rectangle
+        // height. In both cases, strikethrough marks should stay thin relative to text.
+        double maxRuleThickness = Math.min(MAX_RULE_THICKNESS, textHeight * MAX_RULE_TO_TEXT_HEIGHT_RATIO);
+        if (rule.thickness > maxRuleThickness) {
             return false;
         }
 
         // Check vertical position: the line's Y should be near the vertical center of the text
         double textCenterY = textChunk.getCenterY();
-        double lineY = line.getCenterY();
+        double lineY = rule.centerY;
         double tolerance = textHeight * VERTICAL_CENTER_TOLERANCE;
 
         if (Math.abs(lineY - textCenterY) > tolerance) {
@@ -122,8 +162,8 @@ public class StrikethroughProcessor {
         // Check horizontal overlap
         double textLeftX = textChunk.getLeftX();
         double textRightX = textChunk.getRightX();
-        double lineLeftX = line.getLeftX();
-        double lineRightX = line.getRightX();
+        double lineLeftX = rule.leftX;
+        double lineRightX = rule.rightX;
 
         double overlapLeft = Math.max(textLeftX, lineLeftX);
         double overlapRight = Math.min(textRightX, lineRightX);
@@ -138,12 +178,58 @@ public class StrikethroughProcessor {
             return false;
         }
 
-        // Reject lines that extend far beyond the text
-        double lineWidth = line.getBoundingBox().getWidth();
-        if (lineWidth / textWidth > MAX_LINE_TO_TEXT_WIDTH_RATIO) {
+        return true;
+    }
+
+    private static boolean isValidMatch(HorizontalRuleCandidate rule, List<TextChunk> matchingChunks) {
+        if (matchingChunks.isEmpty()) {
             return false;
         }
 
-        return true;
+        // Validate against the combined span of all matched chunks. This accepts
+        // split text on one visual line while still rejecting table separators
+        // and background rules that extend far past the text group.
+        double textGroupWidth = 0.0;
+        for (TextChunk chunk : matchingChunks) {
+            textGroupWidth += chunk.getWidth();
+        }
+        return textGroupWidth > 0 && rule.width / textGroupWidth <= MAX_LINE_TO_TEXT_WIDTH_RATIO;
+    }
+
+    /**
+     * Normalized geometry for either LineChunk or LineArtChunk.
+     */
+    private static class HorizontalRuleCandidate {
+        private final double leftX;
+        private final double rightX;
+        private final double centerY;
+        private final double width;
+        private final double thickness;
+
+        private HorizontalRuleCandidate(double leftX, double rightX, double centerY, double width, double thickness) {
+            this.leftX = leftX;
+            this.rightX = rightX;
+            this.centerY = centerY;
+            this.width = width;
+            this.thickness = thickness;
+        }
+
+        private static HorizontalRuleCandidate fromLineChunk(LineChunk line) {
+            if (line == null || line.getBoundingBox() == null || !line.isHorizontalLine()) {
+                return null;
+            }
+            BoundingBox bbox = line.getBoundingBox();
+            return new HorizontalRuleCandidate(line.getLeftX(), line.getRightX(), line.getCenterY(),
+                bbox.getWidth(), line.getWidth());
+        }
+
+        private static HorizontalRuleCandidate fromLineArtChunk(LineArtChunk lineArt) {
+            if (lineArt == null || !isHorizontalLineArt(lineArt)) {
+                return null;
+            }
+            BoundingBox bbox = lineArt.getBoundingBox();
+            return new HorizontalRuleCandidate(lineArt.getLeftX(), lineArt.getRightX(), lineArt.getCenterY(),
+                bbox.getWidth(), bbox.getHeight());
+        }
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/StrikethroughProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/StrikethroughProcessorTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.verapdf.wcag.algorithms.entities.IObject;
+import org.verapdf.wcag.algorithms.entities.content.LineArtChunk;
 import org.verapdf.wcag.algorithms.entities.content.LineChunk;
 import org.verapdf.wcag.algorithms.entities.content.LinesCollection;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
@@ -179,7 +180,7 @@ public class StrikethroughProcessorTest {
     }
 
     @Test
-    public void testWideLineSpanningMultipleChunksRejected() {
+    public void testWideLineSpanningMultipleChunksDetected() {
         List<IObject> contents = new ArrayList<>();
 
         // Two text chunks at different horizontal positions
@@ -190,15 +191,39 @@ public class StrikethroughProcessorTest {
         contents.add(chunk1);
         contents.add(chunk2);
 
-        // A wide line spanning both chunks — likely a table border or separator
+        // A thin line spanning multiple chunks on one visual text line.
         LineChunk line = LineChunk.createLineChunk(0, 10.0, 110.0, 130.0, 110.0, 1.0,
             LineChunk.BUTT_CAP_STYLE);
         StaticContainers.getLinesCollection().getHorizontalLines(0).add(line);
 
         StrikethroughProcessor.processStrikethroughs(contents, 0);
 
-        Assertions.assertFalse(chunk1.getIsStrikethroughText(), "Wide line matching multiple chunks should be rejected as structural separator");
-        Assertions.assertFalse(chunk2.getIsStrikethroughText(), "Wide line matching multiple chunks should be rejected as structural separator");
+        Assertions.assertTrue(chunk1.getIsStrikethroughText(),
+            "Thin line matching multiple chunks should be detected");
+        Assertions.assertTrue(chunk2.getIsStrikethroughText(),
+            "Thin line matching multiple chunks should be detected");
+    }
+
+    @Test
+    public void testWideLineArtSpanningMultipleChunksDetected() {
+        List<IObject> contents = new ArrayList<>();
+
+        TextChunk chunk1 = new TextChunk(new BoundingBox(0, 10.0, 100.0, 40.0, 120.0),
+            "hello", 12, 100.0);
+        TextChunk chunk2 = new TextChunk(new BoundingBox(0, 45.0, 100.0, 90.0, 120.0),
+            "world", 12, 100.0);
+        contents.add(chunk1);
+        contents.add(chunk2);
+
+        LineArtChunk lineArt = new LineArtChunk(new BoundingBox(0, 10.0, 109.5, 90.0, 110.5));
+        contents.add(lineArt);
+
+        StrikethroughProcessor.processStrikethroughs(contents, 0);
+
+        Assertions.assertTrue(chunk1.getIsStrikethroughText(),
+            "Line-art strikethrough should support multiple chunks on one visual line");
+        Assertions.assertTrue(chunk2.getIsStrikethroughText(),
+            "Line-art strikethrough should support multiple chunks on one visual line");
     }
 
     @Test
@@ -229,15 +254,34 @@ public class StrikethroughProcessorTest {
             "hello", 12, 100.0);
         contents.add(textChunk);
 
-        // Line with stroke=30.0 — thicker than text height (30/20 = 1.5 > 1.3)
-        // This is a background fill or table cell shading, not a strikethrough
+        // Line with stroke=30.0. This is a background fill or table cell shading,
+        // not a strikethrough.
         LineChunk line = LineChunk.createLineChunk(0, 10.0, 110.0, 60.0, 110.0, 30.0,
             LineChunk.BUTT_CAP_STYLE);
         StaticContainers.getLinesCollection().getHorizontalLines(0).add(line);
 
         StrikethroughProcessor.processStrikethroughs(contents, 0);
 
-        Assertions.assertFalse(textChunk.getIsStrikethroughText(), "Thick line (stroke > 1.3x text height) should be rejected");
+        Assertions.assertFalse(textChunk.getIsStrikethroughText(), "Thick line should be rejected");
+    }
+
+    @Test
+    public void testTextHeightLineRejectedAsGlyphArtifact() {
+        List<IObject> contents = new ArrayList<>();
+
+        TextChunk textChunk = new TextChunk(new BoundingBox(0, 10.0, 100.0, 60.0, 120.0),
+            "hello", 12, 100.0);
+        contents.add(textChunk);
+
+        // Centered but text-height-ish rules are often extracted glyph/vector
+        // artifacts, not strikethrough marks.
+        LineChunk line = LineChunk.createLineChunk(0, 10.0, 110.0, 60.0, 110.0, 10.0,
+            LineChunk.BUTT_CAP_STYLE);
+        StaticContainers.getLinesCollection().getHorizontalLines(0).add(line);
+
+        StrikethroughProcessor.processStrikethroughs(contents, 0);
+
+        Assertions.assertFalse(textChunk.getIsStrikethroughText(), "Text-height line should be rejected");
     }
 
     @Test
@@ -250,6 +294,95 @@ public class StrikethroughProcessorTest {
 
         Assertions.assertTrue(StrikethroughProcessor.isStrikethroughLine(line, textChunk),
             "Thin line at center should be detected as strikethrough");
+    }
+
+    @Test
+    public void testNullLineInputsAreIgnored() {
+        TextChunk textChunk = new TextChunk(new BoundingBox(0, 10.0, 100.0, 60.0, 120.0),
+            "test", 12, 100.0);
+
+        Assertions.assertFalse(StrikethroughProcessor.isStrikethroughLine(null, textChunk),
+            "Null LineChunk should not throw or match");
+        Assertions.assertFalse(StrikethroughProcessor.isStrikethroughLineArt(null, textChunk),
+            "Null LineArtChunk should not throw or match");
+    }
+
+    @Test
+    public void testThinLineArtDetectedAsStrikethrough() {
+        List<IObject> contents = new ArrayList<>();
+
+        TextChunk textChunk = new TextChunk(new BoundingBox(0, 10.0, 100.0, 60.0, 120.0),
+            "test", 12, 100.0);
+        contents.add(textChunk);
+
+        // Thin horizontal rectangle through the text center.
+        LineArtChunk lineArt = new LineArtChunk(new BoundingBox(0, 10.0, 109.5, 60.0, 110.5));
+        contents.add(lineArt);
+
+        StrikethroughProcessor.processStrikethroughs(contents, 0);
+
+        Assertions.assertTrue(textChunk.getIsStrikethroughText(), "Thin centered line art should trigger strikethrough");
+    }
+
+    @Test
+    public void testWideLineArtHelperRejected() {
+        TextChunk textChunk = new TextChunk(new BoundingBox(0, 50.0, 100.0, 80.0, 120.0),
+            "hi", 12, 100.0);
+        LineArtChunk lineArt = new LineArtChunk(new BoundingBox(0, 10.0, 109.5, 200.0, 110.5));
+
+        Assertions.assertFalse(StrikethroughProcessor.isStrikethroughLineArt(lineArt, textChunk),
+            "Direct line-art helper should reject rules much wider than the text");
+    }
+
+    @Test
+    public void testUnderlineLineArtNotDetectedAsStrikethrough() {
+        List<IObject> contents = new ArrayList<>();
+
+        TextChunk textChunk = new TextChunk(new BoundingBox(0, 10.0, 100.0, 60.0, 120.0),
+            "test", 12, 100.0);
+        contents.add(textChunk);
+
+        // Thin horizontal rectangle near the text bottom.
+        LineArtChunk lineArt = new LineArtChunk(new BoundingBox(0, 10.0, 100.5, 60.0, 101.5));
+        contents.add(lineArt);
+
+        StrikethroughProcessor.processStrikethroughs(contents, 0);
+
+        Assertions.assertFalse(textChunk.getIsStrikethroughText(), "Underline-position line art should be ignored");
+    }
+
+    @Test
+    public void testTallLineArtRejectedAsBackgroundFill() {
+        List<IObject> contents = new ArrayList<>();
+
+        TextChunk textChunk = new TextChunk(new BoundingBox(0, 10.0, 100.0, 60.0, 120.0),
+            "test", 12, 100.0);
+        contents.add(textChunk);
+
+        // Height=30, far thicker than a strikethrough rule.
+        LineArtChunk lineArt = new LineArtChunk(new BoundingBox(0, 10.0, 95.0, 60.0, 125.0));
+        contents.add(lineArt);
+
+        StrikethroughProcessor.processStrikethroughs(contents, 0);
+
+        Assertions.assertFalse(textChunk.getIsStrikethroughText(), "Tall line art should be rejected");
+    }
+
+    @Test
+    public void testLargeBackgroundLineArtRejected() {
+        List<IObject> contents = new ArrayList<>();
+
+        TextChunk textChunk = new TextChunk(new BoundingBox(0, 50.0, 100.0, 80.0, 120.0),
+            "hi", 12, 100.0);
+        contents.add(textChunk);
+
+        // Thin but much wider than the text, so it is likely a separator or background shape.
+        LineArtChunk lineArt = new LineArtChunk(new BoundingBox(0, 10.0, 109.5, 200.0, 110.5));
+        contents.add(lineArt);
+
+        StrikethroughProcessor.processStrikethroughs(contents, 0);
+
+        Assertions.assertFalse(textChunk.getIsStrikethroughText(), "Large background-like line art should be rejected");
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strikethrough detection now recognizes horizontal line-art as well as traditional horizontal rules, with improved validation of rule thickness, width and alignment to nearby text.
  * Fewer false positives from background-like shapes, glyph artifacts, and underline-position marks; null/empty inputs are safely ignored.

* **Tests**
  * Expanded tests for line-art detection, multi-chunk strikethroughs, rejection rules, and null-input safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->