### PR TITLE
fix(hybrid): replace em-dash in --help text crashing on cp949 consoles

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -839,7 +839,10 @@ def main():
     ocr_mode_group.add_argument(
         "--no-ocr",
         action="store_true",
-        help="Disable OCR entirely. Use when input PDFs already have reliable embedded text — "
+        # ASCII only: argparse --help crashes with UnicodeEncodeError on
+        # non-UTF-8 consoles (e.g. cp949 on Korean Windows) if help text
+        # contains characters the locale codec cannot encode.
+        help="Disable OCR entirely. Use when input PDFs already have reliable embedded text - "
              "prevents duplicate text extraction from images (charts, diagrams, screenshots). "
              "Mutually exclusive with --force-ocr.",
     )
@@ -979,7 +982,7 @@ def main():
         if torch.cuda.is_available():
             gpu_name = torch.cuda.get_device_name(0)
             cuda_version = torch.version.cuda
-            logger.info(f"Accelerator: CUDA — {gpu_name} (CUDA {cuda_version})")
+            logger.info(f"Accelerator: CUDA - {gpu_name} (CUDA {cuda_version})")
         elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
             logger.info("Accelerator: MPS (Apple Silicon)")
         elif hasattr(torch, "xpu") and torch.xpu.is_available():


### PR DESCRIPTION
## Objective
On Korean Windows (cp949 console), running the hybrid CLI with
`--help` crashes with `UnicodeEncodeError: 'cp949' codec can't encode
character '—'` instead of printing the help text.

## Approach
Replace the em-dash (U+2014) with an ASCII hyphen in the two strings
that reach the console at runtime — the `--no-ocr` help text and the
CUDA accelerator log line. argparse writes help through the console
codec, so user-facing strings must stay within ASCII; comments and
docstrings keep their em-dashes (they never reach the console).

A targeted fix was chosen over a global
`sys.stdout.reconfigure(errors="replace")` — the project precedent is
hardening the specific output path, and the upcoming CI verification
harness guards this class of regression going forward.

## Evidence
Ran `--help` with `PYTHONIOENCODING=cp949` — the same condition as a
Korean Windows console:

| Scenario | Expected | Actual |
|----------|----------|--------|
| Before: `python -m opendataloader_pdf.hybrid_server --help` under cp949 | help text | exit 1, `UnicodeEncodeError` at position 1339 |
| After: same command | full help, exit 0 | exit 0, full help text, no `UnicodeEncodeError` |
| After: non-ASCII scan of the module | none in runtime strings | 6 em-dashes remain, all in comments/docstrings (never rendered) |
| Main CLI `--help` under cp949 | unaffected | passes (already ASCII-clean) |

Wrapper unit tests: the suite's pre-existing failures (docling import
issue in the local env) are identical before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
  * Updated command-line interface help text and logging messages to enhance compatibility with systems and locales that may have restricted character encoding support, ensuring proper display across diverse environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->