### PR TITLE
Improve detection of paragraphs with right alignment

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ParagraphProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ParagraphProcessor.java
@@ -46,9 +46,9 @@ public class ParagraphProcessor {
         blocks = detectParagraphsWithLeftAlignments(blocks, true);
         blocks = detectParagraphsWithLeftAlignments(blocks, false);
         blocks = detectFirstLinesOfParagraphWithLeftAlignments(blocks);
-        blocks = detectTwoLinesParagraphs(blocks);
         blocks = detectParagraphsWithCenterAlignments(blocks);
         blocks = detectParagraphsWithRightAlignments(blocks);
+        blocks = detectTwoLinesParagraphs(blocks);
         blocks = processOtherLines(blocks);
         return getContentsWithDetectedParagraphs(contents, blocks);
     }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ParagraphProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ParagraphProcessorTest.java
@@ -19,8 +19,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
+import org.verapdf.wcag.algorithms.entities.content.TextBlock;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
+import org.verapdf.wcag.algorithms.entities.enums.TextAlignment;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 
@@ -42,5 +44,60 @@ public class ParagraphProcessorTest {
         contents = ParagraphProcessor.processParagraphs(contents);
         Assertions.assertEquals(1, contents.size());
         Assertions.assertTrue(contents.get(0) instanceof SemanticParagraph);
+    }
+
+    /**
+     * Regression test for PR `#567`: right-alignment detection must claim adjacent single-line
+     * blocks before the two-line paragraph heuristic.
+     *
+     * <p>Two adjacent single-line TextLines with right-aligned geometry (identical rightX,
+     * differing leftX) satisfy BOTH detection predicates:
+     * <ul>
+     *   <li>{`@code` areLinesOfParagraphsWithRightAlignments} → would set {`@link` TextAlignment#RIGHT}</li>
+     *   <li>{`@code` isTwoLinesParagraph} → would set {`@link` TextAlignment#LEFT}</li>
+     * </ul>
+     *
+     * <p>After the reorder ({`@code` detectParagraphsWithRightAlignments} before
+     * {`@code` detectTwoLinesParagraphs}), the right-alignment pass must claim the blocks first,
+     * so the merged paragraph carries {`@link` TextAlignment#RIGHT}.
+     * If the detection order were reversed the block would be LEFT-aligned instead.
+     */
+    @Test
+    public void testRightAlignmentTakesPrecedenceOverTwoLineHeuristic() {
+        StaticContainers.setIsDataLoader(true);
+
+        // Line 1 – shorter, flush right: leftX=15, rightX=20
+        // Line 2 – longer,  flush right: leftX=10, rightX=20
+        //
+        // Geometry properties:
+        //   • Both lines share rightX=20                  → ChunksMergeUtils.getAlignment() == RIGHT
+        //   • line1.leftX(15) ≥ line2.leftX(10)          → isTwoLinesParagraph leftX  check passes
+        //   • line1.rightX(20) ≥ line2.rightX(20)        → isTwoLinesParagraph rightX check passes
+        //   • Lines are vertically adjacent (line height = font size = 10)
+        //   • Same font size (10)                         → areTextBlocksHaveSameTextSize passes
+        //
+        // Both heuristics would match, so the test verifies which one wins after the reorder.
+        List<IObject> contents = new ArrayList<>();
+        contents.add(new TextLine(new TextChunk(
+            new BoundingBox(1, 15.0, 20.0, 20.0, 30.0), "short", 10, 20.0)));
+        contents.add(new TextLine(new TextChunk(
+            new BoundingBox(1, 10.0, 10.0, 20.0, 20.0), "longer line", 10, 10.0)));
+
+        contents = ParagraphProcessor.processParagraphs(contents);
+
+        // The two right-aligned lines must be merged into exactly one paragraph.
+        Assertions.assertEquals(1, contents.size(),
+            "Two right-aligned single lines should be merged into one paragraph");
+        Assertions.assertInstanceOf(SemanticParagraph.class, contents.get(0));
+
+        // The merged block must carry TextAlignment.RIGHT because detectParagraphsWithRightAlignments
+        // now runs before detectTwoLinesParagraphs.  If the order were reversed, the block would
+        // be LEFT-aligned (set by isTwoLinesParagraph).
+        SemanticParagraph para = (SemanticParagraph) contents.get(0);
+        TextBlock block = para.getLastColumn().getBlocks().get(0);
+        Assertions.assertEquals(TextAlignment.RIGHT, block.getTextAlignment(),
+            "detectParagraphsWithRightAlignments must claim the blocks before " +
+                "detectTwoLinesParagraphs; expected TextAlignment.RIGHT but got: " +
+                block.getTextAlignment());
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changed paragraph-detection ordering to prioritize center- and right-alignment checks before multi-line merging, improving which adjacent text blocks are combined and which alignment/metadata are applied.
  * Reduces incorrect paragraph merges and yields more accurate alignment classification in PDF text extraction.

* **Tests**
  * Added a regression test verifying right-alignment detection takes precedence over the two-line heuristic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->