### PR TITLE
ci: add Dependabot config (weekly, grouped)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+version: 2
+updates:
+  # Java — multi-module Maven (parent /java declares core/cli child modules; Dependabot auto-detects them)
+  - package-ecosystem: "maven"
+    directory: "/java"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      maven-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Node.js SDK (pnpm; Dependabot handles pnpm under the "npm" ecosystem).
+  # Root package.json is a scripts-only workspace meta-file with no deps, so it is omitted.
+  - package-ecosystem: "npm"
+    directory: "/node/opendataloader-pdf"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Python SDK + MCP server (example requirements.txt excluded to avoid noise)
+  - package-ecosystem: "pip"
+    directories:
+      - "/python/opendataloader-pdf"
+      - "/python/opendataloader-pdf-mcp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Objective
Enable automated dependency updates via Dependabot.

## Approach
Add `.github/dependabot.yml` with a consistent policy across ODL repos:
- **Schedule**: weekly, Monday 09:00 KST
- **Grouping**: minor/patch grouped into one PR; major bumps get their own PR for review
- **Scope**: all dependency manifests in this repo + GitHub Actions (where workflows exist)
- Security updates continue to be PR'd immediately, independent of this schedule

## Evidence
`dependabot.yml` validated as YAML; ecosystems/directories matched against the actual manifest layout in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency update checks scheduled weekly across Java, Node.js, Python, and GitHub Actions components, with updates limited to minor and patch versions to maintain stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->