### PR TITLE
Fix the issue where list item can appear before previous one (bbox)

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -175,6 +175,10 @@ public class ListProcessor {
         for (int index = listIntervals.size() - 1; index >= minIndex; index--) {
             TextListInterval interval = listIntervals.get(index);
             ListItemTextInfo preivousListItemTextInfo = interval.getLastListItemInfo();
+            if (Objects.equals(listItemTextInfo.getPageNumber(), preivousListItemTextInfo.getPageNumber()) &&
+                listItemTextInfo.getListItemValue().getTopY() > preivousListItemTextInfo.getListItemValue().getTopY()) {
+                break;
+            }
             double leftDifference = listItemTextInfo.getListItemValue().getLeftX() -
                     preivousListItemTextInfo.getListItemValue().getLeftX();
             boolean haveSameLeft = NodeUtils.areCloseNumbers(leftDifference, 0, maxXGap);

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,8 +58,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <verapdf.version>1.31.80</verapdf.version>
-        <verapdf.wcag.algs.version>1.31.25</verapdf.wcag.algs.version>
+        <verapdf.version>1.31.83</verapdf.version>
+        <verapdf.wcag.algs.version>1.31.27</verapdf.wcag.algs.version>
         <jackson.databind.version>2.21.1</jackson.databind.version>
         <junit.jupiter.version>5.14.3</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list item detection by refining backward scanning behavior, preventing unnecessary interval growth and improving list accuracy during PDF processing.
  * Enhanced reliability when merging related list items by improving layout handling for neighbor-list combinations.

* **Chores**
  * Updated VeraPDF dependencies to newer patch versions for improved validation library currency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->