### PR TITLE
docs(sanitize): document that built-in rules follow only HIPAA Safe Harbor subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,12 +349,16 @@ PDFs can contain hidden prompt injection attacks. OpenDataLoader automatically f
 - Off-page content
 - Suspicious invisible layers
 
-To sanitize sensitive data (emails, URLs, phone numbers → placeholders), enable it explicitly:
+To sanitize sensitive data (emails, URLs, phone numbers, IPs, MACs, credit cards → placeholders), enable it explicitly:
 
 ```bash
 # Batch all files in one call — each invocation spawns a JVM process, so repeated calls are slow
 opendataloader-pdf file1.pdf file2.pdf folder/ --sanitize
 ```
+
+The built-in rules target identifiers whose format is internationally recognizable (emails, phone numbers, URLs, IPs, MACs, credit-card shapes). They also mask some generic long-digit/ID tokens, which can over-mask ordinary numbers. Anything else is not sanitized by default.
+
+> **`--sanitize` is best-effort pattern matching, not compliance-grade de-identification.** It does not detect names, addresses, dates, or SSNs, does not validate matches (there is no credit-card checksum), and does not guarantee removal of every email/phone/card. Do not rely on it to satisfy HIPAA, GDPR, or any regulatory requirement — review the output before sharing.
 
 [AI Safety Guide](https://opendataloader.org/docs/ai-safety)
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/FilterConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/FilterConfig.java
@@ -33,7 +33,22 @@ public class FilterConfig {
     private boolean filterSensitiveData = false;
     private final List<SanitizationRule> filterRules;
 
-    /** Default rules */
+    /**
+     * Default sanitization rules. The built-in set targets identifiers whose
+     * format is internationally recognizable, e.g. email, phone number, URL, IP,
+     * MAC, and credit-card number shapes (illustrative, not exhaustive). It also
+     * masks some generic long-digit and alphanumeric ID tokens, which may
+     * over-mask ordinary numbers such as quantities or order IDs.
+     *
+     * <p><b>This is best-effort pattern matching, not compliance-grade
+     * de-identification.</b> It does not detect names, addresses, dates, or SSNs,
+     * does not validate matches (e.g. no credit-card checksum), and does not
+     * guarantee removal of every email/phone/card. Do not rely on it to satisfy
+     * HIPAA, GDPR, or any regulatory requirement; review output before sharing.
+     *
+     * <p>Identifiers outside this set are not sanitized by default; add them as
+     * custom rules via {@link #addFilterRule(String, String)}.
+     */
     private void initializeDefaultRules() {
         filterRules.add(new SanitizationRule(
             Pattern.compile("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"),

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -94,7 +94,10 @@ public class CLIOptions {
     // ===== Sanitize =====
     private static final String SANITIZE_LONG_OPTION = "sanitize";
     private static final String SANITIZE_DESC = "Enable sensitive data sanitization. "
-            + "Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders";
+            + "Replaces recognizable patterns (emails, phone numbers, IPs, MACs, credit-card shapes, URLs, "
+            + "and some long-digit/ID tokens) with placeholders. "
+            + "Best-effort pattern matching, not compliance-grade de-identification: it misses names, "
+            + "addresses, dates, and SSNs, and may over-mask ordinary numbers; review output before sharing";
 
     // ===== Keep Line Breaks =====
     private static final String KEEP_LINE_BREAKS_LONG_OPTION = "keep-line-breaks";

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -12,7 +12,7 @@ export function registerCliOptions(program: Command): void {
   program.option('-f, --format <value>', 'Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.');
   program.option('-q, --quiet', 'Suppress console logging output');
   program.option('--content-safety-off <value>', 'Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg');
-  program.option('--sanitize', 'Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders');
+  program.option('--sanitize', 'Enable sensitive data sanitization. Replaces recognizable patterns (emails, phone numbers, IPs, MACs, credit-card shapes, URLs, and some long-digit/ID tokens) with placeholders. Best-effort pattern matching, not compliance-grade de-identification: it misses names, addresses, dates, and SSNs, and may over-mask ordinary numbers; review output before sharing');
   program.option('--keep-line-breaks', 'Preserve original line breaks in extracted text');
   program.option('--replace-invalid-chars <value>', 'Replacement character for invalid/unrecognized characters. Default: space');
   program.option('--use-struct-tree', 'Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -15,7 +15,7 @@ export interface ConvertOptions {
   quiet?: boolean;
   /** Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg */
   contentSafetyOff?: string | string[];
-  /** Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders */
+  /** Enable sensitive data sanitization. Replaces recognizable patterns (emails, phone numbers, IPs, MACs, credit-card shapes, URLs, and some long-digit/ID tokens) with placeholders. Best-effort pattern matching, not compliance-grade de-identification: it misses names, addresses, dates, and SSNs, and may over-mask ordinary numbers; review output before sharing */
   sanitize?: boolean;
   /** Preserve original line breaks in extracted text */
   keepLineBreaks?: boolean;

--- a/options.json
+++ b/options.json
@@ -46,7 +46,7 @@
       "type": "boolean",
       "required": false,
       "default": false,
-      "description": "Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders"
+      "description": "Enable sensitive data sanitization. Replaces recognizable patterns (emails, phone numbers, IPs, MACs, credit-card shapes, URLs, and some long-digit/ID tokens) with placeholders. Best-effort pattern matching, not compliance-grade de-identification: it misses names, addresses, dates, and SSNs, and may over-mask ordinary numbers; review output before sharing"
     },
     {
       "name": "keep-line-breaks",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -61,7 +61,7 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "type": "boolean",
         "required": False,
         "default": False,
-        "description": "Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders",
+        "description": "Enable sensitive data sanitization. Replaces recognizable patterns (emails, phone numbers, IPs, MACs, credit-card shapes, URLs, and some long-digit/ID tokens) with placeholders. Best-effort pattern matching, not compliance-grade de-identification: it misses names, addresses, dates, and SSNs, and may over-mask ordinary numbers; review output before sharing",
     },
     {
         "name": "keep-line-breaks",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -53,7 +53,7 @@ def convert(
         format: Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.
         quiet: Suppress console logging output
         content_safety_off: Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg
-        sanitize: Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders
+        sanitize: Enable sensitive data sanitization. Replaces recognizable patterns (emails, phone numbers, IPs, MACs, credit-card shapes, URLs, and some long-digit/ID tokens) with placeholders. Best-effort pattern matching, not compliance-grade de-identification: it misses names, addresses, dates, and SSNs, and may over-mask ordinary numbers; review output before sharing
         keep_line_breaks: Preserve original line breaks in extracted text
         replace_invalid_chars: Replacement character for invalid/unrecognized characters. Default: space
         use_struct_tree: Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality


### PR DESCRIPTION
## Objective
When users ask why `--sanitize` does not mask SSNs, national IDs, or other identifiers (as raised in #550, and previously attempted in the reverted #510), nothing in the code, CLI help, or docs stated what the built-in rules cover or how far they can be trusted. Contributors kept re-raising "add more patterns", and — worse — a user could assume `--sanitize` produces compliance-grade de-identified output.

Relates to [opendataloader-project/opendataloader-pdf#550](https://github.com/opendataloader-project/opendataloader-pdf/issues/550)

## Approach
Document, at every layer (FilterConfig Javadoc, CLIOptions description, README — with `npm run sync` propagating to the Python/Node/JSON bindings):

- **What the built-in rules actually are** — recognizable-format patterns (emails, phones, URLs, IPs, MACs, credit-card shapes) plus some generic long-digit/ID tokens. Loosely inspired by a few machine-detectable HIPAA Safe Harbor categories — **not** a claim of following the standard.
- **What they are not** — a best-effort caveat stating this is pattern matching, not compliance-grade de-identification: it misses names/addresses/dates/SSNs, does no validation (no credit-card checksum), may over-mask ordinary numbers, and output should be reviewed before sharing.
- Custom-rule guidance (`addFilterRule`) is kept in the **Java Javadoc only**, since that API is not exposed to the bindings.

No behavior change — documentation only.

## Evidence
Two independent reviews (code-review + security-lens) flagged the original wording as overstating protection ("follows HIPAA Safe Harbor standard", "checksum-verifiable credit cards"). Both concerns were addressed. Verified across all layers after `npm run sync`:

| Check | Result |
|-------|--------|
| `"checksum-verifiable"` (false claim — no Luhn in code) | ✅ removed everywhere |
| Hard `"follows ... HIPAA ... standard"` claim | ✅ softened to "loosely inspired by" |
| Best-effort / not-compliance-grade caveat | ✅ present in Javadoc, README, options.json, Python, Node |
| `addFilterRule` guidance leaked into CLI/Python/Node | ✅ no — Java Javadoc only |
| SANITIZE_DESC synced consistently across 5 generated files | ✅ byte-identical |
| ReDoS in documented patterns / secrets in diff | ✅ none |
| `mvn -pl opendataloader-pdf-core compile` + core tests | ✅ 0 failures, 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the “AI Safety: Prompt Injection Protection” guidance for `--sanitize`, detailing additional masked patterns (including MACs, credit-card–shaped identifiers, URLs, and some long digit/ID tokens).
  * Clarified `--sanitize` is best-effort pattern matching (not compliance-grade de-identification), may over-mask ordinary numbers, and may miss sensitive categories such as names, addresses, dates, and SSNs.
  * Added stronger warnings to review output before sharing and updated scope notes to align with a HIPAA Safe Harbor machine-detectable subset.
  * Refreshed the same help/option descriptions across CLI/docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->