### PR TITLE
Fix null value of the StaticResources.getDocument in threads

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -249,6 +249,7 @@ public class DocumentProcessor {
 
         // Capture ALL ThreadLocal state from main thread for propagation to workers
         final var document = StaticContainers.getDocument();
+        final var pdDocument = StaticResources.getDocument();
         final var tableBordersCollection = StaticContainers.getTableBordersCollection();
         final var accumulatedNodeMapper = StaticContainers.getAccumulatedNodeMapper();
         final var objectKeyMapper = StaticContainers.getObjectKeyMapper();
@@ -265,6 +266,7 @@ public class DocumentProcessor {
 
         // Runnable that propagates ThreadLocal state to the current (worker) thread
         final Runnable propagateState = () -> {
+            StaticResources.setDocument(pdDocument);
             // veraPDF StaticContainers
             StaticContainers.setDocument(document);
             StaticContainers.setTableBordersCollection(tableBordersCollection);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a multi-threaded PDF processing issue where worker threads could end up using inconsistent document instances.
  * Worker-side state propagation now ensures the same underlying PDF document is available consistently during processing, improving reliability when tasks run in parallel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->