### PR TITLE
fix(markdown): strip duplicated bullet markers from list items

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -21,6 +21,7 @@ import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticPicture;
 import org.opendataloader.pdf.utils.Base64ImageUtils;
+import org.opendataloader.pdf.utils.BulletedParagraphUtils;
 import org.opendataloader.pdf.utils.GeneratorUtils;
 import org.opendataloader.pdf.utils.ImagesUtils;
 import org.opendataloader.pdf.utils.OutputType;
@@ -288,11 +289,13 @@ public class MarkdownGenerator implements Closeable {
 
     protected void writeList(PDFList list) throws IOException {
         for (ListItem item : list.getListItems()) {
+            String itemText = GeneratorUtils.getTextFromLines(item.getLines(), OutputType.MD);
             if (!isInsideTable()) {
                 markdownWriter.write(MarkdownSyntax.LIST_ITEM);
                 markdownWriter.write(MarkdownSyntax.SPACE);
+                itemText = stripRedundantBulletLabel(itemText);
             }
-            markdownWriter.write(getCorrectMarkdownString(GeneratorUtils.getTextFromLines(item.getLines(), OutputType.MD)));
+            markdownWriter.write(getCorrectMarkdownString(itemText));
             writeLineBreak();
 
             List<IObject> itemContents = item.getContents();
@@ -301,6 +304,33 @@ public class MarkdownGenerator implements Closeable {
                 writeContents(itemContents, false);
             }
         }
+    }
+
+    /**
+     * Removes a leading bullet glyph (and the whitespace separating it from the
+     * content) from list item text. {@code writeList} already emits the Markdown
+     * {@code - } marker, so a bullet carried over from the source PDF would render
+     * as a doubled marker like {@code - •} (#584). Only symbol bullets followed by
+     * whitespace are stripped: ordered labels ("1.", "a)") carry numbering
+     * information, and a leading label character with no separator ("-5") may be
+     * real content.
+     */
+    static String stripRedundantBulletLabel(String text) {
+        if (text == null || text.length() < 2) {
+            return text;
+        }
+        if (!BulletedParagraphUtils.isSymbolLabel(text.charAt(0)) || !isInlineWhitespace(text.charAt(1))) {
+            return text;
+        }
+        int contentStart = 2;
+        while (contentStart < text.length() && isInlineWhitespace(text.charAt(contentStart))) {
+            contentStart++;
+        }
+        return text.substring(contentStart);
+    }
+
+    private static boolean isInlineWhitespace(char character) {
+        return character == ' ' || character == '\t' || character == '\u00A0';
     }
 
     protected void writeTOC(SemanticTOC toc) throws IOException {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/BulletedParagraphUtils.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/BulletedParagraphUtils.java
@@ -81,8 +81,7 @@ public class BulletedParagraphUtils {
         if (value == null || value.isEmpty()) {
             return false;
         }
-        char character = value.charAt(0);
-        if (POSSIBLE_LABELS.indexOf(character) != -1) {
+        if (isSymbolLabel(value.charAt(0))) {
             return true;
         }
         if (textLine.getConnectedLineArtLabel() != null) {
@@ -94,6 +93,16 @@ public class BulletedParagraphUtils {
             }
         }
         return false;
+    }
+
+    /**
+     * Checks if a character is one of the recognized symbol bullet labels.
+     *
+     * @param character the character to check
+     * @return true if the character is a symbol bullet label, false otherwise
+     */
+    public static boolean isSymbolLabel(char character) {
+        return POSSIBLE_LABELS.indexOf(character) != -1;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
@@ -180,4 +180,62 @@ public class MarkdownGeneratorTest {
     void testFormatLinkDestination_handlesNull() {
         assertNull(MarkdownGenerator.formatMarkdownLinkDestination(null));
     }
+
+    // ----- stripRedundantBulletLabel (#584) -----
+    //
+    // writeList() emits its own `- ` marker for every list item, but the item
+    // text extracted from the PDF still starts with the original bullet glyph,
+    // producing doubled markers like `- • Configuration Files`.
+
+    @ParameterizedTest
+    @ValueSource(strings = {"•", "●", "◦", "▪", "‣", "∙", "○", "◆", "➤", "✓", "-", "*", "+"})
+    void testStripBulletLabel_stripsLeadingBulletFollowedBySpace(String bullet) {
+        assertEquals("Configuration Files",
+                MarkdownGenerator.stripRedundantBulletLabel(bullet + " Configuration Files"),
+                "Bullet '" + bullet + "' followed by a space should be stripped");
+    }
+
+    @Test
+    void testStripBulletLabel_stripsAllWhitespaceAfterBullet() {
+        assertEquals("item", MarkdownGenerator.stripRedundantBulletLabel("•   item"));
+        assertEquals("item", MarkdownGenerator.stripRedundantBulletLabel("•\titem"));
+        // Non-breaking space is common in extracted PDF text.
+        assertEquals("item", MarkdownGenerator.stripRedundantBulletLabel("\u2022\u00A0item"));
+    }
+
+    @Test
+    void testStripBulletLabel_keepsBulletNotFollowedByWhitespace() {
+        // Without a separating space the leading char may be real content
+        // (negative numbers, dashed identifiers), so leave it untouched.
+        assertEquals("-5 degrees", MarkdownGenerator.stripRedundantBulletLabel("-5 degrees"));
+        assertEquals("*emphasis*", MarkdownGenerator.stripRedundantBulletLabel("*emphasis*"));
+    }
+
+    @Test
+    void testStripBulletLabel_keepsNumberedAndLetteredLabels() {
+        // Ordered labels carry meaning (numbering); only symbol bullets are
+        // redundant next to the `- ` marker.
+        assertEquals("1. First step", MarkdownGenerator.stripRedundantBulletLabel("1. First step"));
+        assertEquals("a) Option", MarkdownGenerator.stripRedundantBulletLabel("a) Option"));
+        assertEquals("1.1.1 Software", MarkdownGenerator.stripRedundantBulletLabel("1.1.1 Software"));
+    }
+
+    @Test
+    void testStripBulletLabel_keepsPlainText() {
+        assertEquals("Configuration Files",
+                MarkdownGenerator.stripRedundantBulletLabel("Configuration Files"));
+    }
+
+    @Test
+    void testStripBulletLabel_stripsOnlyFirstLineOfMultilineItem() {
+        assertEquals("first line\n• second line",
+                MarkdownGenerator.stripRedundantBulletLabel("• first line\n• second line"));
+    }
+
+    @Test
+    void testStripBulletLabel_handlesNullAndEmpty() {
+        assertNull(MarkdownGenerator.stripRedundantBulletLabel(null));
+        assertEquals("", MarkdownGenerator.stripRedundantBulletLabel(""));
+        assertEquals("•", MarkdownGenerator.stripRedundantBulletLabel("•"));
+    }
 }


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #584

## Problem

Markdown generated from PDFs with bulleted lists contains doubled list markers — the exporter's `- ` plus the bullet glyph carried over from the source PDF:

```markdown
- • Core Emulator
- • Core Test
- • O-CU Test
```

Reported with hybrid backends (docling-fast, hancom-ai), but it reproduces with the pure Java path as well (no `--hybrid` needed), confirming the comments on the issue: the bug is backend-independent and lives in the Markdown serialization layer.

## Root cause

`MarkdownGenerator.writeList()` emits its own `- ` marker for every list item, but the item text built from the extracted `TextLine`s still starts with the original bullet glyph (`•`, `●`, `▪`, …). The two markers end up side by side.

## Fix

Strip a leading symbol bullet (plus the whitespace separating it from the content) from the item text before writing it, since `- ` already marks the item. The bullet character set is not new — it reuses `BulletedParagraphUtils.POSSIBLE_LABELS`, the same set the pipeline uses for list detection, exposed via a new `isSymbolLabel(char)` helper.

Deliberately conservative:

- **Ordered labels are kept** (`1.`, `a)`, `1.1.1`) — they carry numbering information.
- **Unseparated leading characters are kept** (`-5 degrees`, `*emphasis*`) — without a separating space the character may be real content.
- **Items inside tables are untouched** — `writeList` adds no `- ` marker there, so the glyph is the only marker and must stay.
- JSON/text/HTML outputs are unchanged.

`MarkdownHTMLGenerator` inherits `writeList`, so both Markdown variants are covered by the single change.

## Testing

- New unit tests in `MarkdownGeneratorTest` (20 cases: stripped bullets, kept ordered labels, no-separator cases, multiline items, NBSP separator, null/empty).
- Full Java suite passes: 742 (core) + 29 (cli), 0 failures.
- End-to-end on the `Kubernetes Deployment Guide v2.56.pdf` attached to #584 (pages 6–23, pure Java path):

| | before | after |
|---|---|---|
| `- •` doubled markers | 33 | **0** |
| other diff lines | — | 0 (diff is exactly the 33 list lines) |

- No change on the repo sample PDFs (`lorem`, `1901.03003`, `2408.02509v1`).
- `./scripts/bench.sh --check-regression`: all thresholds met (NID 0.9023, TEDS 0.4887, MHS 0.7395).

Possible follow-ups (out of scope here): `HtmlGenerator` has the same visual duplication (`<li>• text</li>`), and items with ordered labels currently render as `- 1. text` rather than a Markdown ordered list.

**Checklist:**

- [ ] Documentation has been updated, if necessary. *(not necessary — output-only bug fix)*
- [ ] Examples have been added, if necessary. *(not necessary)*
- [x] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown list rendering by removing redundant bullet symbols from list-item content.
  * Prevented doubled bullets while preserving numbered lists, lettered labels, negative numbers, and other valid text.
  * Improved handling of whitespace, multiline items, and common bullet characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->