### PR TITLE
deps: migrate okhttp 4.12.0 → 5.4.0 (incl. mockwebserver3)

### DIFF
--- a/java/opendataloader-pdf-core/pom.xml
+++ b/java/opendataloader-pdf-core/pom.xml
@@ -81,10 +81,16 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
         </dependency>
+        <!--
+          okhttp 5's plain `okhttp` artifact is an empty Kotlin-Multiplatform
+          metadata jar; the JVM classes live in `okhttp-jvm`, and Maven cannot
+          resolve the JVM variant from Gradle module metadata — so depend on
+          `okhttp-jvm` explicitly. Version is managed by the okhttp-bom in the
+          parent pom (see java/pom.xml dependencyManagement).
+        -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>4.12.0</version>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -93,8 +99,7 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <version>4.12.0</version>
+            <artifactId>mockwebserver3</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridBackendFailureIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/HybridBackendFailureIntegrationTest.java
@@ -15,8 +15,8 @@
  */
 package org.opendataloader.pdf;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,7 +79,7 @@ class HybridBackendFailureIntegrationTest {
             // before the assignment). JUnit 5 still calls tearDown, so the guard
             // prevents an NPE from masking the real setup failure.
             if (server != null) {
-                server.shutdown();
+                server.close();
             }
         } finally {
             // Drop the cached HybridClient holding the mock server's URL so other
@@ -92,7 +92,7 @@ class HybridBackendFailureIntegrationTest {
     @Test
     void backendPartialSuccessFailsFastWhenFallbackDisabled() {
         // /health probe (Phase 0 checkAvailability)
-        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+        server.enqueue(new MockResponse.Builder().code(200).body("ok").build());
         // /v1/convert/file response — the single page of lorem.pdf is marked
         // failed. Listing just the requested pages keeps the test's intent
         // explicit instead of relying on the processor's intersection logic.
@@ -103,9 +103,10 @@ class HybridBackendFailureIntegrationTest {
             + "\"errors\": [\"Unknown page: pipeline terminated early\"],"
             + "\"failed_pages\": [1]"
             + "}";
-        server.enqueue(new MockResponse()
-            .setBody(partialSuccess)
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body(partialSuccess)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         Config config = new Config();
         config.setOutputFolder(tempDir.toString());

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DoclingFastServerClientTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/DoclingFastServerClientTest.java
@@ -17,8 +17,8 @@ package org.opendataloader.pdf.hybrid;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +55,7 @@ class DoclingFastServerClientTest {
     @AfterEach
     void tearDown() throws IOException {
         client.shutdown();
-        server.shutdown();
+        server.close();
     }
 
     @Test
@@ -68,9 +68,10 @@ class DoclingFastServerClientTest {
             + "\"failed_pages\": []"
             + "}";
 
-        server.enqueue(new MockResponse()
-            .setBody(responseJson)
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body(responseJson)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
         HybridResponse response = client.convert(request);
@@ -89,9 +90,10 @@ class DoclingFastServerClientTest {
             + "\"failed_pages\": [3]"
             + "}";
 
-        server.enqueue(new MockResponse()
-            .setBody(responseJson)
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body(responseJson)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
         HybridResponse response = client.convert(request);
@@ -110,9 +112,10 @@ class DoclingFastServerClientTest {
             + "\"failed_pages\": [2, 4]"
             + "}";
 
-        server.enqueue(new MockResponse()
-            .setBody(responseJson)
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body(responseJson)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
         HybridResponse response = client.convert(request);
@@ -128,9 +131,10 @@ class DoclingFastServerClientTest {
             + "\"errors\": [\"PDF conversion failed: ValueError: corrupted file\"]"
             + "}";
 
-        server.enqueue(new MockResponse()
-            .setBody(responseJson)
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body(responseJson)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
 
@@ -147,9 +151,10 @@ class DoclingFastServerClientTest {
             + "\"processing_time\": 1.0"
             + "}";
 
-        server.enqueue(new MockResponse()
-            .setBody(responseJson)
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body(responseJson)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
         HybridResponse response = client.convert(request);
@@ -169,9 +174,10 @@ class DoclingFastServerClientTest {
             + "\"failed_pages\": [3, \"bad\", null, 5]"
             + "}";
 
-        server.enqueue(new MockResponse()
-            .setBody(responseJson)
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body(responseJson)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
         HybridResponse response = client.convert(request);
@@ -183,7 +189,7 @@ class DoclingFastServerClientTest {
 
     @Test
     void testCheckAvailabilitySucceeds() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+        server.enqueue(new MockResponse.Builder().code(200).body("ok").build());
 
         // Should not throw
         client.checkAvailability();
@@ -192,7 +198,7 @@ class DoclingFastServerClientTest {
     @Test
     void testCheckAvailabilityFailsWhenServerUnavailable() throws IOException {
         // Shut down the server to simulate unavailability
-        server.shutdown();
+        server.close();
 
         IOException exception = assertThrows(IOException.class, () -> client.checkAvailability());
         assertTrue(exception.getMessage().contains("Hybrid server is not available"));
@@ -204,7 +210,7 @@ class DoclingFastServerClientTest {
 
     @Test
     void testCheckAvailabilityFailsOnUnhealthyServer() {
-        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse.Builder().code(503).build());
 
         IOException exception = assertThrows(IOException.class, () -> client.checkAvailability());
         assertTrue(exception.getMessage().contains("returned HTTP 503"));
@@ -221,9 +227,10 @@ class DoclingFastServerClientTest {
             + "\"failed_pages\": [1, 2, 3]"
             + "}";
 
-        server.enqueue(new MockResponse()
-            .setBody(responseJson)
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body(responseJson)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         HybridRequest request = HybridRequest.allPages(new byte[]{0x25, 0x50, 0x44, 0x46});
         HybridResponse response = client.convert(request);

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAIClientRequestIdTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAIClientRequestIdTest.java
@@ -2,9 +2,9 @@ package org.opendataloader.pdf.hybrid;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ class HancomAIClientRequestIdTest {
 
     @AfterEach
     void tearDown() throws Exception {
-        server.shutdown();
+        server.close();
     }
 
     @Test
@@ -40,15 +40,16 @@ class HancomAIClientRequestIdTest {
         byte[] pdfBytes = "PDF_CONTENT_FOR_TEST".getBytes();
         String shaShort = sha256Hex(pdfBytes).substring(0, 12);
 
-        server.enqueue(new MockResponse()
-            .setResponseCode(200)
-            .setBody("{\"SUCCESS\":true,\"RESULT\":[]}"));
+        server.enqueue(new MockResponse.Builder()
+            .code(200)
+            .body("{\"SUCCESS\":true,\"RESULT\":[]}")
+            .build());
 
         // invokeCallModule is a package-private test hook added by the patch.
         client.invokeCallModule(pdfBytes, "DOCUMENT_LAYOUT_WITH_OCR");
 
         RecordedRequest req = server.takeRequest();
-        String body = req.getBody().readUtf8();
+        String body = req.getBody().utf8();
         assertTrue(body.contains("odl-" + shaShort + "-dla-ocr"),
             "REQUEST_ID should include sha_short and module short name; body=" + body);
     }
@@ -59,14 +60,15 @@ class HancomAIClientRequestIdTest {
         String shaShort = sha256Hex(pdfBytes).substring(0, 12);
         client.setSourcePdfShaShort(shaShort); // test hook
 
-        server.enqueue(new MockResponse()
-            .setResponseCode(200)
-            .setBody("{\"SUCCESS\":true,\"RESULT\":[[{\"caption\":\"x\"}]]}"));
+        server.enqueue(new MockResponse.Builder()
+            .code(200)
+            .body("{\"SUCCESS\":true,\"RESULT\":[[{\"caption\":\"x\"}]]}")
+            .build());
 
         client.invokeCallImageCaptioning(new byte[]{1, 2, 3}, /*pageNum*/ 2, /*objectId*/ 7);
 
         RecordedRequest req = server.takeRequest();
-        String body = req.getBody().readUtf8();
+        String body = req.getBody().utf8();
         assertTrue(body.contains("odl-" + shaShort + "-p2-o7-caption"),
             "image REQUEST_ID format mismatch; body=" + body);
     }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomClientTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomClientTest.java
@@ -16,9 +16,9 @@
 package org.opendataloader.pdf.hybrid;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +60,7 @@ public class HancomClientTest {
     @AfterEach
     void tearDown() throws IOException {
         client.shutdown();
-        mockServer.shutdown();
+        mockServer.close();
     }
 
     @Test
@@ -75,18 +75,20 @@ public class HancomClientTest {
     void testConvertFullWorkflow() throws Exception {
         // Mock upload response (Hancom API format: data.fileId)
         String uploadResponse = "{\"codeNum\":0,\"code\":\"file.upload.success\",\"data\":{\"fileId\":\"test-file-123\",\"fileName\":\"test.pdf\"}}";
-        mockServer.enqueue(new MockResponse()
-            .setBody(uploadResponse)
-            .setHeader("Content-Type", "application/json"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .body(uploadResponse)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         // Mock visualinfo response
         String visualInfoResponse = createVisualInfoResponse();
-        mockServer.enqueue(new MockResponse()
-            .setBody(visualInfoResponse)
-            .setHeader("Content-Type", "application/json"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .body(visualInfoResponse)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         // Mock delete response
-        mockServer.enqueue(new MockResponse().setResponseCode(200));
+        mockServer.enqueue(new MockResponse.Builder().code(200).build());
 
         HybridRequest request = HybridRequest.allPages(SAMPLE_PDF_BYTES);
         HybridResponse response = client.convert(request);
@@ -99,19 +101,19 @@ public class HancomClientTest {
 
         // Verify upload request
         RecordedRequest uploadReq = mockServer.takeRequest(1, TimeUnit.SECONDS);
-        Assertions.assertTrue(uploadReq.getPath().contains("/v1/dl/files/upload"));
-        Assertions.assertTrue(uploadReq.getHeader("Content-Type").contains("multipart/form-data"));
+        Assertions.assertTrue(uploadReq.getTarget().contains("/v1/dl/files/upload"));
+        Assertions.assertTrue(uploadReq.getHeaders().get("Content-Type").contains("multipart/form-data"));
 
         // Verify visualinfo request
         RecordedRequest visualInfoReq = mockServer.takeRequest(1, TimeUnit.SECONDS);
-        Assertions.assertTrue(visualInfoReq.getPath().contains("/v1/dl/files/test-file-123/visualinfo"));
-        Assertions.assertTrue(visualInfoReq.getPath().contains("engine=pdf_ai_dl"));
-        Assertions.assertTrue(visualInfoReq.getPath().contains("dlaMode=ENABLED"));
-        Assertions.assertTrue(visualInfoReq.getPath().contains("ocrMode=FORCE"));
+        Assertions.assertTrue(visualInfoReq.getTarget().contains("/v1/dl/files/test-file-123/visualinfo"));
+        Assertions.assertTrue(visualInfoReq.getTarget().contains("engine=pdf_ai_dl"));
+        Assertions.assertTrue(visualInfoReq.getTarget().contains("dlaMode=ENABLED"));
+        Assertions.assertTrue(visualInfoReq.getTarget().contains("ocrMode=FORCE"));
 
         // Verify delete request
         RecordedRequest deleteReq = mockServer.takeRequest(1, TimeUnit.SECONDS);
-        Assertions.assertTrue(deleteReq.getPath().contains("/v1/dl/files/test-file-123"));
+        Assertions.assertTrue(deleteReq.getTarget().contains("/v1/dl/files/test-file-123"));
         Assertions.assertEquals("DELETE", deleteReq.getMethod());
     }
 
@@ -119,17 +121,19 @@ public class HancomClientTest {
     void testConvertWithCleanupOnProcessingError() throws Exception {
         // Mock upload response (Hancom API format: data.fileId)
         String uploadResponse = "{\"codeNum\":0,\"code\":\"file.upload.success\",\"data\":{\"fileId\":\"test-file-456\",\"fileName\":\"test.pdf\"}}";
-        mockServer.enqueue(new MockResponse()
-            .setBody(uploadResponse)
-            .setHeader("Content-Type", "application/json"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .body(uploadResponse)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         // Mock visualinfo error response
-        mockServer.enqueue(new MockResponse()
-            .setResponseCode(500)
-            .setBody("{\"error\": \"Internal server error\"}"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .code(500)
+            .body("{\"error\": \"Internal server error\"}")
+            .build());
 
         // Mock delete response - should still be called
-        mockServer.enqueue(new MockResponse().setResponseCode(200));
+        mockServer.enqueue(new MockResponse.Builder().code(200).build());
 
         HybridRequest request = HybridRequest.allPages(SAMPLE_PDF_BYTES);
 
@@ -145,18 +149,20 @@ public class HancomClientTest {
     void testConvertWithSpecificPages() throws Exception {
         // Mock upload response (Hancom API format: data.fileId)
         String uploadResponse = "{\"codeNum\":0,\"code\":\"file.upload.success\",\"data\":{\"fileId\":\"test-file-pages\",\"fileName\":\"test.pdf\"}}";
-        mockServer.enqueue(new MockResponse()
-            .setBody(uploadResponse)
-            .setHeader("Content-Type", "application/json"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .body(uploadResponse)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         // Mock visualinfo response
         String visualInfoResponse = createVisualInfoResponse();
-        mockServer.enqueue(new MockResponse()
-            .setBody(visualInfoResponse)
-            .setHeader("Content-Type", "application/json"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .body(visualInfoResponse)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         // Mock delete response
-        mockServer.enqueue(new MockResponse().setResponseCode(200));
+        mockServer.enqueue(new MockResponse.Builder().code(200).build());
 
         Set<Integer> pages = new HashSet<>();
         pages.add(1);
@@ -171,9 +177,10 @@ public class HancomClientTest {
     @Test
     void testUploadFailure() throws Exception {
         // Mock upload error
-        mockServer.enqueue(new MockResponse()
-            .setResponseCode(400)
-            .setBody("{\"error\": \"Invalid file format\"}"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .code(400)
+            .body("{\"error\": \"Invalid file format\"}")
+            .build());
 
         HybridRequest request = HybridRequest.allPages(SAMPLE_PDF_BYTES);
 
@@ -189,18 +196,20 @@ public class HancomClientTest {
     void testDeleteFailureIsIgnored() throws Exception {
         // Mock upload response (Hancom API format: data.fileId)
         String uploadResponse = "{\"codeNum\":0,\"code\":\"file.upload.success\",\"data\":{\"fileId\":\"test-file-del\",\"fileName\":\"test.pdf\"}}";
-        mockServer.enqueue(new MockResponse()
-            .setBody(uploadResponse)
-            .setHeader("Content-Type", "application/json"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .body(uploadResponse)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         // Mock visualinfo response
         String visualInfoResponse = createVisualInfoResponse();
-        mockServer.enqueue(new MockResponse()
-            .setBody(visualInfoResponse)
-            .setHeader("Content-Type", "application/json"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .body(visualInfoResponse)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         // Mock delete failure - should be ignored
-        mockServer.enqueue(new MockResponse().setResponseCode(404));
+        mockServer.enqueue(new MockResponse.Builder().code(404).build());
 
         HybridRequest request = HybridRequest.allPages(SAMPLE_PDF_BYTES);
         HybridResponse response = client.convert(request);
@@ -214,16 +223,18 @@ public class HancomClientTest {
     void testConvertAsync() throws Exception {
         // Mock responses (Hancom API format: data.fileId)
         String uploadResponse = "{\"codeNum\":0,\"code\":\"file.upload.success\",\"data\":{\"fileId\":\"async-file\",\"fileName\":\"test.pdf\"}}";
-        mockServer.enqueue(new MockResponse()
-            .setBody(uploadResponse)
-            .setHeader("Content-Type", "application/json"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .body(uploadResponse)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         String visualInfoResponse = createVisualInfoResponse();
-        mockServer.enqueue(new MockResponse()
-            .setBody(visualInfoResponse)
-            .setHeader("Content-Type", "application/json"));
+        mockServer.enqueue(new MockResponse.Builder()
+            .body(visualInfoResponse)
+            .addHeader("Content-Type", "application/json")
+            .build());
 
-        mockServer.enqueue(new MockResponse().setResponseCode(200));
+        mockServer.enqueue(new MockResponse.Builder().code(200).build());
 
         HybridRequest request = HybridRequest.allPages(SAMPLE_PDF_BYTES);
         HybridResponse response = client.convertAsync(request).get(10, TimeUnit.SECONDS);

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HealthCheckTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HealthCheckTest.java
@@ -18,8 +18,8 @@ package org.opendataloader.pdf.hybrid;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,16 +47,17 @@ class HealthCheckTest {
     @AfterEach
     void tearDown() throws IOException {
         if (server != null) {
-            server.shutdown();
+            server.close();
         }
     }
 
     @Test
     void testDoclingHealthCheckSucceeds() throws IOException {
         server.start();
-        server.enqueue(new MockResponse()
-            .setBody("{\"status\": \"ok\"}")
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body("{\"status\": \"ok\"}")
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         String baseUrl = stripTrailingSlash(server.url("").toString());
         DoclingFastServerClient client = new DoclingFastServerClient(
@@ -97,7 +98,7 @@ class HealthCheckTest {
     @Test
     void testDoclingHealthCheckFailsOnServerError() throws IOException {
         server.start();
-        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse.Builder().code(503).build());
 
         String baseUrl = stripTrailingSlash(server.url("").toString());
         DoclingFastServerClient client = new DoclingFastServerClient(
@@ -117,7 +118,7 @@ class HealthCheckTest {
     @Test
     void testHancomHealthCheckSucceeds() throws IOException {
         server.start();
-        server.enqueue(new MockResponse().setResponseCode(200));
+        server.enqueue(new MockResponse.Builder().code(200).build());
 
         String baseUrl = stripTrailingSlash(server.url("").toString());
         HancomClient client = new HancomClient(
@@ -183,9 +184,10 @@ class HealthCheckTest {
     @Test
     void testHancomFetchHealthReturnsParsedJsonOnSuccess() throws IOException {
         server.start();
-        server.enqueue(new MockResponse()
-            .setBody("{\"hardware\":{\"cpu\":\"Xeon\"},\"backend_version\":\"v1\"}")
-            .addHeader("Content-Type", "application/json"));
+        server.enqueue(new MockResponse.Builder()
+            .body("{\"hardware\":{\"cpu\":\"Xeon\"},\"backend_version\":\"v1\"}")
+            .addHeader("Content-Type", "application/json")
+            .build());
 
         String baseUrl = stripTrailingSlash(server.url("").toString());
         HancomAIClient client = new HancomAIClient(
@@ -200,7 +202,7 @@ class HealthCheckTest {
     @Test
     void testHancomFetchHealthReturnsNullOnNotFound() throws IOException {
         server.start();
-        server.enqueue(new MockResponse().setResponseCode(404));
+        server.enqueue(new MockResponse.Builder().code(404).build());
 
         String baseUrl = stripTrailingSlash(server.url("").toString());
         HancomAIClient client = new HancomAIClient(
@@ -213,9 +215,10 @@ class HealthCheckTest {
     @Test
     void testHancomFetchHealthReturnsNullOnNonJsonBody() throws IOException {
         server.start();
-        server.enqueue(new MockResponse()
-            .setBody("not json at all")
-            .addHeader("Content-Type", "text/plain"));
+        server.enqueue(new MockResponse.Builder()
+            .body("not json at all")
+            .addHeader("Content-Type", "text/plain")
+            .build());
 
         String baseUrl = stripTrailingSlash(server.url("").toString());
         HancomAIClient client = new HancomAIClient(

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -63,6 +63,7 @@
         <jackson.databind.version>2.22.0</jackson.databind.version>
         <junit.jupiter.version>6.1.0</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>
+        <okhttp.version>5.4.0</okhttp.version>
         <commons.cli.version>1.11.0</commons.cli.version>
         <maven-compiler.plugin.version>3.15.0</maven-compiler.plugin.version>
         <flatten.plugin.version>1.7.3</flatten.plugin.version>
@@ -84,6 +85,20 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--
+              okhttp BOM keeps okhttp-jvm and mockwebserver3 lock-stepped at one
+              version. Note: okhttp 5's plain `okhttp` artifact is an empty
+              Kotlin-Multiplatform metadata jar, so modules must still depend on
+              the `okhttp-jvm` coordinate explicitly (the BOM manages the version,
+              not the artifact selection).
+            -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-bom</artifactId>
+                <version>${okhttp.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.verapdf</groupId>
                 <artifactId>wcag-algorithms</artifactId>


### PR DESCRIPTION
## Objective

Migrate `okhttp` from 4.12.0 to 5.4.0 (a breaking major) across the hybrid-backend HTTP clients and their tests. This supersedes the Dependabot bumps #592 (okhttp) and #593 (mockwebserver), which could not be merged as-is: the major bump broke the build and 5 hybrid tests, so it needed a real migration rather than a version flip.

## Approach

**Dependencies (`java/pom.xml`, `core/pom.xml`)**
- Import `com.squareup.okhttp3:okhttp-bom` in the parent `dependencyManagement` (via a new `${okhttp.version}` property) so `okhttp-jvm` and `mockwebserver3` stay version-locked, matching the repo's centralized-version convention.
- Depend on **`okhttp-jvm`** (not `okhttp`): okhttp 5 publishes the plain `okhttp` artifact as an empty Kotlin-Multiplatform metadata jar — the JVM classes live in `okhttp-jvm`, and Maven cannot resolve the JVM variant from Gradle module metadata. Without this, the `cli` module failed at runtime with `NoClassDefFound okhttp3/RequestBody`.
- `mockwebserver` 4.12.0 → `mockwebserver3` (test scope).

**Tests (mechanical API migration, 5 files)**
- `okhttp3.mockwebserver` → `mockwebserver3`
- `MockResponse` is now immutable → `new MockResponse.Builder().code().body().addHeader().build()`
- `MockWebServer.shutdown()` → `close()`
- `RecordedRequest.getPath()` → `getTarget()`, `getBody().readUtf8()` → `getBody().utf8()`, `getHeader(n)` → `getHeaders().get(n)`

## Evidence

- **Full multi-module build green**: core **742 tests**, cli **29 tests**, **0 failures** (`mvn test` on core + cli).
- The 5 hybrid tests that previously failed with `NoClassDefFound okhttp3/mockwebserver/MockWebServer` now pass.
- Reviewed by 3 independent agents (API completeness, build/dependency config, regression risk) and Codex — no correctness/build/test issues found. Build-config review prompted the `okhttp-bom` + centralized-version improvement now included.

Closes #592, closes #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded OkHTTP dependency to version 5.4.0.
  * Migrated test infrastructure from legacy mockwebserver to mockwebserver3 API.
  * Updated Maven dependency management to use OkHTTP Bill of Materials for improved version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->