### PR TITLE
fix(python): relay JAR stdout in quiet mode so --to-stdout and folder summary reach the caller

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
@@ -30,15 +30,27 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
             ]
 
             if quiet:
-                # Quiet mode → capture all output
+                # Quiet mode → suppress the JAR's log stream (stderr) but
+                # relay its stdout to the caller: --to-stdout content and the
+                # folder summary line arrive on stdout, and swallowing them
+                # breaks pipe consumers (`... --quiet --to-stdout | jq`).
                 result = subprocess.run(
                     command,
-                    capture_output=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
                     text=True,
                     check=True,
                     encoding="utf-8",
                     errors="replace",
                 )
+                if result.stdout:
+                    if hasattr(sys.stdout, "buffer"):
+                        sys.stdout.buffer.write(
+                            result.stdout.encode("utf-8", errors="replace")
+                        )
+                        sys.stdout.buffer.flush()
+                    else:
+                        sys.stdout.write(result.stdout)
                 return result.stdout
 
             # Streaming mode → live output

--- a/python/opendataloader-pdf/tests/test_runner.py
+++ b/python/opendataloader-pdf/tests/test_runner.py
@@ -7,6 +7,7 @@ yet and is allowed to print the captured streams — but only once
 (``CalledProcessError.output`` and ``.stdout`` are the same attribute).
 """
 
+import io
 import subprocess
 from unittest.mock import MagicMock
 
@@ -88,6 +89,43 @@ def test_quiet_success_relays_stdout_but_not_stderr(monkeypatch, capsys, patched
     assert "java log noise" not in captured.err
     # Return value is unchanged for library callers.
     assert returned == "extracted text payload\n"
+
+
+def test_quiet_relays_through_stdout_buffer_byte_path(monkeypatch, patched_jar):
+    """The production CLI writes the relayed payload through
+    ``sys.stdout.buffer`` (bytes), not the ``sys.stdout.write`` (str)
+    fallback. ``capsys`` replaces ``sys.stdout`` with an object whose
+    ``.buffer`` semantics differ, so the sibling test only exercises the
+    str branch. This drives the real byte-relay path and asserts the
+    payload is encoded to UTF-8 and written exactly once, intact — covering
+    the ``encode("utf-8", "replace")`` step that the str branch skips.
+    """
+    payload = "héllo 한글 payload\n"  # non-ASCII: exercises the utf-8 encode
+    result = subprocess.CompletedProcess(
+        args=["java", "-jar", "fake.jar"],
+        returncode=0,
+        stdout=payload,
+        stderr="[INFO] java log noise\n",
+    )
+    monkeypatch.setattr(runner.subprocess, "run", MagicMock(return_value=result))
+
+    # Fake stdout with a real binary buffer, mirroring a genuine TextIOWrapper
+    # (hasattr(sys.stdout, "buffer") is True), so run_jar takes the byte path.
+    fake_stdout = MagicMock()
+    fake_stdout.buffer = io.BytesIO()
+    monkeypatch.setattr(runner.sys, "stdout", fake_stdout)
+
+    returned = runner.run_jar(["doc.pdf", "--quiet", "--to-stdout"], quiet=True)
+
+    written = fake_stdout.buffer.getvalue()
+    # Byte path was taken: payload written as UTF-8 exactly once, intact.
+    assert written == payload.encode("utf-8")
+    assert written.decode("utf-8") == payload
+    # The str fallback branch was NOT used.
+    fake_stdout.write.assert_not_called()
+    fake_stdout.buffer.flush()  # buffer is flushed by run_jar; no error
+    # Return value is unchanged for library callers.
+    assert returned == payload
 
 
 def test_quiet_failure_prints_captured_streams_once(monkeypatch, capsys, patched_jar):

--- a/python/opendataloader-pdf/tests/test_runner.py
+++ b/python/opendataloader-pdf/tests/test_runner.py
@@ -65,6 +65,31 @@ def test_streaming_failure_does_not_duplicate_output(monkeypatch, capsys, patche
     assert "Return code: 2" in captured.err
 
 
+def test_quiet_success_relays_stdout_but_not_stderr(monkeypatch, capsys, patched_jar):
+    """Quiet mode must relay the JAR's stdout (--to-stdout payload, folder
+    summary line) to the caller while still suppressing the JAR's log
+    stream (stderr). Regression: --quiet + --to-stdout produced no output,
+    breaking pipe consumers."""
+    result = subprocess.CompletedProcess(
+        args=["java", "-jar", "fake.jar"],
+        returncode=0,
+        stdout="extracted text payload\n",
+        stderr="[INFO] java log noise\n",
+    )
+    monkeypatch.setattr(runner.subprocess, "run", MagicMock(return_value=result))
+
+    returned = runner.run_jar(["doc.pdf", "--quiet", "--to-stdout"], quiet=True)
+
+    captured = capsys.readouterr()
+    # Payload reaches the caller's stdout exactly once.
+    assert captured.out.count("extracted text payload") == 1
+    # The JAR's log stream stays suppressed (that is what quiet means).
+    assert "java log noise" not in captured.out
+    assert "java log noise" not in captured.err
+    # Return value is unchanged for library callers.
+    assert returned == "extracted text payload\n"
+
+
 def test_quiet_failure_prints_captured_streams_once(monkeypatch, capsys, patched_jar):
     """Quiet mode captures output, so the except handler surfaces it — but
     must avoid the old bug where Output and Stdout (aliases) both printed."""


### PR DESCRIPTION
## Objective
Combining `--quiet` with `--to-stdout` produced empty output — pipe
consumers (`opendataloader-pdf --quiet --to-stdout f.pdf | jq ...`)
received nothing. The folder summary line (`Processed N PDF file(s) ...`)
was also swallowed under `--quiet`.

## Approach
In `run_jar` quiet mode, capture stderr (the JAR's log stream — that is
what quiet suppresses) but relay the captured stdout to the caller via
`sys.stdout.buffer`, reusing the encoding-safe pattern from streaming
mode (`errors="replace"`).

The JAR intentionally keeps payload and summary on stdout under `--quiet`
(CLIMain javadoc: the summary is a result, not a log); the wrapper
swallowing them was the bug, so this restores the documented contract
rather than changing it. The relay lives in `run_jar` rather than the CLI
entry point because `convert()` discards `run_jar`'s return value, so a
CLI-boundary relay would lose the summary for library callers.

### User-visible behavior change
Library callers using `convert(quiet=True)` (or `run_jar(..., quiet=True)`)
now see the JAR's stdout — typically one folder summary line — where they
previously got silence. Callers that `print()` the return value will see
the content twice; use either the return value or the relayed stream, not both.

## Evidence
Ran the packaged CLI on macOS the way a user would:

| Scenario | Expected | Actual |
|----------|----------|--------|
| Before: `--quiet --to-stdout --format text` | text on stdout | exit 0, stdout **0 bytes** |
| After: same command | full text on stdout | stdout **39,168 bytes**, stderr 0 bytes (quiet preserved) |
| After: folder run with `--quiet` | summary preserved | `Processed 1 PDF file in '...'` on stdout |
| After: failing run in quiet mode | streams surfaced once on stderr | unchanged — `check=True` raises before the relay |

Regression tests in `tests/test_runner.py` (4/4 pass):
- `test_quiet_success_relays_stdout_but_not_stderr` — payload relayed
  exactly once, stderr suppressed, return value intact.
- `test_quiet_relays_through_stdout_buffer_byte_path` — covers the
  production `sys.stdout.buffer` byte-relay path that `capsys` masks in
  the str-fallback test; a non-ASCII payload exercises the `utf-8` encode,
  and mutating the branch to str-only turns the test RED, proving it pins
  the byte path.

The wrapper suite's pre-existing docling import failures are unrelated and
identical before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quiet mode now correctly relays the tool's standard output to the caller when using the "to-stdout" style flag, while continuing to suppress diagnostic error output.

* **Tests**
  * Added tests verifying quiet mode relays stdout but not stderr.
  * Added a test covering the byte-buffer relay path to ensure binary/stdout buffer forwarding works correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
