### PR TITLE
chore(deps): bump junit-jupiter to 6.1.2 and spotbugs-maven-plugin to 4.10.3.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
         <verapdf.version>1.31.99</verapdf.version>
         <verapdf.wcag.algs.version>1.31.33</verapdf.wcag.algs.version>
         <jackson.databind.version>2.22.1</jackson.databind.version>
-        <junit.jupiter.version>6.1.1</junit.jupiter.version>
+        <junit.jupiter.version>6.1.2</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>
         <okhttp.version>5.4.0</okhttp.version>
         <commons.cli.version>1.11.0</commons.cli.version>
@@ -75,7 +75,7 @@
         <maven-surefire.plugin.version>3.5.6</maven-surefire.plugin.version>
         <central-publishing.plugin.version>0.11.0</central-publishing.plugin.version>
         <checkstyle.plugin.version>3.6.0</checkstyle.plugin.version>
-        <spotbugs.plugin.version>4.10.2.0</spotbugs.plugin.version>
+        <spotbugs.plugin.version>4.10.3.0</spotbugs.plugin.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Objective
Keep the Java build on the latest stable releases of its test and static-analysis tooling, so contributors pick up current bug fixes and the project doesn't drift onto unsupported versions.

## Approach
Audited every version property and plugin in `java/pom.xml` against authoritative sources — Maven Central release metadata for Central-hosted artifacts, and the vera-dev artifactory for the veraPDF family (veraPDF is not mirrored to Central at current versions).

Only the two artifacts with a newer **stable** release were bumped:

- `junit-jupiter`: 6.1.1 → **6.1.2**
- `spotbugs-maven-plugin`: 4.10.2.0 → **4.10.3.0**

Everything else is already at its latest stable and was left untouched: veraPDF `validation-model`/`wcag-validation` 1.31.99, `wcag-algorithms` 1.31.33, jackson-databind 2.22.1, okhttp 5.4.0, commons-cli 1.11.0, and the remaining Maven plugins.

Pre-release versions that exist for a few tools (assertj `4.0.0-M1`, maven-compiler `4.0.0-beta-4`, surefire `3.6.0-M1`, source/deploy betas) were intentionally **not** adopted — a published library should not ship on milestones/betas.

## Evidence
Ran the real build and full test suite after the bump (not just an assertion that the pom changed):

| Scenario | Expected | Actual |
|----------|----------|--------|
| `mvn clean package` after bump | Build succeeds | BUILD SUCCESS |
| `mvn test` (all modules) | 0 failures / 0 errors | 0 failures / 0 errors, exit 0 |
| veraPDF resolution unchanged | Same versions resolve | 1.31.99 / 1.31.33 resolve as before |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project build and testing tools to newer versions.
  * Improved compatibility with the latest development and quality-checking workflows.
  * No user-facing functionality or interface changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->