### PR TITLE
Add space-ratio option

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -91,6 +91,7 @@ public class Config {
     private final HybridConfig hybridConfig = new HybridConfig();
     private boolean includeHeaderFooter = false;
     private boolean detectStrikethrough = false;
+    private Double spaceRatio;
 
     /** Table detection method: default (border-based detection). */
     public static final String TABLE_METHOD_DEFAULT = "default";
@@ -375,6 +376,24 @@ public class Config {
      */
     public void setUseStructTree(boolean useStructTree) {
         this.useStructTree = useStructTree;
+    }
+
+    /**
+     * Gets space ratio for TextLines parsing.
+     *
+     * @return textLineSpaceRatio.
+     */
+    public Double getSpaceRatio() {
+        return spaceRatio;
+    }
+
+    /**
+     * Sets space ratio for TextLines parsing.
+     *
+     * @param spaceRatio The space ratio (default 0.17).
+     */
+    public void setSpaceRatio(Double spaceRatio) {
+        this.spaceRatio = spaceRatio;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -147,7 +147,7 @@ public class CLIOptions {
     private static final String IMAGE_RESOLUTION_DESC = "Set the rendering resolution for images in DPI. " +
         "Higher values improve image quality but increase memory consumption; " +
         "lower values reduce memory usage at the cost of detail. " +
-        "Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0.";
+        "Accepts positive decimal DPI values (e.g., 144.0). Default: 144.0.";
 
     // ===== Pages =====
     private static final String PAGES_LONG_OPTION = "pages";
@@ -398,7 +398,11 @@ public class CLIOptions {
         }
         if (commandLine.hasOption(CLIOptions.SPACE_RATIO_LONG_OPTION)) {
             try {
-                Double spaceRatio = Double.parseDouble(commandLine.getOptionValue(CLIOptions.SPACE_RATIO_LONG_OPTION));
+                double spaceRatio = Double.parseDouble(commandLine.getOptionValue(CLIOptions.SPACE_RATIO_LONG_OPTION));
+                if (!Double.isFinite(spaceRatio) || spaceRatio <= 0) {
+                    throw new IllegalArgumentException(
+                        "Option --space-ratio requires a finite positive double value.");
+                }
                 config.setSpaceRatio(spaceRatio);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -104,6 +104,12 @@ public class CLIOptions {
     private static final String REPLACE_INVALID_CHARS_LONG_OPTION = "replace-invalid-chars";
     private static final String REPLACE_INVALID_CHARS_DESC = "Replacement character for invalid/unrecognized characters. Default: space";
 
+    // ===== Set space ratio =====
+    private static final String SPACE_RATIO_LONG_OPTION = "space-ratio";
+    private static final String SPACE_RATIO_DESC = "Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). " +
+        "If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. " +
+        "Accepts decimals (e.g., 0.17). Default: 0.17";
+
     // ===== Use Struct Tree =====
     private static final String USE_STRUCT_TREE_LONG_OPTION = "use-struct-tree";
     private static final String USE_STRUCT_TREE_DESC = "Use PDF structure tree (tagged PDF) for reading order and semantic structure. Output quality depends on tag quality. "
@@ -282,6 +288,7 @@ public class CLIOptions {
             new OptionDefinition(THREADS_LONG_OPTION, null, "string", "1", THREADS_DESC, true),
             new OptionDefinition(IMAGE_RESOLUTION_LONG_OPTION, null, "string", null, IMAGE_RESOLUTION_DESC, true),
             new OptionDefinition(EXPORT_OPTIONS_LONG_OPTION, null, "boolean", null, null, false),
+            new OptionDefinition(SPACE_RATIO_LONG_OPTION, null, "string", null, SPACE_RATIO_DESC, true),
 
             // Legacy options (not exported, for backward compatibility)
             new OptionDefinition(HYBRID_OCR_LONG_OPTION, null, "string", null, HYBRID_OCR_DESC, false),
@@ -388,6 +395,15 @@ public class CLIOptions {
         }
         if (commandLine.hasOption(CLIOptions.HTML_PAGE_SEPARATOR_LONG_OPTION)) {
             config.setHtmlPageSeparator(commandLine.getOptionValue(CLIOptions.HTML_PAGE_SEPARATOR_LONG_OPTION));
+        }
+        if (commandLine.hasOption(CLIOptions.SPACE_RATIO_LONG_OPTION)) {
+            try {
+                Double spaceRatio = Double.parseDouble(commandLine.getOptionValue(CLIOptions.SPACE_RATIO_LONG_OPTION));
+                config.setSpaceRatio(spaceRatio);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                    "Option --space-ratio requires valid double value.", e);
+            }
         }
         applyContentSafetyOption(config, commandLine);
         applySanitizeOption(config, commandLine);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -267,6 +267,7 @@ public class DocumentProcessor {
         final boolean keepLineBreaks = StaticContainers.isKeepLineBreaks();
         final boolean isDataLoader = StaticContainers.isDataLoader();
         final var isIgnoreCharsWithoutUnicode = StaticContainers.getIsIgnoreCharactersWithoutUnicode();
+        final var textLineSpaceRatio =  StaticContainers.getTextLineSpaceRatio();
 
         // Capture StaticLayoutContainers state (shared mutable — synchronized list for headings)
         final var headings = StaticLayoutContainers.getHeadings();
@@ -293,6 +294,9 @@ public class DocumentProcessor {
             StaticLayoutContainers.setCurrentContentId(contentId);
             StaticLayoutContainers.setIsUseStructTree(useStructTree);
             StaticLayoutContainers.setEmbeddedImageBytesMap(embeddedImageBytesMap);
+            if (textLineSpaceRatio != null) {
+                StaticContainers.setTextLineSpaceRatio(textLineSpaceRatio);
+            }
         };
 
         // Pre-fetch all page artifacts on main thread (document access is ThreadLocal)
@@ -653,6 +657,10 @@ public class DocumentProcessor {
         StaticResources.setIsFontProgramsParsing(true);
         StaticStorages.setIsIgnoreMCIDs(!StaticLayoutContainers.isUseStructTree());
         StaticStorages.setIsAddSpacesBetweenTextPieces(true);
+        Double textLineSpaceRatio = config.getSpaceRatio();
+        if (textLineSpaceRatio != null) {
+            StaticContainers.setTextLineSpaceRatio(textLineSpaceRatio);
+        }
         document.parseChunks();
         LinesPreprocessingConsumer linesPreprocessingConsumer = new LinesPreprocessingConsumer();
         linesPreprocessingConsumer.findTableBorders();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -267,7 +267,7 @@ public class DocumentProcessor {
         final boolean keepLineBreaks = StaticContainers.isKeepLineBreaks();
         final boolean isDataLoader = StaticContainers.isDataLoader();
         final var isIgnoreCharsWithoutUnicode = StaticContainers.getIsIgnoreCharactersWithoutUnicode();
-        final var textLineSpaceRatio =  StaticContainers.getTextLineSpaceRatio();
+        final var textLineSpaceRatio = StaticContainers.getTextLineSpaceRatio();
 
         // Capture StaticLayoutContainers state (shared mutable — synchronized list for headings)
         final var headings = StaticLayoutContainers.getHeadings();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TextLineProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TextLineProcessor.java
@@ -22,6 +22,7 @@ import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextLine;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ChunksMergeUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ListUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.TextChunkUtils;
@@ -87,7 +88,7 @@ public class TextLineProcessor {
             if (content instanceof TextLine) {
                 TextLine textLine = (TextLine) content;
                 textLine.getTextChunks().sort(TEXT_CHUNK_COMPARATOR);
-                double threshold = textLine.getFontSize() * TextChunkUtils.TEXT_LINE_SPACE_RATIO;
+                double threshold = textLine.getFontSize() * StaticContainers.getTextLineSpaceRatio();
                 newContents.set(i, getTextLineWithSpaces(textLine, threshold, chunksAfterWhitespace));
             }
         }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -59,7 +59,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <verapdf.version>1.31.115</verapdf.version>
-        <verapdf.wcag.algs.version>1.31.39</verapdf.wcag.algs.version>
+        <verapdf.wcag.algs.version>1.31.40</verapdf.wcag.algs.version>
         <jackson.databind.version>2.22.1</jackson.databind.version>
         <junit.jupiter.version>6.1.2</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -38,5 +38,6 @@ export function registerCliOptions(program: Command): void {
   program.option('--hybrid-hancom-ai-image-cache <value>', 'Page image cache backing. Requires --hybrid=hancom-ai. Values: memory (default), disk');
   program.option('--to-stdout', 'Write output to stdout instead of file (single format only)');
   program.option('--threads <value>', 'Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode');
-  program.option('--image-resolution <value>', 'Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0.');
+  program.option('--image-resolution <value>', 'Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 144.0). Default: 144.0.');
+  program.option('--space-ratio <value>', 'Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17');
 }

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -67,8 +67,10 @@ export interface ConvertOptions {
   toStdout?: boolean;
   /** Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode */
   threads?: string;
-  /** Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0. */
+  /** Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 144.0). Default: 144.0. */
   imageResolution?: string;
+  /** Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17 */
+  spaceRatio?: string;
 }
 
 /**
@@ -107,6 +109,7 @@ export interface CliOptions {
   toStdout?: boolean;
   threads?: string;
   imageResolution?: string;
+  spaceRatio?: string;
 }
 
 /**
@@ -210,6 +213,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.imageResolution) {
     convertOptions.imageResolution = cliOptions.imageResolution;
+  }
+  if (cliOptions.spaceRatio) {
+    convertOptions.spaceRatio = cliOptions.spaceRatio;
   }
 
   return convertOptions;
@@ -328,6 +334,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.imageResolution) {
     args.push('--image-resolution', options.imageResolution);
+  }
+  if (options.spaceRatio) {
+    args.push('--space-ratio', options.spaceRatio);
   }
 
   return args;

--- a/options.json
+++ b/options.json
@@ -254,7 +254,15 @@
       "type": "string",
       "required": false,
       "default": null,
-      "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0."
+      "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 144.0). Default: 144.0."
+    },
+    {
+      "name": "space-ratio",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": null,
+      "description": "Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17"
     }
   ]
 }

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -295,7 +295,16 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "type": "string",
         "required": False,
         "default": None,
-        "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0.",
+        "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 144.0). Default: 144.0.",
+    },
+    {
+        "name": "space-ratio",
+        "python_name": "space_ratio",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": None,
+        "description": "Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17",
     },
 ]
 

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -43,6 +43,7 @@ def convert(
     to_stdout: bool = False,
     threads: Optional[str] = None,
     image_resolution: Optional[str] = None,
+    space_ratio: Optional[str] = None,
 ) -> None:
     """
     Convert PDF(s) into the requested output format(s).
@@ -80,7 +81,8 @@ def convert(
         hybrid_hancom_ai_image_cache: Page image cache backing. Requires --hybrid=hancom-ai. Values: memory (default), disk
         to_stdout: Write output to stdout instead of file (single format only)
         threads: Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode
-        image_resolution: Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0.
+        image_resolution: Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 144.0). Default: 144.0.
+        space_ratio: Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17
     """
     args: List[str] = []
 
@@ -162,5 +164,7 @@ def convert(
         args.extend(["--threads", threads])
     if image_resolution:
         args.extend(["--image-resolution", image_resolution])
+    if space_ratio:
+        args.extend(["--space-ratio", space_ratio])
 
     run_jar(args, quiet)

--- a/verification/ci-verify.py
+++ b/verification/ci-verify.py
@@ -78,7 +78,7 @@ COVERED_OPTIONS = {
     "--image-output", "--image-format", "--image-dir",
     "--markdown-with-html",
     "--markdown-page-separator", "--text-page-separator", "--html-page-separator",
-    "--image-resolution",
+    "--image-resolution", "--space-ratio",
 }
 
 HYBRID_OPTIONS = {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **space-ratio** setting (CLI/JSON/Python: `space_ratio`) to control automatic whitespace insertion during PDF text parsing, using a threshold of **space-ratio × font size** (decimals supported). Default behavior is **0.17**.
  * The configured ratio is applied consistently during text extraction, including parallel page processing.
* **CLI/Docs**
  * Added `--space-ratio` with validation (must be finite and **> 0**).
  * Updated the documented default for **`--image-resolution`** from **288.0** to **144.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->