### PR TITLE
Fix placing of middle content between lists

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -511,7 +511,7 @@ public class ListProcessor {
     }
 
     private static void addFirstLBodyToList(PDFList currentList, SemanticTextNode middleContent) {
-        ListItem listItem = new ListItem(middleContent.getBoundingBox(), middleContent.getRecognizedStructureId());
+        ListItem listItem = new ListItem(new BoundingBox(), middleContent.getRecognizedStructureId());
         for (TextColumn textColumn : middleContent.getColumns()) {
             listItem.add(textColumn.getLines());
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -455,8 +455,7 @@ public class ListProcessor {
                         if (previousList.getNextList() == null && currentList.getPreviousList() == null) {
                             if (isNeighborLists(previousList, currentList, middleContent)) {
                                 if (middleContent != null) {
-                                    pageContents.set(middleContent.getIndex(), null);
-                                    addMiddleContentToList(previousList, currentList, middleContent);
+                                    addMiddleContentToList(previousList, currentList, middleContent, pageContents);
                                 }
                                 if (Objects.equals(previousList.getPageNumber(), currentList.getPageNumber()) &&
                                         BoundingBox.areHorizontalOverlapping(previousList.getBoundingBox(), currentList.getBoundingBox())) {
@@ -469,8 +468,7 @@ public class ListProcessor {
                             }
                         } else if (Objects.equals(previousList.getNextListId(), currentList.getRecognizedStructureId())) {
                             if (middleContent != null && isMiddleContentPartOfList(previousList, middleContent, currentList)) {
-                                pageContents.set(middleContent.getIndex(), null);
-                                addMiddleContentToList(previousList, currentList, middleContent);
+                                addMiddleContentToList(previousList, currentList, middleContent, pageContents);
                             }
                         }
                     }
@@ -495,7 +493,7 @@ public class ListProcessor {
         contents.replaceAll(DocumentProcessor::removeNullObjectsFromList);
     }
 
-    private static void addMiddleContentToList(PDFList previousList, PDFList currentList, SemanticTextNode middleContent) {
+    private static void addMiddleContentToList(PDFList previousList, PDFList currentList, SemanticTextNode middleContent, List<IObject> pageContents) {
         ListItem lastListItem = previousList.getLastListItem();
         if (Objects.equals(lastListItem.getPageNumber(), middleContent.getPageNumber()) &&
                 BoundingBox.areHorizontalOverlapping(lastListItem.getBoundingBox(), middleContent.getBoundingBox())) {
@@ -503,28 +501,21 @@ public class ListProcessor {
                 lastListItem.add(textColumn.getLines());
             }
             previousList.getBoundingBox().union(middleContent.getBoundingBox());
+            pageContents.set(middleContent.getIndex(), null);
         } else {
-            addFirstLBodyToList(currentList, middleContent);
+            if (middleContent.getTopY() > currentList.getTopY()) {
+                addFirstLBodyToList(currentList, middleContent);
+                pageContents.set(middleContent.getIndex(), null);
+            }
         }
     }
 
     private static void addFirstLBodyToList(PDFList currentList, SemanticTextNode middleContent) {
-        BoundingBox contentBBox = middleContent.getBoundingBox();
-        ListItem listItem = new ListItem(contentBBox, middleContent.getRecognizedStructureId());
+        ListItem listItem = new ListItem(middleContent.getBoundingBox(), middleContent.getRecognizedStructureId());
         for (TextColumn textColumn : middleContent.getColumns()) {
             listItem.add(textColumn.getLines());
         }
-
-        int insertIndex = 0;
-        for (int i = 0; i < currentList.getNumberOfListItems(); i++) {
-            ListItem existingItem = currentList.getListItems().get(i);
-            BoundingBox existingBBox = existingItem.getBoundingBox();
-            if (contentBBox.getTopY() > existingBBox.getTopY()) {
-                break;
-            }
-            insertIndex++;
-        }
-        currentList.add(insertIndex, listItem);
+        currentList.add(0, listItem);
     }
 
     public static boolean isNeighborLists(PDFList previousList, PDFList currentList, SemanticTextNode middleContent) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -509,11 +509,22 @@ public class ListProcessor {
     }
 
     private static void addFirstLBodyToList(PDFList currentList, SemanticTextNode middleContent) {
-        ListItem listItem = new ListItem(new BoundingBox(), middleContent.getRecognizedStructureId());
+        BoundingBox contentBBox = middleContent.getBoundingBox();
+        ListItem listItem = new ListItem(contentBBox, middleContent.getRecognizedStructureId());
         for (TextColumn textColumn : middleContent.getColumns()) {
             listItem.add(textColumn.getLines());
         }
-        currentList.add(0, listItem);
+
+        int insertIndex = 0;
+        for (int i = 0; i < currentList.getNumberOfListItems(); i++) {
+            ListItem existingItem = currentList.getListItems().get(i);
+            BoundingBox existingBBox = existingItem.getBoundingBox();
+            if (contentBBox.getTopY() > existingBBox.getTopY()) {
+                break;
+            }
+            insertIndex++;
+        }
+        currentList.add(insertIndex, listItem);
     }
 
     public static boolean isNeighborLists(PDFList previousList, PDFList currentList, SemanticTextNode middleContent) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list extraction/order in PDF processing by refining how “middle” elements are merged into surrounding list items and how their vertical position affects insertion. This prevents incorrect handling of intermediate content and results in more accurate, sequential list item extraction from PDFs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->