### PR TITLE
Use escapeHtmlAttribute for page separator in html

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/html/HtmlGenerator.java
@@ -104,7 +104,7 @@ public class HtmlGenerator implements Closeable {
         this.htmlFileName = pdfFileName.substring(0, pdfFileName.length() - 3) + "html";
         this.htmlFilePath = Path.of(config.getOutputFolder(), htmlFileName);
         this.htmlWriter = new FileWriter(htmlFilePath.toFile(), StandardCharsets.UTF_8);
-        this.htmlPageSeparator = config.getHtmlPageSeparator();
+        this.htmlPageSeparator = escapeHtmlAttribute(config.getHtmlPageSeparator());
         this.selectedPageNumbers = new HashSet<>(config.getPageNumbers());
         this.embedImages = config.isEmbedImages();
         this.imageFormat = config.getImageFormat();

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PageSeparatorIntegrationTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/PageSeparatorIntegrationTest.java
@@ -171,7 +171,7 @@ class PageSeparatorIntegrationTest {
         assertTrue(Files.exists(htmlOutput), "HTML output should exist");
 
         String htmlContent = Files.readString(htmlOutput);
-        assertTrue(htmlContent.contains("<hr class=\"page-break\"/>"), "HTML should contain the page separator");
+        assertTrue(htmlContent.contains("&lt;hr class=&quot;page-break&quot;/&gt;"), "HTML should contain the page separator");
     }
 
     @Test
@@ -188,7 +188,7 @@ class PageSeparatorIntegrationTest {
         assertTrue(Files.exists(htmlOutput), "HTML output should exist");
 
         String htmlContent = Files.readString(htmlOutput);
-        assertTrue(htmlContent.contains("<div class=\"page\" data-page=\"1\">"), "HTML should contain page separator with page number 1");
+        assertTrue(htmlContent.contains("&lt;div class=&quot;page&quot; data-page=&quot;1&quot;&gt;"), "HTML should contain page separator with page number 1");
     }
 
     @Test
@@ -272,7 +272,7 @@ class PageSeparatorIntegrationTest {
     }
 
     private static String htmlMarker(int page) {
-        return "data-page=\"" + page + "\"";
+        return "data-page=&quot;" + page + "&quot;";
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML page separator handling to properly escape special characters in generated documents, ensuring correct rendering and preventing potential parsing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->