### PR TITLE
Set ListNumbering in Lists from struct-tree element

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -826,30 +826,27 @@ public class AutoTaggingProcessor {
             addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.CONTINUED_FROM,
                 COSString.construct(String.valueOf(list.getPreviousList().getRecognizedStructureId()).getBytes()));
         }
-        ASAtom numbering = ListProcessor.getASAtomFromListNumbering(list.getNumberingStyle());
+        ASAtom numbering = ListProcessor.getListNumbering(list.getNumberingStyle());
         // ListProcessor.getListNumbering returns null for unmapped styles. Fold
         // null into NONE so the hasLabel promotion and COSName.construct below
         // never receive null.
         if (numbering == null || numbering == ASAtom.NONE) {
-            if (list.getListItems().size() == 1) {
-                numbering = ASAtom.NONE;
-            } else {
-                boolean hasLabel = false;
-                for (ListItem item : list.getListItems()) {
-                    if (item.getLabelLength() > 0) { hasLabel = true; break; }
-                }
-                if (hasLabel) {
-                    ListItem first = list.getListItems().get(0);
+            boolean hasLabel;
+            ListItem first = list.getListItems().get(0);
+            hasLabel = first.getLabelLength() > 0;
+            if (hasLabel) {
+                if (list.getListItems().size() == 1) {
+                    numbering = ASAtom.UNORDERED;
+                } else {
                     ListItem second = list.getListItems().get(1);
-                    if (Objects.equals(first.toString().substring(0, first.getLabelLength()),
-                        second.toString().substring(0, second.getLabelLength()))) {
+                    if (Objects.equals(first.getLabelText(), second.getLabelText())) {
                         numbering = ASAtom.UNORDERED;
                     } else {
                         numbering = ASAtom.ORDERED;
                     }
-                } else {
-                    numbering = ASAtom.NONE;
                 }
+            } else {
+                numbering = ASAtom.NONE;
             }
         }
         if (!isPDF2_0) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -855,7 +855,7 @@ public class AutoTaggingProcessor {
         if (!isPDF2_0) {
             if (numbering == ASAtom.UNORDERED) {
                 numbering = ASAtom.DISC;
-            } else if (numbering == ASAtom.ORDERED) {
+            } else if (numbering == ASAtom.ORDERED || numbering == ASAtom.DESCRIPTION) {
                 numbering = ASAtom.NONE;
             }
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -831,11 +831,33 @@ public class AutoTaggingProcessor {
         // null into NONE so the hasLabel promotion and COSName.construct below
         // never receive null.
         if (numbering == null || numbering == ASAtom.NONE) {
-            boolean hasLabel = false;
-            for (ListItem item : list.getListItems()) {
-                if (item.getLabelLength() > 0) { hasLabel = true; break; }
+            if (list.getListItems().size() == 1) {
+                numbering = ASAtom.NONE;
+            } else {
+                boolean hasLabel = false;
+                for (ListItem item : list.getListItems()) {
+                    if (item.getLabelLength() > 0) { hasLabel = true; break; }
+                }
+                if (hasLabel) {
+                    ListItem first = list.getListItems().get(0);
+                    ListItem second = list.getListItems().get(1);
+                    if (Objects.equals(first.toString().substring(0, first.getLabelLength()),
+                        second.toString().substring(0, second.getLabelLength()))) {
+                        numbering = ASAtom.UNORDERED;
+                    } else {
+                        numbering = ASAtom.ORDERED;
+                    }
+                } else {
+                    numbering = ASAtom.NONE;
+                }
             }
-            numbering = hasLabel ? ASAtom.ORDERED : ASAtom.NONE;
+        }
+        if (!isPDF2_0) {
+            if (numbering == ASAtom.UNORDERED) {
+                numbering = ASAtom.DISC;
+            } else if (numbering == ASAtom.ORDERED) {
+                numbering = ASAtom.NONE;
+            }
         }
         addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.LIST_NUMBERING, COSName.construct(numbering));
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -826,7 +826,7 @@ public class AutoTaggingProcessor {
             addAttributeToStructElem(listObject, ASAtom.LIST, ASAtom.CONTINUED_FROM,
                 COSString.construct(String.valueOf(list.getPreviousList().getRecognizedStructureId()).getBytes()));
         }
-        ASAtom numbering = ListProcessor.getListNumbering(list.getNumberingStyle());
+        ASAtom numbering = ListProcessor.getASAtomFromListNumbering(list.getNumberingStyle());
         // ListProcessor.getListNumbering returns null for unmapped styles. Fold
         // null into NONE so the hasLabel promotion and COSName.construct below
         // never receive null.

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
@@ -106,7 +106,7 @@ public class ContentFilterProcessor {
             }
         }
         if (!backgrounds.isEmpty()) {
-            LOGGER.log(Level.WARNING, "Detected background on page " + pageNumber + 1);
+            LOGGER.log(Level.WARNING, "Detected background on page " + (pageNumber + 1));
             contents.removeAll(backgrounds);
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
@@ -106,7 +106,7 @@ public class ContentFilterProcessor {
             }
         }
         if (!backgrounds.isEmpty()) {
-            LOGGER.log(Level.WARNING, "Detected background on page " + pageNumber);
+            LOGGER.log(Level.WARNING, "Detected background on page " + pageNumber + 1);
             contents.removeAll(backgrounds);
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -57,24 +57,42 @@ public class ListProcessor {
      */
     private static final int MAX_LIST_INTERVAL_LOOKBACK = 500;
 
-    private static final Map<String, ASAtom> listNumberingMap = new HashMap<>();
+    private static final Map<String, ASAtom> listNumberingToASAtomMap = new HashMap<>();
+    private static final Map<ASAtom, String> asAtomMapToListNumbering = new HashMap<>();
 
     static {
-        listNumberingMap.put(NumberingStyleNames.ENGLISH_LETTERS, ASAtom.ORDERED);
-        listNumberingMap.put(NumberingStyleNames.ENGLISH_LETTERS_UPPER_CASE, ASAtom.UPPER_ALPHA);
-        listNumberingMap.put(NumberingStyleNames.ENGLISH_LETTERS_LOWER_CASE, ASAtom.LOWER_ALPHA);
-        listNumberingMap.put(NumberingStyleNames.ROMAN_NUMBERS_LOWER_CASE, ASAtom.LOWER_ROMAN);
-        listNumberingMap.put(NumberingStyleNames.ROMAN_NUMBERS, ASAtom.ORDERED);
-        listNumberingMap.put(NumberingStyleNames.ROMAN_NUMBERS_UPPER_CASE, ASAtom.UPPER_ROMAN);
-        listNumberingMap.put(NumberingStyleNames.KOREAN_LETTERS, ASAtom.ORDERED);
-        listNumberingMap.put(NumberingStyleNames.ARABIC_NUMBERS, ASAtom.DECIMAL);
-        listNumberingMap.put(NumberingStyleNames.CIRCLED_ARABIC_NUMBERS, ASAtom.ORDERED);
-        listNumberingMap.put(NumberingStyleNames.UNORDERED,ASAtom.UNORDERED);
-        listNumberingMap.put(NumberingStyleNames.UNKNOWN, ASAtom.NONE);
+        listNumberingToASAtomMap.put(NumberingStyleNames.ENGLISH_LETTERS, ASAtom.ORDERED);
+        listNumberingToASAtomMap.put(NumberingStyleNames.ENGLISH_LETTERS_UPPER_CASE, ASAtom.UPPER_ALPHA);
+        listNumberingToASAtomMap.put(NumberingStyleNames.ENGLISH_LETTERS_LOWER_CASE, ASAtom.LOWER_ALPHA);
+        listNumberingToASAtomMap.put(NumberingStyleNames.ROMAN_NUMBERS_LOWER_CASE, ASAtom.LOWER_ROMAN);
+        listNumberingToASAtomMap.put(NumberingStyleNames.ROMAN_NUMBERS, ASAtom.ORDERED);
+        listNumberingToASAtomMap.put(NumberingStyleNames.ROMAN_NUMBERS_UPPER_CASE, ASAtom.UPPER_ROMAN);
+        listNumberingToASAtomMap.put(NumberingStyleNames.KOREAN_LETTERS, ASAtom.ORDERED);
+        listNumberingToASAtomMap.put(NumberingStyleNames.ARABIC_NUMBERS, ASAtom.DECIMAL);
+        listNumberingToASAtomMap.put(NumberingStyleNames.CIRCLED_ARABIC_NUMBERS, ASAtom.ORDERED);
+        listNumberingToASAtomMap.put(NumberingStyleNames.UNORDERED,ASAtom.UNORDERED);
+        listNumberingToASAtomMap.put(NumberingStyleNames.UNKNOWN, ASAtom.NONE);
+        listNumberingToASAtomMap.put(NumberingStyleNames.ORDERED, ASAtom.ORDERED);
+
+        asAtomMapToListNumbering.put(ASAtom.UPPER_ALPHA, NumberingStyleNames.ENGLISH_LETTERS_UPPER_CASE);
+        asAtomMapToListNumbering.put(ASAtom.LOWER_ALPHA,  NumberingStyleNames.ENGLISH_LETTERS_LOWER_CASE);
+        asAtomMapToListNumbering.put(ASAtom.UPPER_ROMAN, NumberingStyleNames.ROMAN_NUMBERS_UPPER_CASE);
+        asAtomMapToListNumbering.put(ASAtom.LOWER_ROMAN, NumberingStyleNames.ROMAN_NUMBERS_LOWER_CASE);
+        asAtomMapToListNumbering.put(ASAtom.DECIMAL, NumberingStyleNames.ARABIC_NUMBERS);
+        asAtomMapToListNumbering.put(ASAtom.CIRCLE, NumberingStyleNames.UNORDERED);
+        asAtomMapToListNumbering.put(ASAtom.DISC, NumberingStyleNames.UNORDERED);
+        asAtomMapToListNumbering.put(ASAtom.SQUARE, NumberingStyleNames.ARABIC_NUMBERS);
+        asAtomMapToListNumbering.put(ASAtom.UNORDERED, NumberingStyleNames.UNORDERED);
+        asAtomMapToListNumbering.put(ASAtom.ORDERED, NumberingStyleNames.ORDERED);
+        asAtomMapToListNumbering.put(ASAtom.NONE, NumberingStyleNames.UNKNOWN);
     }
 
-    public static ASAtom getListNumbering(String numberingStyle) {
-        return listNumberingMap.get(numberingStyle);
+    public static ASAtom getASAtomFromListNumbering(String numberingStyle) {
+        return listNumberingToASAtomMap.get(numberingStyle);
+    }
+
+    public static String getListNumberingFromASAtom(ASAtom listNumbering) {
+        return asAtomMapToListNumbering.get(listNumbering);
     }
 
     public static void processLists(List<List<IObject>> contents, boolean isTableCell) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -73,6 +73,7 @@ public class ListProcessor {
         listNumberingToASAtomMap.put(NumberingStyleNames.UNORDERED,ASAtom.UNORDERED);
         listNumberingToASAtomMap.put(NumberingStyleNames.UNKNOWN, ASAtom.NONE);
         listNumberingToASAtomMap.put(NumberingStyleNames.ORDERED, ASAtom.ORDERED);
+        listNumberingToASAtomMap.put(NumberingStyleNames.DESCRIPTION, ASAtom.DESCRIPTION);
 
         asAtomMapToListNumbering.put(ASAtom.UPPER_ALPHA, NumberingStyleNames.ENGLISH_LETTERS_UPPER_CASE);
         asAtomMapToListNumbering.put(ASAtom.LOWER_ALPHA,  NumberingStyleNames.ENGLISH_LETTERS_LOWER_CASE);
@@ -81,10 +82,11 @@ public class ListProcessor {
         asAtomMapToListNumbering.put(ASAtom.DECIMAL, NumberingStyleNames.ARABIC_NUMBERS);
         asAtomMapToListNumbering.put(ASAtom.CIRCLE, NumberingStyleNames.UNORDERED);
         asAtomMapToListNumbering.put(ASAtom.DISC, NumberingStyleNames.UNORDERED);
-        asAtomMapToListNumbering.put(ASAtom.SQUARE, NumberingStyleNames.ARABIC_NUMBERS);
+        asAtomMapToListNumbering.put(ASAtom.SQUARE, NumberingStyleNames.UNORDERED);
         asAtomMapToListNumbering.put(ASAtom.UNORDERED, NumberingStyleNames.UNORDERED);
         asAtomMapToListNumbering.put(ASAtom.ORDERED, NumberingStyleNames.ORDERED);
         asAtomMapToListNumbering.put(ASAtom.NONE, NumberingStyleNames.UNKNOWN);
+        asAtomMapToListNumbering.put(ASAtom.DESCRIPTION, NumberingStyleNames.DESCRIPTION);
     }
 
     public static ASAtom getASAtomFromListNumbering(String numberingStyle) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -57,44 +57,44 @@ public class ListProcessor {
      */
     private static final int MAX_LIST_INTERVAL_LOOKBACK = 500;
 
-    private static final Map<String, ASAtom> listNumberingToASAtomMap = new HashMap<>();
-    private static final Map<ASAtom, String> asAtomMapToListNumbering = new HashMap<>();
+    private static final Map<String, ASAtom> numberingStyleToListNumbering = new HashMap<>();
+    private static final Map<ASAtom, String> listNumberingToNumberingStyle = new HashMap<>();
 
     static {
-        listNumberingToASAtomMap.put(NumberingStyleNames.ENGLISH_LETTERS, ASAtom.ORDERED);
-        listNumberingToASAtomMap.put(NumberingStyleNames.ENGLISH_LETTERS_UPPER_CASE, ASAtom.UPPER_ALPHA);
-        listNumberingToASAtomMap.put(NumberingStyleNames.ENGLISH_LETTERS_LOWER_CASE, ASAtom.LOWER_ALPHA);
-        listNumberingToASAtomMap.put(NumberingStyleNames.ROMAN_NUMBERS_LOWER_CASE, ASAtom.LOWER_ROMAN);
-        listNumberingToASAtomMap.put(NumberingStyleNames.ROMAN_NUMBERS, ASAtom.ORDERED);
-        listNumberingToASAtomMap.put(NumberingStyleNames.ROMAN_NUMBERS_UPPER_CASE, ASAtom.UPPER_ROMAN);
-        listNumberingToASAtomMap.put(NumberingStyleNames.KOREAN_LETTERS, ASAtom.ORDERED);
-        listNumberingToASAtomMap.put(NumberingStyleNames.ARABIC_NUMBERS, ASAtom.DECIMAL);
-        listNumberingToASAtomMap.put(NumberingStyleNames.CIRCLED_ARABIC_NUMBERS, ASAtom.ORDERED);
-        listNumberingToASAtomMap.put(NumberingStyleNames.UNORDERED,ASAtom.UNORDERED);
-        listNumberingToASAtomMap.put(NumberingStyleNames.UNKNOWN, ASAtom.NONE);
-        listNumberingToASAtomMap.put(NumberingStyleNames.ORDERED, ASAtom.ORDERED);
-        listNumberingToASAtomMap.put(NumberingStyleNames.DESCRIPTION, ASAtom.DESCRIPTION);
+        numberingStyleToListNumbering.put(NumberingStyleNames.ENGLISH_LETTERS, ASAtom.ORDERED);
+        numberingStyleToListNumbering.put(NumberingStyleNames.ENGLISH_LETTERS_UPPER_CASE, ASAtom.UPPER_ALPHA);
+        numberingStyleToListNumbering.put(NumberingStyleNames.ENGLISH_LETTERS_LOWER_CASE, ASAtom.LOWER_ALPHA);
+        numberingStyleToListNumbering.put(NumberingStyleNames.ROMAN_NUMBERS_LOWER_CASE, ASAtom.LOWER_ROMAN);
+        numberingStyleToListNumbering.put(NumberingStyleNames.ROMAN_NUMBERS, ASAtom.ORDERED);
+        numberingStyleToListNumbering.put(NumberingStyleNames.ROMAN_NUMBERS_UPPER_CASE, ASAtom.UPPER_ROMAN);
+        numberingStyleToListNumbering.put(NumberingStyleNames.KOREAN_LETTERS, ASAtom.ORDERED);
+        numberingStyleToListNumbering.put(NumberingStyleNames.ARABIC_NUMBERS, ASAtom.DECIMAL);
+        numberingStyleToListNumbering.put(NumberingStyleNames.CIRCLED_ARABIC_NUMBERS, ASAtom.ORDERED);
+        numberingStyleToListNumbering.put(NumberingStyleNames.UNORDERED,ASAtom.UNORDERED);
+        numberingStyleToListNumbering.put(NumberingStyleNames.UNKNOWN, ASAtom.NONE);
+        numberingStyleToListNumbering.put(NumberingStyleNames.ORDERED, ASAtom.ORDERED);
+        numberingStyleToListNumbering.put(NumberingStyleNames.DESCRIPTION, ASAtom.DESCRIPTION);
 
-        asAtomMapToListNumbering.put(ASAtom.UPPER_ALPHA, NumberingStyleNames.ENGLISH_LETTERS_UPPER_CASE);
-        asAtomMapToListNumbering.put(ASAtom.LOWER_ALPHA,  NumberingStyleNames.ENGLISH_LETTERS_LOWER_CASE);
-        asAtomMapToListNumbering.put(ASAtom.UPPER_ROMAN, NumberingStyleNames.ROMAN_NUMBERS_UPPER_CASE);
-        asAtomMapToListNumbering.put(ASAtom.LOWER_ROMAN, NumberingStyleNames.ROMAN_NUMBERS_LOWER_CASE);
-        asAtomMapToListNumbering.put(ASAtom.DECIMAL, NumberingStyleNames.ARABIC_NUMBERS);
-        asAtomMapToListNumbering.put(ASAtom.CIRCLE, NumberingStyleNames.UNORDERED);
-        asAtomMapToListNumbering.put(ASAtom.DISC, NumberingStyleNames.UNORDERED);
-        asAtomMapToListNumbering.put(ASAtom.SQUARE, NumberingStyleNames.UNORDERED);
-        asAtomMapToListNumbering.put(ASAtom.UNORDERED, NumberingStyleNames.UNORDERED);
-        asAtomMapToListNumbering.put(ASAtom.ORDERED, NumberingStyleNames.ORDERED);
-        asAtomMapToListNumbering.put(ASAtom.NONE, NumberingStyleNames.UNKNOWN);
-        asAtomMapToListNumbering.put(ASAtom.DESCRIPTION, NumberingStyleNames.DESCRIPTION);
+        listNumberingToNumberingStyle.put(ASAtom.UPPER_ALPHA, NumberingStyleNames.ENGLISH_LETTERS_UPPER_CASE);
+        listNumberingToNumberingStyle.put(ASAtom.LOWER_ALPHA,  NumberingStyleNames.ENGLISH_LETTERS_LOWER_CASE);
+        listNumberingToNumberingStyle.put(ASAtom.UPPER_ROMAN, NumberingStyleNames.ROMAN_NUMBERS_UPPER_CASE);
+        listNumberingToNumberingStyle.put(ASAtom.LOWER_ROMAN, NumberingStyleNames.ROMAN_NUMBERS_LOWER_CASE);
+        listNumberingToNumberingStyle.put(ASAtom.DECIMAL, NumberingStyleNames.ARABIC_NUMBERS);
+        listNumberingToNumberingStyle.put(ASAtom.CIRCLE, NumberingStyleNames.UNORDERED);
+        listNumberingToNumberingStyle.put(ASAtom.DISC, NumberingStyleNames.UNORDERED);
+        listNumberingToNumberingStyle.put(ASAtom.SQUARE, NumberingStyleNames.UNORDERED);
+        listNumberingToNumberingStyle.put(ASAtom.UNORDERED, NumberingStyleNames.UNORDERED);
+        listNumberingToNumberingStyle.put(ASAtom.ORDERED, NumberingStyleNames.ORDERED);
+        listNumberingToNumberingStyle.put(ASAtom.NONE, NumberingStyleNames.UNKNOWN);
+        listNumberingToNumberingStyle.put(ASAtom.DESCRIPTION, NumberingStyleNames.DESCRIPTION);
     }
 
-    public static ASAtom getASAtomFromListNumbering(String numberingStyle) {
-        return listNumberingToASAtomMap.get(numberingStyle);
+    public static ASAtom getListNumbering(String numberingStyle) {
+        return numberingStyleToListNumbering.get(numberingStyle);
     }
 
-    public static String getListNumberingFromASAtom(ASAtom listNumbering) {
-        return asAtomMapToListNumbering.get(listNumbering);
+    public static String getNumberingStyle(ASAtom listNumbering) {
+        return listNumberingToNumberingStyle.get(listNumbering);
     }
 
     public static void processLists(List<List<IObject>> contents, boolean isTableCell) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
@@ -4,7 +4,10 @@ import org.opendataloader.pdf.api.Config;
 import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticFootnote;
+import org.verapdf.as.ASAtom;
 import org.verapdf.gf.model.impl.sa.GFSANode;
+import org.verapdf.gf.model.impl.sa.structelems.GFSAL;
+import org.verapdf.tools.AttributeHelper;
 import org.verapdf.wcag.algorithms.entities.*;
 import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextBlock;
@@ -196,6 +199,9 @@ public class TaggedDocumentProcessor {
 
     private static void processList(INode node) {
         PDFList list = new PDFList();
+        GFSAL gfsal = (GFSAL) ((GFSANode) node).getStructElem();
+        String listNumbering = AttributeHelper.getListNumbering(gfsal.getStructElemDictionary().getObject());
+        list.setNumberingStyle(ListProcessor.getListNumberingFromASAtom(ASAtom.getASAtom(listNumbering)));
         list.setBoundingBox(new MultiBoundingBox());
         for (INode child : node.getChildren()) {
             if (child.getInitialSemanticType() == SemanticType.LIST) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
@@ -201,7 +201,7 @@ public class TaggedDocumentProcessor {
         PDFList list = new PDFList();
         GFSAL gfsal = (GFSAL) ((GFSANode) node).getStructElem();
         String listNumbering = AttributeHelper.getListNumbering(gfsal.getStructElemDictionary().getObject());
-        list.setNumberingStyle(ListProcessor.getListNumberingFromASAtom(ASAtom.getASAtom(listNumbering)));
+        list.setNumberingStyle(ListProcessor.getNumberingStyle(ASAtom.getASAtom(listNumbering)));
         list.setBoundingBox(new MultiBoundingBox());
         for (INode child : node.getChildren()) {
             if (child.getInitialSemanticType() == SemanticType.LIST) {

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,8 +58,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <verapdf.version>1.31.104</verapdf.version>
-        <verapdf.wcag.algs.version>1.31.34</verapdf.wcag.algs.version>
+        <verapdf.version>1.31.115</verapdf.version>
+        <verapdf.wcag.algs.version>1.31.39</verapdf.wcag.algs.version>
         <jackson.databind.version>2.22.1</jackson.databind.version>
         <junit.jupiter.version>6.1.2</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF list tagging by deriving each list’s numbering style from structure metadata and preserving it on the generated list content.
  * Fixed list numbering conversions by adding consistent bidirectional mapping between structure numbering values and internal list styles.
  * Improved numbering fallback when style data is missing by analyzing list item label patterns, with compatibility remapping for non–PDF 2.0 output.
  * Corrected background-element warning logs to report page numbers using 1-based indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->