### PR TITLE
fix(cli): warn when --use-struct-tree silently suppresses --hybrid (#633)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ await convert(['file1.pdf', 'file2.pdf', 'folder/'], {
 
 Hybrid mode combines fast local Java processing with AI backends. Simple pages stay local (0.02s); complex pages route to AI for +90% table accuracy.
 
+> **Don't combine with `--use-struct-tree` on tagged PDFs.** `--use-struct-tree` takes precedence, so the hybrid backend is **not** called (a warning is logged). If you want the hybrid backend, drop `--use-struct-tree`.
+
 ```bash
 pip install -U "opendataloader-pdf[hybrid]"
 ```
@@ -329,6 +331,8 @@ Combine formats: `format="json,markdown"`
 When a PDF has structure tags, OpenDataLoader extracts the **exact layout** the author intended — no guessing, no heuristics. Headings, lists, tables, and reading order are preserved from the source.
 
 > **Output quality depends on tag quality.** Not all tagged PDFs are well-tagged. For PDFs with sparse or incorrect tags, the default heuristic mode or `--hybrid docling-fast` often produces better results.
+
+> **`--use-struct-tree` takes precedence over `--hybrid`.** If both are set on a tagged PDF, the structure tree is used and the hybrid backend is **not** called (a well-tagged PDF already carries reading order and structure). Drop `--use-struct-tree` if you want the hybrid backend instead.
 
 ```python
 # Batch all files in one call — each convert() spawns a JVM process, so repeated calls are slow

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -106,7 +106,8 @@ public class CLIOptions {
 
     // ===== Use Struct Tree =====
     private static final String USE_STRUCT_TREE_LONG_OPTION = "use-struct-tree";
-    private static final String USE_STRUCT_TREE_DESC = "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality";
+    private static final String USE_STRUCT_TREE_DESC = "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality. "
+            + "Takes precedence over --hybrid: when both are set on a tagged PDF, the structure tree is used and the hybrid backend is not called";
 
     // ===== Table Method =====
     private static final String TABLE_METHOD_LONG_OPTION = "table-method";
@@ -152,7 +153,8 @@ public class CLIOptions {
     private static final String HYBRID_LONG_OPTION = "hybrid";
     private static final String HYBRID_DESC = "Hybrid backend (requires a running server). "
             + "Quick start: pip install \"opendataloader-pdf[hybrid]\" && opendataloader-pdf-hybrid --port 5002. "
-            + "For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai";
+            + "For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai. "
+            + "Ignored when --use-struct-tree is set on a tagged PDF (structure tree takes precedence)";
 
     private static final String HYBRID_MODE_LONG_OPTION = "hybrid-mode";
     private static final String HYBRID_MODE_DESC = "Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)";

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -178,6 +178,16 @@ public class DocumentProcessor {
         Set<Integer> pagesToProcess = getValidPageNumbers(config);
         List<List<IObject>> contents;
         if (StaticLayoutContainers.isUseStructTree()) {
+            if (config.isHybridEnabled()) {
+                // Counterpart to the "no structure tree" warning emitted in preprocessing():
+                // here the struct-tree path wins, so the hybrid backend is never called.
+                // Warn at this branch (where precedence is resolved) instead of silently
+                // dropping the hybrid request (#633).
+                LOGGER.log(Level.WARNING, "Both --use-struct-tree and --hybrid were set on a tagged PDF. "
+                    + "The structure tree takes precedence, so the hybrid backend was NOT called. "
+                    + "A well-tagged PDF already carries reading order and structure; "
+                    + "drop --use-struct-tree if you want the hybrid backend instead.");
+            }
             contents = TaggedDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);
         } else if (config.isHybridEnabled()) {
             contents = HybridDocumentProcessor.processDocument(inputPdfName, config, pagesToProcess);

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/StructTreeHybridPrecedenceTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/StructTreeHybridPrecedenceTest.java
@@ -1,0 +1,114 @@
+package org.opendataloader.pdf.processors;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+
+/**
+ * Regression tests for #633: when {@code --use-struct-tree} and {@code --hybrid}
+ * are combined on a tagged PDF, the struct-tree path takes precedence and the
+ * hybrid backend is never called. That precedence is fine, but it must not be
+ * silent — a warning symmetric to the existing no-struct-tree warning must fire.
+ */
+public class StructTreeHybridPrecedenceTest {
+
+    // Must be an actually-tagged PDF: the warning is gated on the effective
+    // isUseStructTree() flag, which preprocessing() only leaves true when the
+    // document really has a structure tree. This PDF/UA reference file is tagged.
+    private static final String TAGGED_PDF =
+        "../../samples/pdf/pdfua-1-reference-suite-1-1/PDFUA-Ref-2-04_Presentation.pdf";
+    private static final String OUTPUT_JSON = "PDFUA-Ref-2-04_Presentation.json";
+
+    @TempDir
+    Path tempDir;
+
+    /** Captures WARNING-level messages from DocumentProcessor while a body runs. */
+    private List<String> captureWarnings(ThrowingRunnable body) throws IOException {
+        Logger logger = Logger.getLogger(DocumentProcessor.class.getCanonicalName());
+        // synchronized: the tagged path may log from ForkJoinPool workers.
+        List<String> warnings = Collections.synchronizedList(new ArrayList<>());
+        Handler handler = new Handler() {
+            @Override public void publish(LogRecord r) {
+                if (r.getLevel() == Level.WARNING) {
+                    warnings.add(r.getMessage());
+                }
+            }
+            @Override public void flush() {}
+            @Override public void close() {}
+        };
+        logger.addHandler(handler);
+        try {
+            // The warning under test is emitted in extractContents() before the tagged
+            // path runs, so a later failure in document processing must not mask it.
+            // We assert purely on what was logged; swallow body errors here.
+            body.run();
+        } catch (IOException | RuntimeException ignored) {
+            // intentionally ignored — see comment above
+        } finally {
+            logger.removeHandler(handler);
+        }
+        return warnings;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws IOException;
+    }
+
+    @Test
+    void warnsWhenStructTreeSuppressesHybridOnTaggedPdf() throws IOException {
+        File taggedPdf = new File(TAGGED_PDF);
+        assumeTrue(taggedPdf.exists(), "Tagged PDF fixture not found: " + taggedPdf.getAbsolutePath());
+
+        List<String> warnings = captureWarnings(() -> {
+            Config config = new Config();
+            config.setOutputFolder(tempDir.toString());
+            config.setGenerateJSON(true);
+            config.setUseStructTree(true);
+            config.setHybrid("docling-fast");
+            DocumentProcessor.processFile(taggedPdf.getAbsolutePath(), config);
+        });
+
+        boolean warned = warnings.stream().anyMatch(w ->
+            w.contains("use-struct-tree") && w.toLowerCase().contains("hybrid"));
+        Assertions.assertTrue(warned,
+            "Expected a WARNING that the hybrid backend is suppressed by --use-struct-tree. Got: " + warnings);
+    }
+
+    @Test
+    void noSuchWarningWhenOnlyStructTree() throws IOException {
+        File taggedPdf = new File(TAGGED_PDF);
+        assumeTrue(taggedPdf.exists(), "Tagged PDF fixture not found: " + taggedPdf.getAbsolutePath());
+
+        List<String> warnings = captureWarnings(() -> {
+            Config config = new Config();
+            config.setOutputFolder(tempDir.toString());
+            config.setGenerateJSON(true);
+            config.setUseStructTree(true);
+            DocumentProcessor.processFile(taggedPdf.getAbsolutePath(), config);
+        });
+
+        // Prove the struct-tree path actually ran (captureWarnings swallows body
+        // errors); otherwise assertFalse could pass vacuously on an early failure.
+        Assertions.assertTrue(Files.exists(tempDir.resolve(OUTPUT_JSON)),
+            "Struct-tree path should have produced JSON output");
+        boolean warned = warnings.stream().anyMatch(w ->
+            w.contains("use-struct-tree") && w.toLowerCase().contains("hybrid"));
+        Assertions.assertFalse(warned,
+            "Should not warn about hybrid when --hybrid was not requested. Got: " + warnings);
+    }
+}

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -15,7 +15,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--sanitize', 'Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders');
   program.option('--keep-line-breaks', 'Preserve original line breaks in extracted text');
   program.option('--replace-invalid-chars <value>', 'Replacement character for invalid/unrecognized characters. Default: space');
-  program.option('--use-struct-tree', 'Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality');
+  program.option('--use-struct-tree', 'Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality. Takes precedence over --hybrid: when both are set on a tagged PDF, the structure tree is used and the hybrid backend is not called');
   program.option('--table-method <value>', 'Table detection method. Values: default (border-based), cluster (border + cluster). Default: default');
   program.option('--reading-order <value>', 'Reading order algorithm. Values: off, xycut. Default: xycut');
   program.option('--markdown-page-separator <value>', 'Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none');
@@ -28,7 +28,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--pages <value>', 'Pages to extract (e.g., "1,3,5-7"). Default: all pages');
   program.option('--include-header-footer', 'Include page headers and footers in output');
   program.option('--detect-strikethrough', 'Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)');
-  program.option('--hybrid <value>', 'Hybrid backend (requires a running server). Quick start: pip install "opendataloader-pdf[hybrid]" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai');
+  program.option('--hybrid <value>', 'Hybrid backend (requires a running server). Quick start: pip install "opendataloader-pdf[hybrid]" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai. Ignored when --use-struct-tree is set on a tagged PDF (structure tree takes precedence)');
   program.option('--hybrid-mode <value>', 'Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)');
   program.option('--hybrid-url <value>', 'Hybrid backend server URL (overrides default)');
   program.option('--hybrid-timeout <value>', 'Hybrid backend request timeout in milliseconds (0 = no timeout). Default: 0');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -21,7 +21,7 @@ export interface ConvertOptions {
   keepLineBreaks?: boolean;
   /** Replacement character for invalid/unrecognized characters. Default: space */
   replaceInvalidChars?: string;
-  /** Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality */
+  /** Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality. Takes precedence over --hybrid: when both are set on a tagged PDF, the structure tree is used and the hybrid backend is not called */
   useStructTree?: boolean;
   /** Table detection method. Values: default (border-based), cluster (border + cluster). Default: default */
   tableMethod?: string;
@@ -47,7 +47,7 @@ export interface ConvertOptions {
   includeHeaderFooter?: boolean;
   /** Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental) */
   detectStrikethrough?: boolean;
-  /** Hybrid backend (requires a running server). Quick start: pip install "opendataloader-pdf[hybrid]" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai */
+  /** Hybrid backend (requires a running server). Quick start: pip install "opendataloader-pdf[hybrid]" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai. Ignored when --use-struct-tree is set on a tagged PDF (structure tree takes precedence) */
   hybrid?: string;
   /** Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend) */
   hybridMode?: string;

--- a/options.json
+++ b/options.json
@@ -70,7 +70,7 @@
       "type": "boolean",
       "required": false,
       "default": false,
-      "description": "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality"
+      "description": "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality. Takes precedence over --hybrid: when both are set on a tagged PDF, the structure tree is used and the hybrid backend is not called"
     },
     {
       "name": "table-method",
@@ -174,7 +174,7 @@
       "type": "string",
       "required": false,
       "default": "off",
-      "description": "Hybrid backend (requires a running server). Quick start: pip install \"opendataloader-pdf[hybrid]\" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai"
+      "description": "Hybrid backend (requires a running server). Quick start: pip install \"opendataloader-pdf[hybrid]\" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai. Ignored when --use-struct-tree is set on a tagged PDF (structure tree takes precedence)"
     },
     {
       "name": "hybrid-mode",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -88,7 +88,7 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "type": "boolean",
         "required": False,
         "default": False,
-        "description": "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality",
+        "description": "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality. Takes precedence over --hybrid: when both are set on a tagged PDF, the structure tree is used and the hybrid backend is not called",
     },
     {
         "name": "table-method",
@@ -205,7 +205,7 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "type": "string",
         "required": False,
         "default": "off",
-        "description": "Hybrid backend (requires a running server). Quick start: pip install \"opendataloader-pdf[hybrid]\" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai",
+        "description": "Hybrid backend (requires a running server). Quick start: pip install \"opendataloader-pdf[hybrid]\" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai. Ignored when --use-struct-tree is set on a tagged PDF (structure tree takes precedence)",
     },
     {
         "name": "hybrid-mode",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -56,7 +56,7 @@ def convert(
         sanitize: Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders
         keep_line_breaks: Preserve original line breaks in extracted text
         replace_invalid_chars: Replacement character for invalid/unrecognized characters. Default: space
-        use_struct_tree: Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality
+        use_struct_tree: Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality. Takes precedence over --hybrid: when both are set on a tagged PDF, the structure tree is used and the hybrid backend is not called
         table_method: Table detection method. Values: default (border-based), cluster (border + cluster). Default: default
         reading_order: Reading order algorithm. Values: off, xycut. Default: xycut
         markdown_page_separator: Separator between pages in Markdown output. Use %page-number% for page numbers. Default: none
@@ -69,7 +69,7 @@ def convert(
         pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages
         include_header_footer: Include page headers and footers in output
         detect_strikethrough: Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)
-        hybrid: Hybrid backend (requires a running server). Quick start: pip install "opendataloader-pdf[hybrid]" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai
+        hybrid: Hybrid backend (requires a running server). Quick start: pip install "opendataloader-pdf[hybrid]" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast, hancom-ai. Ignored when --use-struct-tree is set on a tagged PDF (structure tree takes precedence)
         hybrid_mode: Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend)
         hybrid_url: Hybrid backend server URL (overrides default)
         hybrid_timeout: Hybrid backend request timeout in milliseconds (0 = no timeout). Default: 0


### PR DESCRIPTION
## Objective
When `--use-struct-tree` and `--hybrid <backend>` are combined on a tagged PDF, `DocumentProcessor.extractContents` takes the struct-tree path (checked before hybrid) and the hybrid backend is never called — with no warning and no precedence note in `--help`. The opposite case (document without a structure tree) already logs a warning; only this direction was silent.

## Approach
- Add a WARNING symmetric to the existing no-struct-tree warning, fired when the struct-tree path is taken while `--hybrid` was requested.
- Behavior (precedence) is unchanged: a well-tagged PDF already carries reading order and structure, so the combination is redundant.
- Document the precedence in the `--use-struct-tree` and `--hybrid` help text (regenerated `options.json` + Node/Python bindings via `npm run sync`) and in the README (both the Hybrid Mode and Tagged PDF sections).

## Evidence
Ran `DocumentProcessor.processFile` on a real tagged PDF (`PDFUA-Ref-2-04_Presentation.pdf`):

| Scenario | Expected | Actual |
|----------|----------|--------|
| struct-tree + hybrid (before) | (bug) no warning | ✅ no warning — reproduced |
| struct-tree + hybrid (after)  | warning shown    | ✅ "…hybrid backend was NOT called…" |
| struct-tree only              | no such warning  | ✅ no warning (negative control) |

New regression test `StructTreeHybridPrecedenceTest` (2 cases). Full core + CLI test suites pass.

Fixes opendataloader-project/opendataloader-pdf#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that structure-tree processing takes precedence over hybrid processing for tagged PDFs.
  * Documented that hybrid processing is skipped when both options are enabled.
  * Updated CLI help and conversion documentation with the option precedence behavior.

* **Bug Fixes**
  * Added a warning when both options are selected, making the active processing path clear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->