### PR TITLE
fix(filter): propagate page bounds to workers, restoring off-page & background filtering

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
@@ -43,6 +43,7 @@ public class StaticLayoutContainers {
     private static final ThreadLocal<String> imageFormat = new ThreadLocal<>();
     private static final ThreadLocal<Map<Integer, Double>> replacementCharRatios = ThreadLocal.withInitial(ConcurrentHashMap::new);
     private static final ThreadLocal<Map<String, byte[]>> embeddedImageBytes = ThreadLocal.withInitial(ConcurrentHashMap::new);
+    private static final ThreadLocal<Map<Integer, double[]>> pageCropBoxes = ThreadLocal.withInitial(ConcurrentHashMap::new);
 
     public static void clearContainers() {
         currentContentId.set(1L);
@@ -56,6 +57,7 @@ public class StaticLayoutContainers {
         imageFormat.set(Config.IMAGE_FORMAT_PNG);
         replacementCharRatios.get().clear();
         embeddedImageBytes.get().clear();
+        pageCropBoxes.get().clear();
     }
 
     public static long getCurrentContentId() {
@@ -197,6 +199,16 @@ public class StaticLayoutContainers {
 
     public static void setEmbeddedImageBytesMap(Map<String, byte[]> map) {
         embeddedImageBytes.set(map);
+    }
+
+    // Crop boxes precomputed on the main thread and propagated to workers so off-page / background
+    // filtering can read page bounds without touching the shared PDDocument from worker threads.
+    public static Map<Integer, double[]> getPageCropBoxesMap() {
+        return pageCropBoxes.get();
+    }
+
+    public static void setPageCropBoxesMap(Map<Integer, double[]> map) {
+        pageCropBoxes.set(map);
     }
 
     // Image paths flow through String.format with File.separator (cache write side) and

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -261,6 +261,8 @@ public class DocumentProcessor {
         final long contentId = StaticLayoutContainers.getCurrentContentId();
         final boolean useStructTree = StaticLayoutContainers.isUseStructTree();
         final var embeddedImageBytesMap = StaticLayoutContainers.getEmbeddedImageBytesMap();
+        // Crop boxes populated on this (main) thread below and propagated to workers.
+        final var pageCropBoxes = StaticLayoutContainers.getPageCropBoxesMap();
 
         // Runnable that propagates ThreadLocal state to the current (worker) thread
         final Runnable propagateState = () -> {
@@ -278,12 +280,22 @@ public class DocumentProcessor {
             StaticLayoutContainers.setCurrentContentId(contentId);
             StaticLayoutContainers.setIsUseStructTree(useStructTree);
             StaticLayoutContainers.setEmbeddedImageBytesMap(embeddedImageBytesMap);
+            StaticLayoutContainers.setPageCropBoxesMap(pageCropBoxes);
         };
 
-        // Pre-fetch all page artifacts on main thread (document access is ThreadLocal)
+        // Pre-fetch all page artifacts and page crop boxes on main thread (document access is
+        // ThreadLocal). Crop boxes are cached so worker threads can resolve page bounds for
+        // off-page / background filtering without reading the shared PDDocument concurrently.
+        PDDocument pdDocument = StaticResources.getDocument();
         List<?>[] pageArtifacts = new List<?>[totalPages];
         for (int i = 0; i < totalPages; i++) {
             pageArtifacts[i] = document.getArtifacts(i);
+            if (pdDocument != null) {
+                double[] cropBox = pdDocument.getPage(i).getCropBox();
+                if (cropBox != null) {
+                    pageCropBoxes.put(i, cropBox.clone());
+                }
+            }
         }
 
         int parallelism = config.getThreads();
@@ -787,13 +799,19 @@ public class DocumentProcessor {
      * @return the page bounding box, or null if not available
      */
     public static BoundingBox getPageBoundingBox(int pageNumber) {
-        PDDocument document = StaticResources.getDocument();
-        if (document == null) {
-            return null;
-        }
-        double[] cropBox = document.getPage(pageNumber).getCropBox();
+        // Prefer the crop box cached on the main thread (see process()): StaticResources.getDocument()
+        // is a ThreadLocal that is null on ForkJoinPool worker threads, which previously made
+        // off-page / background filtering silently no-op during parallel processing.
+        double[] cropBox = StaticLayoutContainers.getPageCropBoxesMap().get(pageNumber);
         if (cropBox == null) {
-            return null;
+            PDDocument document = StaticResources.getDocument();
+            if (document == null) {
+                return null;
+            }
+            cropBox = document.getPage(pageNumber).getCropBox();
+            if (cropBox == null) {
+                return null;
+            }
         }
         return new BoundingBox(pageNumber, cropBox);
     }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/OffPageTextFilterIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/OffPageTextFilterIntegrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.processors.DocumentProcessor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end guard for off-page text filtering through the real ForkJoinPool
+ * processing pipeline.
+ *
+ * <p>The fixture {@code off-page-text.pdf} (see generate-off-page-text-pdf.py)
+ * draws {@value #ON_PAGE} at y=700 (inside the [0 0 612 792] page) and
+ * {@value #OFF_PAGE} at y=900 (above the page top, outside the crop box).
+ *
+ * <p>"Off-page" means positioned outside the crop box; this is unrelated to the
+ * contrast-based hidden-text filter (it is handled by the off-page filter only).
+ *
+ * <p>This exercises the regression where {@code filterOutOfPageContents} ran on
+ * ForkJoinPool worker threads but {@code getPageBoundingBox()} returned null
+ * there (StaticResources is a ThreadLocal populated only on the main thread), so
+ * the filter silently no-opped and off-page text leaked into the output. A unit
+ * test that calls the filter directly would NOT catch this — it must go through
+ * the parallel pipeline via {@link DocumentProcessor#processFile}.
+ */
+class OffPageTextFilterIntegrationTest {
+
+    private static final String TEST_PDF =
+        new File("src/test/resources/off-page-text.pdf").getAbsolutePath();
+    private static final String OUTPUT_BASENAME = "off-page-text";
+
+    private static final String ON_PAGE = "ON_PAGE_TEXT";
+    private static final String OFF_PAGE = "OFF_PAGE_TEXT";
+
+    @TempDir
+    Path filterOnDir;
+
+    @TempDir
+    Path filterOffDir;
+
+    @Test
+    void offPageTextIsRemovedByDefault() throws IOException {
+        String text = runAndCollectText(filterOnDir, true);
+
+        assertTrue(text.contains(ON_PAGE),
+            "On-page text must be preserved; got: " + text);
+        assertFalse(text.contains(OFF_PAGE),
+            "Off-page text (outside the crop box) must be filtered out when the " +
+            "off-page safety filter is enabled (default). This guards the " +
+            "ForkJoinPool ThreadLocal regression. Got: " + text);
+    }
+
+    @Test
+    void offPageTextIsExtractedWhenFilterDisabled() throws IOException {
+        // Proves the fixture is meaningful: opendataloader DOES extract the
+        // off-page run, so removal in the other test is attributable to the
+        // off-page filter (not to the parser dropping it).
+        String text = runAndCollectText(filterOffDir, false);
+
+        assertTrue(text.contains(ON_PAGE), "On-page text must be present; got: " + text);
+        assertTrue(text.contains(OFF_PAGE),
+            "With the off-page filter disabled the off-page run must remain, " +
+            "otherwise this fixture cannot detect the regression. Got: " + text);
+    }
+
+    private String runAndCollectText(Path outputDir, boolean filterOutOfPage) throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(outputDir.toString());
+        config.setGenerateJSON(true);
+        config.getFilterConfig().setFilterOutOfPage(filterOutOfPage);
+
+        DocumentProcessor.processFile(TEST_PDF, config);
+
+        Path jsonOutput = outputDir.resolve(OUTPUT_BASENAME + ".json");
+        assertTrue(Files.exists(jsonOutput), "JSON output missing at " + jsonOutput);
+
+        JsonNode root = new ObjectMapper().readTree(Files.readString(jsonOutput));
+        StringBuilder sb = new StringBuilder();
+        collectContent(root, sb);
+        return sb.toString();
+    }
+
+    private static void collectContent(JsonNode node, StringBuilder sb) {
+        if (node == null) {
+            return;
+        }
+        if (node.isObject()) {
+            JsonNode content = node.get("content");
+            if (content != null && content.isTextual()) {
+                sb.append(content.asText()).append('\n');
+            }
+            node.elements().forEachRemaining(child -> collectContent(child, sb));
+        } else if (node.isArray()) {
+            for (JsonNode child : node) {
+                collectContent(child, sb);
+            }
+        }
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorPageBoundingBoxTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorPageBoundingBoxTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.processors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.verapdf.tools.StaticResources;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit guard for {@link DocumentProcessor#getPageBoundingBox(int)} resolving page
+ * bounds from the precomputed crop-box cache.
+ *
+ * <p>On ForkJoinPool worker threads {@code StaticResources.getDocument()} is null
+ * (it is a ThreadLocal set only on the main thread). These tests simulate that
+ * worker condition (document == null) to verify the cache fallback that fixes the
+ * off-page / background filtering regression.
+ */
+class DocumentProcessorPageBoundingBoxTest {
+
+    @BeforeEach
+    void setUp() {
+        StaticLayoutContainers.clearContainers();
+        // Simulate a worker thread: no document available via the ThreadLocal.
+        StaticResources.setDocument(null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        StaticResources.setDocument(null);
+        StaticLayoutContainers.clearContainers();
+    }
+
+    @Test
+    void resolvesFromCacheWhenDocumentUnavailable() {
+        // [leftX, bottomY, rightX, topY]
+        StaticLayoutContainers.getPageCropBoxesMap().put(0, new double[] {0, 0, 612, 792});
+
+        BoundingBox box = DocumentProcessor.getPageBoundingBox(0);
+
+        assertNotNull(box, "Page bounds must resolve from the cache on a worker thread "
+            + "(document ThreadLocal is null there)");
+        assertEquals(0, box.getLeftX());
+        assertEquals(0, box.getBottomY());
+        assertEquals(612, box.getRightX());
+        assertEquals(792, box.getTopY());
+    }
+
+    @Test
+    void returnsNullWhenNeitherCacheNorDocumentAvailable() {
+        assertNull(DocumentProcessor.getPageBoundingBox(0),
+            "Without a cached crop box and without a document, bounds are unknown");
+    }
+
+    @Test
+    void returnsFreshInstanceSoCallerMutationDoesNotCorruptCache() {
+        StaticLayoutContainers.getPageCropBoxesMap().put(0, new double[] {10, 20, 612, 792});
+
+        // filterOutOfPageContents mutates the returned box via move(...).
+        BoundingBox first = DocumentProcessor.getPageBoundingBox(0);
+        first.move(-first.getLeftX(), -first.getBottomY());
+        assertEquals(0, first.getLeftX());
+
+        BoundingBox second = DocumentProcessor.getPageBoundingBox(0);
+        assertEquals(10, second.getLeftX(),
+            "A previous caller's move() must not corrupt the cached crop box");
+        assertEquals(20, second.getBottomY());
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/resources/generate-off-page-text-pdf.py
+++ b/java/opendataloader-pdf-core/src/test/resources/generate-off-page-text-pdf.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Generate a minimal PDF with one on-page text run and one off-page text run.
+
+The page MediaBox is [0 0 612 792]. One text string is drawn at y=700 (inside
+the page) and another at y=900 (above the page top, i.e. outside the crop box and
+therefore not visible to a viewer). A correct extractor must drop the off-page run.
+
+NOTE: "off-page" here means positioned outside the crop box. This is unrelated to
+the contrast-based hidden-text filter (HiddenTextProcessor / --content-safety-off
+hidden-text); removal here is the job of the off-page filter only.
+
+This is the fixture for OffPageTextFilterIntegrationTest, which guards the
+ForkJoinPool ThreadLocal regression where filterOutOfPageContents silently
+no-opped on worker threads (page bounds were unavailable off the main thread).
+
+Uses the standard /Helvetica font, so no font embedding / external deps.
+
+Usage:
+    python3 generate-off-page-text-pdf.py [output.pdf]
+Output defaults to off-page-text.pdf in the same directory.
+"""
+import os
+import sys
+
+ON_PAGE_TEXT = "ON_PAGE_TEXT"
+OFF_PAGE_TEXT = "OFF_PAGE_TEXT"
+
+
+def build_pdf(output_path):
+    """Write a single-page PDF with one on-page and one off-page text run.
+
+    Returns the size in bytes of the written file.
+    """
+    content_stream = (
+        "BT\n"
+        "/F1 14 Tf\n"
+        f"72 700 Td\n({ON_PAGE_TEXT}) Tj\n"
+        "ET\n"
+        "BT\n"
+        "/F1 14 Tf\n"
+        f"72 900 Td\n({OFF_PAGE_TEXT}) Tj\n"
+        "ET\n"
+    ).encode()
+
+    catalog_id, pages_id, page_id, contents_id, font_id = 1, 2, 3, 4, 5
+    objects = {}
+    objects[catalog_id] = f"<< /Type /Catalog /Pages {pages_id} 0 R >>".encode()
+    objects[pages_id] = f"<< /Type /Pages /Kids [{page_id} 0 R] /Count 1 >>".encode()
+    objects[page_id] = (
+        f"<< /Type /Page /Parent {pages_id} 0 R /MediaBox [0 0 612 792] "
+        f"/Contents {contents_id} 0 R "
+        f"/Resources << /Font << /F1 {font_id} 0 R >> >> >>"
+    ).encode()
+    objects[font_id] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"
+
+    pdf = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+    offsets = {}
+    for obj_id in sorted(objects.keys()):
+        offsets[obj_id] = len(pdf)
+        pdf += f"{obj_id} 0 obj\n".encode() + objects[obj_id] + b"\nendobj\n"
+
+    offsets[contents_id] = len(pdf)
+    pdf += f"{contents_id} 0 obj\n".encode()
+    pdf += f"<< /Length {len(content_stream)} >>\n".encode()
+    pdf += b"stream\n" + content_stream + b"\nendstream\nendobj\n"
+
+    xref_offset = len(pdf)
+    max_obj = max(offsets.keys())
+    pdf += b"xref\n" + f"0 {max_obj + 1}\n".encode() + b"0000000000 65535 f \n"
+    for i in range(1, max_obj + 1):
+        pdf += f"{offsets[i]:010d} 00000 n \n".encode()
+    pdf += b"trailer\n"
+    pdf += f"<< /Size {max_obj + 1} /Root {catalog_id} 0 R >>\n".encode()
+    pdf += b"startxref\n" + f"{xref_offset}\n".encode() + b"%%EOF\n"
+
+    with open(output_path, "wb") as f:
+        f.write(pdf)
+    return len(pdf)
+
+
+def main():
+    """Generate the fixture PDF at the default (or given) path and print a summary."""
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    default_output = os.path.join(script_dir, "off-page-text.pdf")
+    output_path = sys.argv[1] if len(sys.argv) > 1 else default_output
+    size = build_pdf(output_path)
+    print(f"Generated: {output_path} ({size} bytes)")
+    print(f"  on-page  text @ y=700: {ON_PAGE_TEXT!r}")
+    print(f"  off-page text @ y=900: {OFF_PAGE_TEXT!r} (MediaBox top = 792)")
+
+
+if __name__ == "__main__":
+    main()

--- a/java/opendataloader-pdf-core/src/test/resources/off-page-text.pdf
+++ b/java/opendataloader-pdf-core/src/test/resources/off-page-text.pdf
@@ -1,0 +1,43 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Length 89 >>
+stream
+BT
+/F1 14 Tf
+72 700 Td
+(ON_PAGE_TEXT) Tj
+ET
+BT
+/F1 14 Tf
+72 900 Td
+(OFF_PAGE_TEXT) Tj
+ET
+
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000317 00000 n 
+0000000247 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+456
+%%EOF


### PR DESCRIPTION
## Summary

Off-page text (positioned outside the crop box) leaked into the output because the off-page safety filter silently did nothing during parallel processing.

`ContentFilterProcessor` runs on `ForkJoinPool` worker threads, but `getPageBoundingBox()` reads `org.verapdf.tools.StaticResources`, whose document is a **ThreadLocal populated only on the main thread**. On worker threads it returned `null`, so `filterOutOfPageContents` bailed out at its entry guard and off-page runs (e.g. a duplicate header placed above the page top) survived into the extracted output.

This is a regression from `bc52918e` (ForkJoinPool parallelization), which propagated `StaticContainers` / `StaticLayoutContainers` to workers but not `StaticResources`.

## Fix

- Precompute page crop boxes on the main thread and propagate them to workers via `DocumentProcessor.propagateState` (mirrors the existing `embeddedImageBytes` ThreadLocal pattern).
- `getPageBoundingBox()` resolves bounds from this cache, falling back to `StaticResources` for main-thread callers — so workers never touch the shared, non-thread-safe `PDDocument` concurrently.

Minimal and behavior-preserving for all existing callers (+37 / −7 in 2 source files).

The same code path is shared by background removal (`processBackgrounds` also calls `getPageBoundingBox`), so it is restored as well — verified via the `"Detected background"` log, though not separately covered by an output-level test.

## Tests

- `OffPageTextFilterIntegrationTest` — runs the full parallel pipeline on a fixture with one on-page and one off-page run; asserts the off-page run is dropped (and kept when the filter is disabled, proving the fixture is meaningful).
- `DocumentProcessorPageBoundingBoxTest` — unit coverage for cache resolution on a simulated worker thread.
- Both fail without the fix; the full `opendataloader-pdf-core` suite passes.

## Remaining / follow-up (out of scope)

This PR addresses **off-page** text only. Detecting **in-page** hidden text (e.g. low-contrast / same-as-background text via the contrast-based hidden-text filter) still has gaps and remains a separate task.

**Checklist:**
- [ ] Documentation has been updated, if necessary. _(N/A — no CLI/option change)_
- [ ] Examples have been added, if necessary. _(N/A)_
- [x] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved off-page text filtering reliability during parallel document processing.
  * Enhanced page boundary detection by using cached per-page crop-box data, improving behavior when shared document context is unavailable.
* **Tests**
  * Added an end-to-end integration test covering off-page text filtering with the real parallel processing pipeline.
  * Added unit tests for page bounding box resolution and safe caching behavior.
  * Added a PDF fixture generator script for the off-page text test input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->