### PR TITLE
Fix escaping of HTML text output

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
@@ -120,7 +120,7 @@ public class HtmlGenerator implements Closeable {
         try {
             htmlWriter.write("<!DOCTYPE html>\n");
             htmlWriter.write("<html lang=\"und\">\n<head>\n<meta charset=\"utf-8\">\n");
-            htmlWriter.write("<title>" + pdfFileName + "</title>\n");
+            htmlWriter.write("<title>" + escapeHtmlText(pdfFileName) + "</title>\n");
             htmlWriter.write("</head>\n<body>\n");
 
             for (int pageNumber = 0; pageNumber < StaticContainers.getDocument().getNumberOfPages(); pageNumber++) {
@@ -214,7 +214,7 @@ public class HtmlGenerator implements Closeable {
     protected void writeFormula(SemanticFormula formula) throws IOException {
         htmlWriter.write(HtmlSyntax.HTML_MATH_DISPLAY_TAG);
         htmlWriter.write("\\[");
-        htmlWriter.write(getCorrectString(formula.getLatex()));
+        htmlWriter.write(escapeHtmlText(formula.getLatex()));
         htmlWriter.write("\\]");
         htmlWriter.write(HtmlSyntax.HTML_MATH_DISPLAY_CLOSE_TAG);
         htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
@@ -249,7 +249,7 @@ public class HtmlGenerator implements Closeable {
                     String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
                             ? ((EnrichedImageChunk) image).sanitizeDescription()
                             : "";
-                    String imageString = String.format("<img src=\"%s\" alt=\"%s\">", escapedSource, altText);
+                    String imageString = String.format("<img src=\"%s\" alt=\"%s\">", escapedSource, escapeHtmlAttribute(altText));
                     htmlWriter.write(imageString);
                     htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
                 }
@@ -288,7 +288,7 @@ public class HtmlGenerator implements Closeable {
 
                     htmlWriter.write(HtmlSyntax.HTML_FIGURE_TAG);
                     htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
-                    String imageString = String.format("<img src=\"%s\" alt=\"%s\">", escapedSource, altText);
+                    String imageString = String.format("<img src=\"%s\" alt=\"%s\">", escapedSource, escapeHtmlAttribute(altText));
                     htmlWriter.write(imageString);
                     htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
                     htmlWriter.write(HtmlSyntax.HTML_FIGURE_CLOSE_TAG);
@@ -314,7 +314,7 @@ public class HtmlGenerator implements Closeable {
 
             htmlWriter.write(HtmlSyntax.HTML_PARAGRAPH_TAG);
             String value = GeneratorUtils.getTextFromLines(item.getLines(), OutputType.HTML);
-            htmlWriter.write(getCorrectString(value));
+            htmlWriter.write(value);
             htmlWriter.write(HtmlSyntax.HTML_PARAGRAPH_CLOSE_TAG);
 
             for (IObject object : item.getContents()) {
@@ -341,7 +341,7 @@ public class HtmlGenerator implements Closeable {
                 htmlWriter.write(HtmlSyntax.HTML_LIST_ITEM_TAG);
                 htmlWriter.write(HtmlSyntax.HTML_PARAGRAPH_TAG);
                 String value = GeneratorUtils.getTextFromLines(tocItem.getLines(), OutputType.HTML);
-                htmlWriter.write(getCorrectString(value));
+                htmlWriter.write(value);
                 htmlWriter.write(HtmlSyntax.HTML_PARAGRAPH_CLOSE_TAG);
                 for (IObject object : tocItem.getContents()) {
                     write(object);
@@ -362,7 +362,7 @@ public class HtmlGenerator implements Closeable {
      */
     protected void writeSemanticTextNode(SemanticTextNode textNode) throws IOException {
         htmlWriter.write(HtmlSyntax.HTML_FIGURE_CAPTION_TAG);
-        htmlWriter.write(getCorrectString(GeneratorUtils.getTextFromTextNode(textNode, OutputType.HTML)));
+        htmlWriter.write(GeneratorUtils.getTextFromTextNode(textNode, OutputType.HTML));
         htmlWriter.write(HtmlSyntax.HTML_FIGURE_CAPTION_CLOSE_TAG);
         htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
     }
@@ -428,7 +428,7 @@ public class HtmlGenerator implements Closeable {
             paragraphValue = paragraphValue.replace(HtmlSyntax.HTML_LINE_BREAK, HtmlSyntax.HTML_LINE_BREAK_TAG);
         }
 
-        htmlWriter.write(getCorrectString(paragraphValue));
+        htmlWriter.write(paragraphValue);
         htmlWriter.write(HtmlSyntax.HTML_PARAGRAPH_CLOSE_TAG);
         htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
     }
@@ -442,7 +442,7 @@ public class HtmlGenerator implements Closeable {
     protected void writeHeading(SemanticHeading heading) throws IOException {
         int headingLevel = Math.min(6, Math.max(1, heading.getHeadingLevel()));
         htmlWriter.write("<h" + headingLevel + ">");
-        htmlWriter.write(getCorrectString(GeneratorUtils.getTextFromTextNode(heading, OutputType.HTML)));
+        htmlWriter.write(GeneratorUtils.getTextFromTextNode(heading, OutputType.HTML));
         htmlWriter.write("</h" + headingLevel + ">");
         htmlWriter.write(HtmlSyntax.HTML_LINE_BREAK);
     }
@@ -460,7 +460,7 @@ public class HtmlGenerator implements Closeable {
             cellTag.append(" rowspan=\"").append(rowSpan).append("\"");
         }
         cellTag.append(">");
-        htmlWriter.write(getCorrectString(cellTag.toString()));
+        htmlWriter.write(cellTag.toString());
     }
 
     /**
@@ -489,36 +489,32 @@ public class HtmlGenerator implements Closeable {
     }
 
     /**
-     * Removes null characters from the given string.
-     *
-     * @param value the string to process
-     * @return the string with null characters removed, or null if input is null
-     */
-    protected String getCorrectString(String value) {
-        if (value != null) {
-            return value.replace("\u0000", "");
-        }
-        return null;
-    }
-
-    /**
      * Escapes special characters for use in HTML attributes.
      * Handles quotes, ampersands, less-than, greater-than, and newlines.
      *
      * @param value the string to escape
      * @return the escaped string safe for HTML attribute values
      */
-    protected String escapeHtmlAttribute(String value) {
+    protected static String escapeHtmlAttribute(String value) {
         if (value == null) {
-            return null;
+            return "";
         }
+        value = escapeHtmlText(value);
         return value
-            .replace("&", "&amp;")
             .replace("\"", "&quot;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
             .replace("\n", " ")
             .replace("\r", "");
+    }
+
+    protected static String escapeHtmlText(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+            .replace("\u0000", "")
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;");
     }
 
     public static void getTextFromLineForHTML(TextLine line, StringBuilder stringBuilder) {
@@ -527,10 +523,10 @@ public class HtmlGenerator implements Closeable {
             if (!style.isEmpty()) {
                 String styleAttribute = String.format(HtmlSyntax.HTML_STYLE_ATTRIBUTE, style.trim());
                 stringBuilder.append(String.format(HtmlSyntax.HTML_SPAN_START_TAG, styleAttribute));
-                stringBuilder.append(chunk.getValue());
+                stringBuilder.append(escapeHtmlText(chunk.getValue()));
                 stringBuilder.append(HtmlSyntax.HTML_SPAN_CLOSE_TAG);
             } else {
-                stringBuilder.append(chunk.getValue());
+                stringBuilder.append(escapeHtmlText(chunk.getValue()));
             }
         }
     }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/html/HtmlGeneratorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/html/HtmlGeneratorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opendataloader.pdf.entities.SemanticFormula;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
@@ -205,5 +206,61 @@ class HtmlGeneratorTest {
         assertEquals("<span style=\"text-decoration: line-through; font-style: italic; "
                 + "color: rgb(0, 255, 0); font-weight: 300;\">order</span>",
             sb.toString());
+    }
+
+    @Test
+    void testPdfTextIsEscapedForHtmlBodyContext() {
+        TextChunk chunk = createChunk("<script>alert(1)</script>&", false, false, false, 400.0, 12.0);
+        TextLine line = new TextLine(chunk);
+        StringBuilder sb = new StringBuilder();
+
+        HtmlGenerator.getTextFromLineForHTML(line, sb);
+
+        assertEquals("&lt;script&gt;alert(1)&lt;/script&gt;&amp;", sb.toString());
+    }
+
+    @Test
+    void testStyledPdfTextIsEscapedInsideSpan() {
+        TextChunk chunk = createChunk("<img src=x onerror=alert(1)>", false, true, false, 400.0, 12.0);
+        TextLine line = new TextLine(chunk);
+        StringBuilder sb = new StringBuilder();
+
+        HtmlGenerator.getTextFromLineForHTML(line, sb);
+
+        assertEquals(
+            "<span style=\"font-style: italic;\">&lt;img src=x onerror=alert(1)&gt;</span>",
+            sb.toString());
+    }
+
+    @Test
+    void testHtmlTextEscapingHandlesTitleCharactersAndNull() {
+        assertEquals("report &lt;draft&gt; &amp; notes", HtmlGenerator.escapeHtmlText("report <draft> & notes"));
+        assertEquals("", HtmlGenerator.escapeHtmlText(null));
+    }
+
+    @Test
+    void testAmpersandIsEscapedExactlyOnce() {
+        TextChunk chunk = new TextChunk(new BoundingBox(0, 0, 10, 20, 30),
+            "&lt; & &amp;", 12, 100.0);
+        chunk.setFontWeight(400.0);
+        TextLine line = new TextLine(chunk);
+        StringBuilder sb = new StringBuilder();
+
+        HtmlGenerator.getTextFromLineForHTML(line, sb);
+
+        assertEquals("&amp;lt; &amp; &amp;amp;", sb.toString());
+    }
+
+    @Test
+    void testFormulaLatexIsEscaped() {
+        String formulaLatex = "x < y & z";
+        String result = HtmlGenerator.escapeHtmlText(formulaLatex);
+        assertEquals("x &lt; y &amp; z", result);
+    }
+
+    @Test
+    void testHtmlAttributeEscapingHandlesQuotesAndNewlines() {
+        assertEquals("quote&quot; and null byte",
+            HtmlGenerator.escapeHtmlAttribute("quote\" and\u0000\nnull byte"));
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF-to-HTML conversion now consistently escapes special characters in document titles, math blocks, image alt text and other content, preventing injected markup from rendering.
  * Unified text handling so styled and unstyled content (lists, TOC, captions, paragraphs, headings, table cells) preserve literal characters reliably.

* **Tests**
  * Added tests validating HTML-escaping for special characters, quotes, newlines, null inputs and math/formula output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->