### PR TITLE
feat(cli): add --filter-hidden-text to enable hidden-text filtering

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -91,6 +91,11 @@ public class CLIOptions {
     private static final String CONTENT_SAFETY_OFF_DESC = "Disable content safety filters. "
             + "Values: all, hidden-text, off-page, tiny, hidden-ocg";
 
+    // ===== Filter Hidden Text =====
+    private static final String FILTER_HIDDEN_TEXT_LONG_OPTION = "filter-hidden-text";
+    private static final String FILTER_HIDDEN_TEXT_DESC = "Filter hidden (low-contrast) text via per-page rendering. "
+            + "Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)";
+
     // ===== Sanitize =====
     private static final String SANITIZE_LONG_OPTION = "sanitize";
     private static final String SANITIZE_DESC = "Enable sensitive data sanitization. "
@@ -238,6 +243,7 @@ public class CLIOptions {
             new OptionDefinition(FORMAT_LONG_OPTION, FORMAT_OPTION, "string", null, FORMAT_DESC, true),
             new OptionDefinition(QUIET_LONG_OPTION, QUIET_OPTION, "boolean", false, QUIET_DESC, true),
             new OptionDefinition(CONTENT_SAFETY_OFF_LONG_OPTION, null, "string", null, CONTENT_SAFETY_OFF_DESC, true),
+            new OptionDefinition(FILTER_HIDDEN_TEXT_LONG_OPTION, null, "string", "off", FILTER_HIDDEN_TEXT_DESC, true),
             new OptionDefinition(SANITIZE_LONG_OPTION, null, "boolean", false, SANITIZE_DESC, true),
             new OptionDefinition(KEEP_LINE_BREAKS_LONG_OPTION, null, "boolean", false, KEEP_LINE_BREAKS_DESC, true),
             new OptionDefinition(REPLACE_INVALID_CHARS_LONG_OPTION, null, "string", " ", REPLACE_INVALID_CHARS_DESC,
@@ -381,6 +387,7 @@ public class CLIOptions {
             config.setHtmlPageSeparator(commandLine.getOptionValue(CLIOptions.HTML_PAGE_SEPARATOR_LONG_OPTION));
         }
         applyContentSafetyOption(config, commandLine);
+        applyFilterHiddenTextOption(config, commandLine);
         applySanitizeOption(config, commandLine);
         applyFormatOption(config, commandLine);
         applyTableMethodOption(config, commandLine);
@@ -521,6 +528,31 @@ public class CLIOptions {
                             "Unsupported value '%s'. Supported values: all, hidden-text, off-page, tiny, hidden-ocg",
                             value));
             }
+        }
+    }
+
+    /**
+     * Applies {@code --filter-hidden-text on|off}. Runs after
+     * {@link #applyContentSafetyOption} so an explicit opt-in wins over a
+     * {@code --content-safety-off hidden-text} disable.
+     */
+    private static void applyFilterHiddenTextOption(Config config, CommandLine commandLine) {
+        if (!commandLine.hasOption(FILTER_HIDDEN_TEXT_LONG_OPTION)) {
+            return;
+        }
+        String value = commandLine.getOptionValue(FILTER_HIDDEN_TEXT_LONG_OPTION);
+        String normalized = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        switch (normalized) {
+            case "on":
+                config.getFilterConfig().setFilterHiddenText(true);
+                break;
+            case "off":
+                config.getFilterConfig().setFilterHiddenText(false);
+                break;
+            default:
+                throw new IllegalArgumentException(String.format(
+                        "Option --%s requires a value of 'on' or 'off' (got '%s').",
+                        FILTER_HIDDEN_TEXT_LONG_OPTION, value));
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -91,6 +91,11 @@ public class CLIOptions {
     private static final String CONTENT_SAFETY_OFF_DESC = "Disable content safety filters. "
             + "Values: all, hidden-text, off-page, tiny, hidden-ocg, background";
 
+    // ===== Filter Hidden Text =====
+    private static final String FILTER_HIDDEN_TEXT_LONG_OPTION = "filter-hidden-text";
+    private static final String FILTER_HIDDEN_TEXT_DESC = "Filter hidden (low-contrast) text via per-page rendering. "
+            + "Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)";
+
     // ===== Sanitize =====
     private static final String SANITIZE_LONG_OPTION = "sanitize";
     private static final String SANITIZE_DESC = "Enable sensitive data sanitization. "
@@ -224,6 +229,7 @@ public class CLIOptions {
             new OptionDefinition(FORMAT_LONG_OPTION, FORMAT_OPTION, "string", null, FORMAT_DESC, true),
             new OptionDefinition(QUIET_LONG_OPTION, QUIET_OPTION, "boolean", false, QUIET_DESC, true),
             new OptionDefinition(CONTENT_SAFETY_OFF_LONG_OPTION, null, "string", null, CONTENT_SAFETY_OFF_DESC, true),
+            new OptionDefinition(FILTER_HIDDEN_TEXT_LONG_OPTION, null, "string", "off", FILTER_HIDDEN_TEXT_DESC, true),
             new OptionDefinition(SANITIZE_LONG_OPTION, null, "boolean", false, SANITIZE_DESC, true),
             new OptionDefinition(KEEP_LINE_BREAKS_LONG_OPTION, null, "boolean", false, KEEP_LINE_BREAKS_DESC, true),
             new OptionDefinition(REPLACE_INVALID_CHARS_LONG_OPTION, null, "string", " ", REPLACE_INVALID_CHARS_DESC,
@@ -372,6 +378,7 @@ public class CLIOptions {
             }
         }
         applyContentSafetyOption(config, commandLine);
+        applyFilterHiddenTextOption(config, commandLine);
         applySanitizeOption(config, commandLine);
         applyFormatOption(config, commandLine);
         applyTableMethodOption(config, commandLine);
@@ -529,6 +536,31 @@ public class CLIOptions {
                             "Unsupported value '%s'. Supported values: all, hidden-text, off-page, tiny, hidden-ocg, background",
                             value));
             }
+        }
+    }
+
+    /**
+     * Applies {@code --filter-hidden-text on|off}. Runs after
+     * {@link #applyContentSafetyOption} so an explicit opt-in wins over a
+     * {@code --content-safety-off hidden-text} disable.
+     */
+    private static void applyFilterHiddenTextOption(Config config, CommandLine commandLine) {
+        if (!commandLine.hasOption(FILTER_HIDDEN_TEXT_LONG_OPTION)) {
+            return;
+        }
+        String value = commandLine.getOptionValue(FILTER_HIDDEN_TEXT_LONG_OPTION);
+        String normalized = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        switch (normalized) {
+            case "on":
+                config.getFilterConfig().setFilterHiddenText(true);
+                break;
+            case "off":
+                config.getFilterConfig().setFilterHiddenText(false);
+                break;
+            default:
+                throw new IllegalArgumentException(String.format(
+                        "Option --%s requires a value of 'on' or 'off' (got '%s').",
+                        FILTER_HIDDEN_TEXT_LONG_OPTION, value));
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -229,7 +229,6 @@ public class CLIOptions {
             new OptionDefinition(FORMAT_LONG_OPTION, FORMAT_OPTION, "string", null, FORMAT_DESC, true),
             new OptionDefinition(QUIET_LONG_OPTION, QUIET_OPTION, "boolean", false, QUIET_DESC, true),
             new OptionDefinition(CONTENT_SAFETY_OFF_LONG_OPTION, null, "string", null, CONTENT_SAFETY_OFF_DESC, true),
-            new OptionDefinition(FILTER_HIDDEN_TEXT_LONG_OPTION, null, "string", "off", FILTER_HIDDEN_TEXT_DESC, true),
             new OptionDefinition(SANITIZE_LONG_OPTION, null, "boolean", false, SANITIZE_DESC, true),
             new OptionDefinition(KEEP_LINE_BREAKS_LONG_OPTION, null, "boolean", false, KEEP_LINE_BREAKS_DESC, true),
             new OptionDefinition(REPLACE_INVALID_CHARS_LONG_OPTION, null, "string", " ", REPLACE_INVALID_CHARS_DESC,
@@ -261,6 +260,7 @@ public class CLIOptions {
             new OptionDefinition(IMAGE_RESOLUTION_LONG_OPTION, null, "string", null, IMAGE_RESOLUTION_DESC, true),
             new OptionDefinition(EXPORT_OPTIONS_LONG_OPTION, null, "boolean", null, null, false),
             new OptionDefinition(SPACE_RATIO_LONG_OPTION, null, "string", null, SPACE_RATIO_DESC, true),
+            new OptionDefinition(FILTER_HIDDEN_TEXT_LONG_OPTION, null, "string", "off", FILTER_HIDDEN_TEXT_DESC, true),
 
             // Legacy options (not exported, for backward compatibility)
             new OptionDefinition(HYBRID_OCR_LONG_OPTION, null, "string", null, HYBRID_OCR_DESC, false),

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsContentSafetyTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsContentSafetyTest.java
@@ -99,4 +99,48 @@ class CLIOptionsContentSafetyTest {
         assertTrue(config.getFilterConfig().isFilterSensitiveData(),
                 "--sanitize should win over deprecated --content-safety-off sensitive-data");
     }
+
+    @Test
+    void filterHiddenTextDefaultsOff() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp");
+        assertFalse(config.getFilterConfig().isFilterHiddenText(),
+                "Without --filter-hidden-text, hidden-text filtering should stay off (default)");
+    }
+
+    @Test
+    void filterHiddenTextOnEnablesFilter() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp", "--filter-hidden-text", "on");
+        assertTrue(config.getFilterConfig().isFilterHiddenText(),
+                "--filter-hidden-text on should enable hidden-text filtering");
+    }
+
+    @Test
+    void filterHiddenTextOffDisablesFilter() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp", "--filter-hidden-text", "off");
+        assertFalse(config.getFilterConfig().isFilterHiddenText(),
+                "--filter-hidden-text off should keep hidden-text filtering off");
+    }
+
+    @Test
+    void filterHiddenTextValueIsCaseInsensitive() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp", "--filter-hidden-text", "ON");
+        assertTrue(config.getFilterConfig().isFilterHiddenText(),
+                "--filter-hidden-text value should be case-insensitive");
+    }
+
+    @Test
+    void filterHiddenTextInvalidValueThrows() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> parseArgs("--output-dir", "/tmp", "--filter-hidden-text", "maybe"));
+        assertTrue(ex.getMessage().contains("on")  && ex.getMessage().contains("off"),
+                "Invalid --filter-hidden-text value should report the supported on/off values");
+    }
+
+    @Test
+    void filterHiddenTextOnWinsOverContentSafetyOff() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp",
+                "--content-safety-off", "hidden-text", "--filter-hidden-text", "on");
+        assertTrue(config.getFilterConfig().isFilterHiddenText(),
+                "--filter-hidden-text on should take precedence over --content-safety-off hidden-text");
+    }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsContentSafetyTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsContentSafetyTest.java
@@ -123,4 +123,48 @@ class CLIOptionsContentSafetyTest {
         assertTrue(config.getFilterConfig().isFilterBackgrounds(),
                 "background removal stays on unless explicitly disabled");
     }
+
+    @Test
+    void filterHiddenTextDefaultsOff() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp");
+        assertFalse(config.getFilterConfig().isFilterHiddenText(),
+                "Without --filter-hidden-text, hidden-text filtering should stay off (default)");
+    }
+
+    @Test
+    void filterHiddenTextOnEnablesFilter() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp", "--filter-hidden-text", "on");
+        assertTrue(config.getFilterConfig().isFilterHiddenText(),
+                "--filter-hidden-text on should enable hidden-text filtering");
+    }
+
+    @Test
+    void filterHiddenTextOffDisablesFilter() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp", "--filter-hidden-text", "off");
+        assertFalse(config.getFilterConfig().isFilterHiddenText(),
+                "--filter-hidden-text off should keep hidden-text filtering off");
+    }
+
+    @Test
+    void filterHiddenTextValueIsCaseInsensitive() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp", "--filter-hidden-text", "ON");
+        assertTrue(config.getFilterConfig().isFilterHiddenText(),
+                "--filter-hidden-text value should be case-insensitive");
+    }
+
+    @Test
+    void filterHiddenTextInvalidValueThrows() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> parseArgs("--output-dir", "/tmp", "--filter-hidden-text", "maybe"));
+        assertTrue(ex.getMessage().contains("on")  && ex.getMessage().contains("off"),
+                "Invalid --filter-hidden-text value should report the supported on/off values");
+    }
+
+    @Test
+    void filterHiddenTextOnWinsOverContentSafetyOff() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp",
+                "--content-safety-off", "hidden-text", "--filter-hidden-text", "on");
+        assertTrue(config.getFilterConfig().isFilterHiddenText(),
+                "--filter-hidden-text on should take precedence over --content-safety-off hidden-text");
+    }
 }

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -12,6 +12,7 @@ export function registerCliOptions(program: Command): void {
   program.option('-f, --format <value>', 'Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.');
   program.option('-q, --quiet', 'Suppress console logging output');
   program.option('--content-safety-off <value>', 'Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg');
+  program.option('--filter-hidden-text <value>', 'Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)');
   program.option('--sanitize', 'Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders');
   program.option('--keep-line-breaks', 'Preserve original line breaks in extracted text');
   program.option('--replace-invalid-chars <value>', 'Replacement character for invalid/unrecognized characters. Default: space');

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -12,7 +12,6 @@ export function registerCliOptions(program: Command): void {
   program.option('-f, --format <value>', 'Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.');
   program.option('-q, --quiet', 'Suppress console logging output');
   program.option('--content-safety-off <value>', 'Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background');
-  program.option('--filter-hidden-text <value>', 'Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)');
   program.option('--sanitize', 'Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders');
   program.option('--keep-line-breaks', 'Preserve original line breaks in extracted text');
   program.option('--replace-invalid-chars <value>', 'Replacement character for invalid/unrecognized characters. Default: space');
@@ -38,4 +37,5 @@ export function registerCliOptions(program: Command): void {
   program.option('--threads <value>', 'Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode');
   program.option('--image-resolution <value>', 'Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 144.0). Default: 144.0.');
   program.option('--space-ratio <value>', 'Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17');
+  program.option('--filter-hidden-text <value>', 'Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)');
 }

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -12,6 +12,7 @@ export function registerCliOptions(program: Command): void {
   program.option('-f, --format <value>', 'Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.');
   program.option('-q, --quiet', 'Suppress console logging output');
   program.option('--content-safety-off <value>', 'Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background');
+  program.option('--filter-hidden-text <value>', 'Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)');
   program.option('--sanitize', 'Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders');
   program.option('--keep-line-breaks', 'Preserve original line breaks in extracted text');
   program.option('--replace-invalid-chars <value>', 'Replacement character for invalid/unrecognized characters. Default: space');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -15,6 +15,8 @@ export interface ConvertOptions {
   quiet?: boolean;
   /** Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg */
   contentSafetyOff?: string | string[];
+  /** Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing) */
+  filterHiddenText?: string;
   /** Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders */
   sanitize?: boolean;
   /** Preserve original line breaks in extracted text */
@@ -78,6 +80,7 @@ export interface CliOptions {
   format?: string;
   quiet?: boolean;
   contentSafetyOff?: string;
+  filterHiddenText?: string;
   sanitize?: boolean;
   keepLineBreaks?: boolean;
   replaceInvalidChars?: string;
@@ -126,6 +129,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.contentSafetyOff) {
     convertOptions.contentSafetyOff = cliOptions.contentSafetyOff;
+  }
+  if (cliOptions.filterHiddenText) {
+    convertOptions.filterHiddenText = cliOptions.filterHiddenText;
   }
   if (cliOptions.sanitize) {
     convertOptions.sanitize = true;
@@ -241,6 +247,9 @@ export function buildArgs(options: ConvertOptions): string[] {
     } else {
       args.push('--content-safety-off', options.contentSafetyOff);
     }
+  }
+  if (options.filterHiddenText) {
+    args.push('--filter-hidden-text', options.filterHiddenText);
   }
   if (options.sanitize) {
     args.push('--sanitize');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -15,6 +15,8 @@ export interface ConvertOptions {
   quiet?: boolean;
   /** Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background */
   contentSafetyOff?: string | string[];
+  /** Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing) */
+  filterHiddenText?: string;
   /** Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders */
   sanitize?: boolean;
   /** Preserve original line breaks in extracted text */
@@ -76,6 +78,7 @@ export interface CliOptions {
   format?: string;
   quiet?: boolean;
   contentSafetyOff?: string;
+  filterHiddenText?: string;
   sanitize?: boolean;
   keepLineBreaks?: boolean;
   replaceInvalidChars?: string;
@@ -123,6 +126,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.contentSafetyOff) {
     convertOptions.contentSafetyOff = cliOptions.contentSafetyOff;
+  }
+  if (cliOptions.filterHiddenText) {
+    convertOptions.filterHiddenText = cliOptions.filterHiddenText;
   }
   if (cliOptions.sanitize) {
     convertOptions.sanitize = true;
@@ -235,6 +241,9 @@ export function buildArgs(options: ConvertOptions): string[] {
     } else {
       args.push('--content-safety-off', options.contentSafetyOff);
     }
+  }
+  if (options.filterHiddenText) {
+    args.push('--filter-hidden-text', options.filterHiddenText);
   }
   if (options.sanitize) {
     args.push('--sanitize');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -15,8 +15,6 @@ export interface ConvertOptions {
   quiet?: boolean;
   /** Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background */
   contentSafetyOff?: string | string[];
-  /** Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing) */
-  filterHiddenText?: string;
   /** Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders */
   sanitize?: boolean;
   /** Preserve original line breaks in extracted text */
@@ -67,6 +65,8 @@ export interface ConvertOptions {
   imageResolution?: string;
   /** Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17 */
   spaceRatio?: string;
+  /** Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing) */
+  filterHiddenText?: string;
 }
 
 /**
@@ -78,7 +78,6 @@ export interface CliOptions {
   format?: string;
   quiet?: boolean;
   contentSafetyOff?: string;
-  filterHiddenText?: string;
   sanitize?: boolean;
   keepLineBreaks?: boolean;
   replaceInvalidChars?: string;
@@ -104,6 +103,7 @@ export interface CliOptions {
   threads?: string;
   imageResolution?: string;
   spaceRatio?: string;
+  filterHiddenText?: string;
 }
 
 /**
@@ -126,9 +126,6 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.contentSafetyOff) {
     convertOptions.contentSafetyOff = cliOptions.contentSafetyOff;
-  }
-  if (cliOptions.filterHiddenText) {
-    convertOptions.filterHiddenText = cliOptions.filterHiddenText;
   }
   if (cliOptions.sanitize) {
     convertOptions.sanitize = true;
@@ -205,6 +202,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   if (cliOptions.spaceRatio) {
     convertOptions.spaceRatio = cliOptions.spaceRatio;
   }
+  if (cliOptions.filterHiddenText) {
+    convertOptions.filterHiddenText = cliOptions.filterHiddenText;
+  }
 
   return convertOptions;
 }
@@ -241,9 +241,6 @@ export function buildArgs(options: ConvertOptions): string[] {
     } else {
       args.push('--content-safety-off', options.contentSafetyOff);
     }
-  }
-  if (options.filterHiddenText) {
-    args.push('--filter-hidden-text', options.filterHiddenText);
   }
   if (options.sanitize) {
     args.push('--sanitize');
@@ -319,6 +316,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.spaceRatio) {
     args.push('--space-ratio', options.spaceRatio);
+  }
+  if (options.filterHiddenText) {
+    args.push('--filter-hidden-text', options.filterHiddenText);
   }
 
   return args;

--- a/options.json
+++ b/options.json
@@ -41,6 +41,14 @@
       "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg"
     },
     {
+      "name": "filter-hidden-text",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": "off",
+      "description": "Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)"
+    },
+    {
       "name": "sanitize",
       "shortName": null,
       "type": "boolean",

--- a/options.json
+++ b/options.json
@@ -41,6 +41,14 @@
       "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background"
     },
     {
+      "name": "filter-hidden-text",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": "off",
+      "description": "Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)"
+    },
+    {
       "name": "sanitize",
       "shortName": null,
       "type": "boolean",

--- a/options.json
+++ b/options.json
@@ -41,14 +41,6 @@
       "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background"
     },
     {
-      "name": "filter-hidden-text",
-      "shortName": null,
-      "type": "string",
-      "required": false,
-      "default": "off",
-      "description": "Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)"
-    },
-    {
       "name": "sanitize",
       "shortName": null,
       "type": "boolean",
@@ -247,6 +239,14 @@
       "required": false,
       "default": null,
       "description": "Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17"
+    },
+    {
+      "name": "filter-hidden-text",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": "off",
+      "description": "Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)"
     }
   ]
 }

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -55,6 +55,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg",
     },
     {
+        "name": "filter-hidden-text",
+        "python_name": "filter_hidden_text",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": "off",
+        "description": "Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)",
+    },
+    {
         "name": "sanitize",
         "python_name": "sanitize",
         "short_name": None,

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -55,15 +55,6 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background",
     },
     {
-        "name": "filter-hidden-text",
-        "python_name": "filter_hidden_text",
-        "short_name": None,
-        "type": "string",
-        "required": False,
-        "default": "off",
-        "description": "Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)",
-    },
-    {
         "name": "sanitize",
         "python_name": "sanitize",
         "short_name": None,
@@ -287,6 +278,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "required": False,
         "default": None,
         "description": "Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17",
+    },
+    {
+        "name": "filter-hidden-text",
+        "python_name": "filter_hidden_text",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": "off",
+        "description": "Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)",
     },
 ]
 

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -55,6 +55,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background",
     },
     {
+        "name": "filter-hidden-text",
+        "python_name": "filter_hidden_text",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": "off",
+        "description": "Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)",
+    },
+    {
         "name": "sanitize",
         "python_name": "sanitize",
         "short_name": None,

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -16,6 +16,7 @@ def convert(
     format: Optional[Union[str, List[str]]] = None,
     quiet: bool = False,
     content_safety_off: Optional[Union[str, List[str]]] = None,
+    filter_hidden_text: Optional[str] = None,
     sanitize: bool = False,
     keep_line_breaks: bool = False,
     replace_invalid_chars: Optional[str] = None,
@@ -53,6 +54,7 @@ def convert(
         format: Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.
         quiet: Suppress console logging output
         content_safety_off: Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg
+        filter_hidden_text: Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)
         sanitize: Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders
         keep_line_breaks: Preserve original line breaks in extracted text
         replace_invalid_chars: Replacement character for invalid/unrecognized characters. Default: space
@@ -106,6 +108,8 @@ def convert(
                 args.extend(["--content-safety-off", ",".join(content_safety_off)])
         else:
             args.extend(["--content-safety-off", content_safety_off])
+    if filter_hidden_text:
+        args.extend(["--filter-hidden-text", filter_hidden_text])
     if sanitize:
         args.append("--sanitize")
     if keep_line_breaks:

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -16,7 +16,6 @@ def convert(
     format: Optional[Union[str, List[str]]] = None,
     quiet: bool = False,
     content_safety_off: Optional[Union[str, List[str]]] = None,
-    filter_hidden_text: Optional[str] = None,
     sanitize: bool = False,
     keep_line_breaks: bool = False,
     replace_invalid_chars: Optional[str] = None,
@@ -42,6 +41,7 @@ def convert(
     threads: Optional[str] = None,
     image_resolution: Optional[str] = None,
     space_ratio: Optional[str] = None,
+    filter_hidden_text: Optional[str] = None,
 ) -> None:
     """
     Convert PDF(s) into the requested output format(s).
@@ -53,7 +53,6 @@ def convert(
         format: Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.
         quiet: Suppress console logging output
         content_safety_off: Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background
-        filter_hidden_text: Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)
         sanitize: Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders
         keep_line_breaks: Preserve original line breaks in extracted text
         replace_invalid_chars: Replacement character for invalid/unrecognized characters. Default: space
@@ -79,6 +78,7 @@ def convert(
         threads: Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode
         image_resolution: Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 144.0). Default: 144.0.
         space_ratio: Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17
+        filter_hidden_text: Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)
     """
     args: List[str] = []
 
@@ -106,8 +106,6 @@ def convert(
                 args.extend(["--content-safety-off", ",".join(content_safety_off)])
         else:
             args.extend(["--content-safety-off", content_safety_off])
-    if filter_hidden_text:
-        args.extend(["--filter-hidden-text", filter_hidden_text])
     if sanitize:
         args.append("--sanitize")
     if keep_line_breaks:
@@ -158,5 +156,7 @@ def convert(
         args.extend(["--image-resolution", image_resolution])
     if space_ratio:
         args.extend(["--space-ratio", space_ratio])
+    if filter_hidden_text:
+        args.extend(["--filter-hidden-text", filter_hidden_text])
 
     run_jar(args, quiet)

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -16,6 +16,7 @@ def convert(
     format: Optional[Union[str, List[str]]] = None,
     quiet: bool = False,
     content_safety_off: Optional[Union[str, List[str]]] = None,
+    filter_hidden_text: Optional[str] = None,
     sanitize: bool = False,
     keep_line_breaks: bool = False,
     replace_invalid_chars: Optional[str] = None,
@@ -52,6 +53,7 @@ def convert(
         format: Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.
         quiet: Suppress console logging output
         content_safety_off: Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background
+        filter_hidden_text: Filter hidden (low-contrast) text via per-page rendering. Values: on, off. Default: off (opt-in; expensive, runs as sequential post-processing)
         sanitize: Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders
         keep_line_breaks: Preserve original line breaks in extracted text
         replace_invalid_chars: Replacement character for invalid/unrecognized characters. Default: space
@@ -104,6 +106,8 @@ def convert(
                 args.extend(["--content-safety-off", ",".join(content_safety_off)])
         else:
             args.extend(["--content-safety-off", content_safety_off])
+    if filter_hidden_text:
+        args.extend(["--filter-hidden-text", filter_hidden_text])
     if sanitize:
         args.append("--sanitize")
     if keep_line_breaks:


### PR DESCRIPTION
## Summary

The contrast-based hidden-text filter (`HiddenTextProcessor`) has been **unreachable** since #362 flipped `FilterConfig.filterHiddenText`'s default from `true` to `false`. That PR described the filter as "opt-in via CLI option" but never added the enabling option — only `--content-safety-off` (which *disables* filters) existed. As a result the filter could never be turned back on, and low-contrast hidden text always leaked into the output regardless of the flags passed.

This adds the missing opt-in.

## Changes

- Add `--filter-hidden-text <on|off>` (default `off`) to enable the contrast-based hidden-text filter. It is off by default because detection renders each page (sequential post-processing; not parallelizable).
- Regenerated `options.json` and the Python/Node bindings via `npm run sync` → `convert(filter_hidden_text="on")` (Python), `filterHiddenText` (Node).
- Added unit tests (default off / on / off / case-insensitive / invalid-value error / precedence over `--content-safety-off hidden-text`).

## Verification

On a PDF with low-contrast hidden text:

| Invocation | Result |
|---|---|
| (default) | hidden text retained — no behavior change |
| `--filter-hidden-text on` | low-contrast hidden text removed |
| `--filter-hidden-text on --content-safety-off hidden-text` | opt-in wins (removed) |
| `--filter-hidden-text maybe` | error: requires `on` or `off` |

## Relationship to `--content-safety-off`

`--content-safety-off` is an opt-**out** mechanism: it disables filters that are ON by default (`off-page`, `tiny`, `hidden-ocg`). The hidden-text filter is OFF by default, so it needs an opt-**in**, which `--content-safety-off` cannot express. Rather than overloading `--content-safety-off` or flipping the default back, this adds a dedicated `--filter-hidden-text on|off`.

- `--content-safety-off hidden-text` is kept for backward compatibility; since the filter is already off by default, it is effectively a no-op.
- When both are given, `--filter-hidden-text` is applied **after** `--content-safety-off`, so an explicit `--filter-hidden-text on` wins.

## Follow-ups (out of scope)

**1. `--content-safety-off` design.** This PR deliberately takes the minimal, non-breaking path, but the #362 default flip left `--content-safety-off` inconsistent and worth a separate design review:
- `--content-safety-off hidden-text` is now a no-op (the filter is already off by default), so "off" no longer holds uniformly across the filters it covers.
- If the intent was to **group** content-safety filters under one option (to limit parameter sprawl), a cleaner shape would drop "off" from the name and make it bidirectional — e.g. `--content-safety <filter>=on|off` — keeping the group while letting each filter toggle both ways.
- Alternatively, drop the grouped option and expose each filter as its own `--<filter> on|off` flag (consistent with `--filter-hidden-text`), at the cost of more parameters.

Both are breaking changes, hence out of scope here.

**2. LangChain wrapper.** The option is now exposed in the core Python SDK (`opendataloader_pdf.convert`) and the Node binding, but the LangChain loader (`langchain-opendataloader-pdf`, a separate repo) hardcodes its parameter list and does not forward `filter_hidden_text` yet. `OpenDataLoaderPDFLoader` users will be able to enable it only after that package adds the parameter and passes it through to `convert()`.

Related: #362 (regression this fixes).

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--filter-hidden-text` to control low-contrast or hidden text filtering during PDF conversion.
  * Supports `on` and `off` values, defaulting to `off`. Enabling it applies optional, potentially expensive sequential processing per page.
  * Available through the CLI and conversion interfaces across supported language bindings.
  * Invalid or missing values now produce a clear error.
* **Tests**
  * Added coverage for defaults, case-insensitive values, invalid inputs, and precedence over related hidden-text settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->