### PR TITLE
fix: temporarily disable TOC detection until it is complete

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -367,7 +367,16 @@ public class DocumentProcessor {
             if (structured) {
                 // Cross-page operations (must be sequential)
                 HeaderFooterProcessor.processHeadersAndFooters(contents, false);
-                new TableOfContentsProcessor().processTableOfContents(contents);
+                // TOC detection is temporarily disabled. It is not yet complete:
+                //  - the heuristic has heavy false positives (any line ending in a
+                //    bare number is treated as a TOC item), so it can restructure
+                //    ordinary body content;
+                //  - it never resolves a TOCI target (destination), so the tagged
+                //    struct tree cannot emit a valid /Ref and the output is not a
+                //    conformant table of contents (PDF/UA-2 clause 8.2.5.8.1).
+                // Re-enable once detection precision and target resolution are in
+                // place. (Remaining hardening is tracked in the internal tasks tracker.)
+                // new TableOfContentsProcessor().processTableOfContents(contents);
                 ListProcessor.processLists(contents, false);
             }
 


### PR DESCRIPTION
## Objective

PDF/UA-2 validation fails on documents where a table of contents is detected. A detected TOC cannot currently become a conformant structure: PDF/UA-2 clause 8.2.5.8.1 requires each `TOCI` to identify the section it references via a target, but the pipeline never resolves that target, so the tagged output carries no valid reference and fails validation. The detector is also triggered too eagerly — any line ending in a number looks like a TOC entry — so it can restructure ordinary body text.

## Approach

Turn TOC detection off at its single call site (`DocumentProcessor`) until it is finished, rather than shipping a half-working table of contents. A partial TOC is worse than none: an entry that points nowhere (or to the wrong place) sends a screen reader astray, and the false positives corrupt normal content. Only the call is commented out — `TableOfContentsProcessor` stays in the tree, so re-enabling is a one-line change once entry-target resolution and detection precision are complete. With detection off, the same text is tagged as ordinary paragraphs, which validates cleanly.

Some additional hardening for the detector is tracked in the internal tasks tracker and should land before re-enabling.

## Evidence

Rebuilt core with detection disabled and converted a document that previously triggered TOC detection.

| Scenario | Expected | Actual |
|----------|----------|--------|
| Doc that previously produced TOC/TOCI, UA-1/UA-2 | veraPDF pass, no TOC/TOCI in struct tree | 1/1 pass; struct tree has **0 TOC, 0 TOCI**, text tagged as 7 `<P>` |
| Normal (non-TOC) document | Unchanged output | No regression — every text line flows through the existing paragraph path |

---

@MaximPlusov — while checking veraPDF conformance I found that the TOC detection you added produces a struct tree that fails PDF/UA-2 (clause 8.2.5.8.1): each `TOCI` needs to identify its reference target, but `TOCIInfo`'s destination is never populated, so there is no valid `/Ref` to emit. Downstream I could only work around it by downgrading TOC items to plain paragraphs, which drops the TOC semantics entirely — so that isn't a real fix either.

My suggestion is to **disable the feature for now and re-enable it once the target/destination resolution is in place** (a couple of follow-up items are tracked in the internal tasks tracker). This PR just comments out the call; the processor stays in the tree so bringing it back is trivial. Happy to collaborate on the proper implementation — I think the right end state is resolving the entry target and tagging as `L`/`LI` (PDF/UA-2 no longer defines TOC/TOCI and expects list structures). What do you think?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily disabled automatic table-of-contents detection to prevent incorrect processing of documents.
  * Other cross-page document structure processing remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->