### PR TITLE
Tagged PDF processing. Calculate list label length

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
@@ -215,6 +215,7 @@ public class TaggedDocumentProcessor {
     private static ListItem processListItem(INode node) {
         ListItem listItem = new ListItem(new MultiBoundingBox(), null);
         List<IObject> contents = new ArrayList<>();
+        listItem.setLabelLength(calculateLabelLength(node));
         processChildContents(node, contents);
         contents = TextLineProcessor.processTextLines(contents);
         for (IObject content : contents) {
@@ -226,6 +227,29 @@ public class TaggedDocumentProcessor {
         }
         listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
         return listItem;
+    }
+
+    private static int calculateLabelLength(INode listItem) {
+        List<INode> children = listItem.getChildren();
+        if (!children.isEmpty()) {
+            INode firstChild = children.get(0);
+            if (firstChild.getInitialSemanticType() == SemanticType.LIST_LABEL) {
+                return getTextChunksLength(firstChild);
+            }
+        }
+        return 0;
+    }
+
+    private static int getTextChunksLength(INode node) {
+        int result = 0;
+        for (INode child : node.getChildren()) {
+            if (child instanceof SemanticSpan) {
+                result += (((SemanticSpan)child).getColumns().get(0).getFirstLine().getFirstTextChunk().getValue().length());
+            } else {
+                result += getTextChunksLength(child);
+            }
+        }
+        return result;
     }
 
     private static void processTable(INode tableNode) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list formatting in tagged PDF output by calculating list item label length more accurately.
  * Helps preserve correct indentation and spacing for list items, especially when labels contain nested or styled text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->