### PR TITLE
fix(ci-verify): fail closed on missing registry and broken --help

### DIFF
--- a/verification/ci-verify.py
+++ b/verification/ci-verify.py
@@ -327,8 +327,11 @@ def check_option_coverage() -> None:
     """Read options.json and verify all non-hybrid options are in COVERED_OPTIONS."""
     options_path = os.path.join(REPO_ROOT, "options.json")
     if not os.path.exists(options_path):
-        print(f"WARNING: options.json not found at {options_path}, skipping coverage check")
-        return
+        # Fail closed: this is the authoritative option registry for the
+        # coverage gate. Skipping when it is absent would let CI pass with
+        # coverage checking silently disabled (e.g. if the path regresses).
+        print(f"ERROR: options.json not found at {options_path}; cannot verify option coverage")
+        sys.exit(1)
 
     with open(options_path, "r", encoding="utf-8") as fh:
         data = json.load(fh)
@@ -375,12 +378,17 @@ def _find_image_files(directory: str) -> list[str]:
 # Encoding safety helpers
 # ---------------------------------------------------------------------------
 
-def _verify_help_cp949_safe(command: list[str]) -> bool | None:
+def _verify_help_cp949_safe(command: list[str], required: bool = False) -> bool | None:
     """Run `command --help` with PYTHONIOENCODING=cp949 and check for UnicodeEncodeError.
 
     Returns True (PASS), False (FAIL — UnicodeEncodeError detected), or None (SKIP).
     Korean Windows console uses cp949; non-ASCII chars (em-dash etc.) in help text
     crash argparse output when stdout codec cannot encode them.
+
+    When ``required`` is True the CLI is known to be installed, so a hang
+    (TimeoutExpired) or any execution failure is a real regression and is
+    reported as FAIL rather than swallowed into a SKIP — otherwise a broken
+    --help would pass the release gate unnoticed.
     """
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "cp949"
@@ -389,11 +397,11 @@ def _verify_help_cp949_safe(command: list[str]) -> bool | None:
             command + ["--help"],
             env=env,
             capture_output=True,
-            timeout=30,
+            timeout=60,
         )
     except Exception as exc:
         print(f"       [cp949 help] exception: {exc}")
-        return None
+        return False if required else None
 
     stderr_text = result.stderr.decode("utf-8", errors="replace")
     stdout_text = result.stdout.decode("utf-8", errors="replace")
@@ -423,8 +431,9 @@ def _verify_hybrid_help_cp949_safe() -> bool | None:
         if "Missing dependencies" in stderr or "ImportError" in stderr:
             print("       [cp949 help] hybrid deps missing, skipping")
             return None
+    # Availability is confirmed above; from here a failure is a real regression.
     return _verify_help_cp949_safe(
-        [sys.executable, "-m", "opendataloader_pdf.hybrid_server"]
+        [sys.executable, "-m", "opendataloader_pdf.hybrid_server"], required=True
     )
 
 
@@ -1483,7 +1492,7 @@ def main() -> None:
     # ------------------------------------------------------------------
     print("\n--- --help cp949 encoding safety ---")
     record("--help cp949 safe (main)", _verify_help_cp949_safe(
-        [sys.executable, "-m", "opendataloader_pdf"]
+        [sys.executable, "-m", "opendataloader_pdf"], required=True
     ))
     record("--help cp949 safe (hybrid)", _verify_hybrid_help_cp949_safe())
 


### PR DESCRIPTION
## Objective
The verification harness (`verification/ci-verify.py`) gates the PR and release workflows, but two paths let it pass when it should not — exactly the silent-pass class this harness exists to prevent:

- If `options.json` (the authoritative option registry) is absent, `check_option_coverage` prints a warning and returns, so the coverage gate is silently disabled and CI goes green with option coverage unchecked.
- If the main CLI's `--help` hangs (`TimeoutExpired`) or cannot run, the cp949 safety check is swallowed into a SKIP, so a broken `--help` passes the release gate unnoticed.

These were raised by CodeRabbit on #580 as outside-diff-range comments and not addressed before merge.

## Approach
Make both fail closed.

- `check_option_coverage`: exit non-zero when `options.json` is missing instead of warning and returning. A missing registry means coverage *cannot* be verified — that is a failure, not a skip. The file is committed at repo root, so this never fires on a normal checkout; it only catches a real regression (deleted/moved file, broken `REPO_ROOT`).
- `_verify_help_cp949_safe` gains a `required` flag. The main CLI (always installed) and the hybrid CLI (only *after* its availability is confirmed) pass `required=True`, so a timeout or exec failure becomes FAIL instead of SKIP. The hybrid "extras not installed → SKIP" path is unchanged — that absence is legitimate (CI installs the plain wheel). The `--help` timeout is raised 30s→60s to avoid false failures on slow runners.

## Evidence
Local run on macOS, fresh JAR build + wheel install into an isolated venv:

| Scenario | Expected | Actual |
|----------|----------|--------|
| `options.json` removed | coverage check fails the run | `check_option_coverage` → `SystemExit(1)` with ERROR (was: silent skip) |
| `_verify_help_cp949_safe(missing_cmd, required=True)` | FAIL | returns `False` |
| `_verify_help_cp949_safe(missing_cmd, required=False)` | SKIP | returns `None` |
| Full suite, happy path | unchanged | 61 passed, 0 failed, 1 skipped, exit 0 (main + hybrid cp949 `--help` still PASS) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened CI verification gates for improved reliability and stricter validation enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->