### PR TITLE
Add escaping for < and > to markdown output

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/markdown/MarkdownGenerator.java
@@ -221,8 +221,8 @@ public class MarkdownGenerator implements Closeable {
                     String altText = (image instanceof EnrichedImageChunk && ((EnrichedImageChunk) image).hasDescription())
                             ? ((EnrichedImageChunk) image).sanitizeDescription()
                             : "";
-                    String imageString = String.format(MarkdownSyntax.IMAGE_FORMAT, altText, imageSource);
-                    markdownWriter.write(getCorrectMarkdownString(imageString));
+                    String imageString = String.format(MarkdownSyntax.IMAGE_FORMAT, getCorrectMarkdownString(altText), imageSource);
+                    markdownWriter.write(imageString);
                 }
             }
         } catch (IOException e) {
@@ -255,8 +255,8 @@ public class MarkdownGenerator implements Closeable {
                     String altText = picture.hasDescription()
                             ? picture.sanitizeDescription()
                             : "";
-                    String imageString = String.format(MarkdownSyntax.IMAGE_FORMAT, altText, imageSource);
-                    markdownWriter.write(getCorrectMarkdownString(imageString));
+                    String imageString = String.format(MarkdownSyntax.IMAGE_FORMAT, getCorrectMarkdownString(altText), imageSource);
+                    markdownWriter.write(imageString);
                 }
             }
         } catch (IOException e) {
@@ -434,10 +434,14 @@ public class MarkdownGenerator implements Closeable {
     }
 
     protected String getCorrectMarkdownString(String value) {
-        if (value != null) {
-            return value.replace("\u0000", " ");
+        if (value == null) {
+            return "";
         }
-        return null;
+        return value
+            .replace("\u0000", "")
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;");
     }
 
     public static void getTextFromLineForMarkdown(TextLine line, StringBuilder stringBuilder) {

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/entities/PictureDescriptionE2ETest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/entities/PictureDescriptionE2ETest.java
@@ -259,8 +259,8 @@ class PictureDescriptionE2ETest {
                 String altText = picture.hasDescription()
                         ? picture.sanitizeDescription()
                         : "image " + picture.getPictureIndex();
-                String imageString = String.format("![%s](%s)", altText, imageSource);
-                markdownWriter.write(getCorrectMarkdownString(imageString));
+                String imageString = String.format("![%s](%s)", getCorrectMarkdownString(altText), imageSource);
+                markdownWriter.write(imageString);
             } catch (java.io.IOException e) {
                 throw new RuntimeException(e);
             }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/markdown/MarkdownGeneratorTest.java
@@ -18,6 +18,7 @@ package org.opendataloader.pdf.markdown;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opendataloader.pdf.api.Config;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -179,5 +180,65 @@ public class MarkdownGeneratorTest {
     @Test
     void testFormatLinkDestination_handlesNull() {
         assertNull(MarkdownGenerator.formatMarkdownLinkDestination(null));
+    }
+
+    // ----- getCorrectMarkdownString (`#637`) -----
+
+    private MarkdownGenerator newGeneratorForEscaping() {
+        Config config = new Config();
+        return new MarkdownGenerator(new java.io.StringWriter(), config);
+    }
+
+    @Test
+    void testGetCorrectMarkdownString_handlesNull() {
+        MarkdownGenerator generator = newGeneratorForEscaping();
+        assertEquals("", generator.getCorrectMarkdownString(null));
+    }
+
+    @Test
+    void testGetCorrectMarkdownString_removesNullCharacter() {
+        MarkdownGenerator generator = newGeneratorForEscaping();
+        assertEquals("ab", generator.getCorrectMarkdownString("a\u0000b"));
+    }
+
+    @Test
+    void testGetCorrectMarkdownString_escapesAmpersand() {
+        MarkdownGenerator generator = newGeneratorForEscaping();
+        assertEquals("A &amp; B", generator.getCorrectMarkdownString("A & B"));
+    }
+
+    @Test
+    void testGetCorrectMarkdownString_escapesLessThan() {
+        MarkdownGenerator generator = newGeneratorForEscaping();
+        assertEquals("a &lt; b", generator.getCorrectMarkdownString("a < b"));
+    }
+
+    @Test
+    void testGetCorrectMarkdownString_escapesGreaterThan() {
+        MarkdownGenerator generator = newGeneratorForEscaping();
+        assertEquals("a &gt; b", generator.getCorrectMarkdownString("a > b"));
+    }
+
+    @Test
+    void testGetCorrectMarkdownString_escapesAllReservedCharsTogether() {
+        MarkdownGenerator generator = newGeneratorForEscaping();
+        assertEquals("&lt;tag&gt; A &amp; B &lt;/tag&gt;",
+            generator.getCorrectMarkdownString("<tag> A & B </tag>"));
+    }
+
+    @Test
+    void testGetCorrectMarkdownString_leavesPlainTextUnchanged() {
+        MarkdownGenerator generator = newGeneratorForEscaping();
+        assertEquals("Plain text 123", generator.getCorrectMarkdownString("Plain text 123"));
+    }
+
+    @Test
+    void testGetCorrectMarkdownString_doubleEscapesExistingEntities() {
+        // Documents current behavior: since '&' is escaped first, any text that
+        // already contains an HTML entity (e.g. "&amp;") gets double-escaped
+        // (e.g. "&amp;amp;"). This is a known limitation, not necessarily the
+        // desired long-term behavior.
+        MarkdownGenerator generator = newGeneratorForEscaping();
+        assertEquals("&amp;amp;", generator.getCorrectMarkdownString("&amp;"));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown generation for image descriptions by sanitizing and escaping the alt text during image/picture Markdown rendering.
  * Removed invalid NUL (`\u0000`) characters from alt text instead of leaving them in output.
  * Updated handling of missing/`null` text to emit empty content, with consistent escaping of `&`, `<`, and `>`.
* **Tests**
  * Expanded Markdown generator test coverage for sanitization and escaping edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->