### PR TITLE
Add image-resolution option for setting custom RENDER_DPI

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -83,6 +83,7 @@ public class Config {
     private String imageOutput = IMAGE_OUTPUT_EXTERNAL;
     private String imageFormat = IMAGE_FORMAT_PNG;
     private String imageDir;
+    private Integer imageResolution;
     private String pages;
     private List<Integer> cachedPageNumbers;
     private final FilterConfig filterConfig = new FilterConfig();
@@ -654,6 +655,24 @@ public class Config {
         } else {
             this.imageDir = imageDir;
         }
+    }
+
+    /**
+     * Gets the resolution for extracted images.
+     *
+     * @return The integer value of resolution or null for default.
+     */
+    public Integer getImageResolution() {
+        return imageResolution;
+    }
+
+    /**
+     * Sets the resolution for extracted images.
+     *
+     * @param imageResolution The resolution value.
+     */
+    public void setImageResolution(Integer imageResolution) {
+        this.imageResolution = imageResolution;
     }
 
     private static final String INVALID_PAGE_RANGE_FORMAT = "Invalid page range format: '%s'. Expected format: 1,3,5-7";

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/Config.java
@@ -83,7 +83,7 @@ public class Config {
     private String imageOutput = IMAGE_OUTPUT_EXTERNAL;
     private String imageFormat = IMAGE_FORMAT_PNG;
     private String imageDir;
-    private Integer imageResolution;
+    private Double imageResolution;
     private String pages;
     private List<Integer> cachedPageNumbers;
     private final FilterConfig filterConfig = new FilterConfig();
@@ -662,7 +662,7 @@ public class Config {
      *
      * @return The integer value of resolution or null for default.
      */
-    public Integer getImageResolution() {
+    public Double getImageResolution() {
         return imageResolution;
     }
 
@@ -671,7 +671,7 @@ public class Config {
      *
      * @param imageResolution The resolution value.
      */
-    public void setImageResolution(Integer imageResolution) {
+    public void setImageResolution(Double imageResolution) {
         this.imageResolution = imageResolution;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -137,6 +137,12 @@ public class CLIOptions {
     private static final String IMAGE_DIR_LONG_OPTION = "image-dir";
     private static final String IMAGE_DIR_DESC = "Directory for extracted images (applies only with --image-output external)";
 
+    private static final String IMAGE_RESOLUTION_LONG_OPTION = "image-resolution";
+    private static final String IMAGE_RESOLUTION_DESC = "Set the rendering resolution for images in DPI. " +
+        "Higher values improve image quality but increase memory consumption; " +
+        "lower values reduce memory usage at the cost of detail. " +
+        "Accepts integer DPI values. Default: 288.";
+
     // ===== Pages =====
     private static final String PAGES_LONG_OPTION = "pages";
     private static final String PAGES_DESC = "Pages to extract (e.g., \"1,3,5-7\"). Default: all pages";
@@ -256,6 +262,7 @@ public class CLIOptions {
             new OptionDefinition(IMAGE_OUTPUT_LONG_OPTION, null, "string", "external", IMAGE_OUTPUT_DESC, true),
             new OptionDefinition(IMAGE_FORMAT_LONG_OPTION, null, "string", "png", IMAGE_FORMAT_DESC, true),
             new OptionDefinition(IMAGE_DIR_LONG_OPTION, null, "string", null, IMAGE_DIR_DESC, true),
+            new OptionDefinition(IMAGE_RESOLUTION_LONG_OPTION, null, "string", null, IMAGE_RESOLUTION_DESC, true),
             new OptionDefinition(PAGES_LONG_OPTION, null, "string", null, PAGES_DESC, true),
             new OptionDefinition(INCLUDE_HEADER_FOOTER_LONG_OPTION, null, "boolean", false,
                     INCLUDE_HEADER_FOOTER_DESC, true),
@@ -449,6 +456,15 @@ public class CLIOptions {
         }
         if (commandLine.hasOption(IMAGE_DIR_LONG_OPTION)) {
             config.setImageDir(commandLine.getOptionValue(IMAGE_DIR_LONG_OPTION));
+        }
+        if (commandLine.hasOption(IMAGE_RESOLUTION_LONG_OPTION)) {
+            try {
+                Integer imageResolution = Integer.parseInt(commandLine.getOptionValue(IMAGE_RESOLUTION_LONG_OPTION));
+                config.setImageResolution(imageResolution);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                    "Option --image-resolution requires valid integer value.", e);
+            }
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -460,9 +460,9 @@ public class CLIOptions {
         if (commandLine.hasOption(IMAGE_RESOLUTION_LONG_OPTION)) {
             try {
                 double imageResolution = Double.parseDouble(commandLine.getOptionValue(IMAGE_RESOLUTION_LONG_OPTION));
-                if (imageResolution < 0) {
+                if (!Double.isFinite(imageResolution) || imageResolution <= 0) {
                     throw new IllegalArgumentException(
-                        "Option --image-resolution requires positive double value.");
+                        "Option --image-resolution requires a finite positive double value.");
                 }
                 config.setImageResolution(imageResolution);
             } catch (NumberFormatException e) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -141,7 +141,7 @@ public class CLIOptions {
     private static final String IMAGE_RESOLUTION_DESC = "Set the rendering resolution for images in DPI. " +
         "Higher values improve image quality but increase memory consumption; " +
         "lower values reduce memory usage at the cost of detail. " +
-        "Accepts decimal DPI values (e.g., 288.0). Default: 288.0.";
+        "Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0.";
 
     // ===== Pages =====
     private static final String PAGES_LONG_OPTION = "pages";
@@ -262,7 +262,6 @@ public class CLIOptions {
             new OptionDefinition(IMAGE_OUTPUT_LONG_OPTION, null, "string", "external", IMAGE_OUTPUT_DESC, true),
             new OptionDefinition(IMAGE_FORMAT_LONG_OPTION, null, "string", "png", IMAGE_FORMAT_DESC, true),
             new OptionDefinition(IMAGE_DIR_LONG_OPTION, null, "string", null, IMAGE_DIR_DESC, true),
-            new OptionDefinition(IMAGE_RESOLUTION_LONG_OPTION, null, "string", null, IMAGE_RESOLUTION_DESC, true),
             new OptionDefinition(PAGES_LONG_OPTION, null, "string", null, PAGES_DESC, true),
             new OptionDefinition(INCLUDE_HEADER_FOOTER_LONG_OPTION, null, "boolean", false,
                     INCLUDE_HEADER_FOOTER_DESC, true),
@@ -281,6 +280,7 @@ public class CLIOptions {
                     "memory", HYBRID_HANCOM_AI_IMAGE_CACHE_DESC, true),
             new OptionDefinition(TO_STDOUT_LONG_OPTION, null, "boolean", false, TO_STDOUT_DESC, true),
             new OptionDefinition(THREADS_LONG_OPTION, null, "string", "1", THREADS_DESC, true),
+            new OptionDefinition(IMAGE_RESOLUTION_LONG_OPTION, null, "string", null, IMAGE_RESOLUTION_DESC, true),
             new OptionDefinition(EXPORT_OPTIONS_LONG_OPTION, null, "boolean", null, null, false),
 
             // Legacy options (not exported, for backward compatibility)
@@ -459,7 +459,11 @@ public class CLIOptions {
         }
         if (commandLine.hasOption(IMAGE_RESOLUTION_LONG_OPTION)) {
             try {
-                Double imageResolution = Double.parseDouble(commandLine.getOptionValue(IMAGE_RESOLUTION_LONG_OPTION));
+                double imageResolution = Double.parseDouble(commandLine.getOptionValue(IMAGE_RESOLUTION_LONG_OPTION));
+                if (imageResolution < 0) {
+                    throw new IllegalArgumentException(
+                        "Option --image-resolution requires positive double value.");
+                }
                 config.setImageResolution(imageResolution);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -141,7 +141,7 @@ public class CLIOptions {
     private static final String IMAGE_RESOLUTION_DESC = "Set the rendering resolution for images in DPI. " +
         "Higher values improve image quality but increase memory consumption; " +
         "lower values reduce memory usage at the cost of detail. " +
-        "Accepts integer DPI values. Default: 288.";
+        "Accepts decimal DPI values (e.g., 288.0). Default: 288.0.";
 
     // ===== Pages =====
     private static final String PAGES_LONG_OPTION = "pages";
@@ -459,11 +459,11 @@ public class CLIOptions {
         }
         if (commandLine.hasOption(IMAGE_RESOLUTION_LONG_OPTION)) {
             try {
-                Integer imageResolution = Integer.parseInt(commandLine.getOptionValue(IMAGE_RESOLUTION_LONG_OPTION));
+                Double imageResolution = Double.parseDouble(commandLine.getOptionValue(IMAGE_RESOLUTION_LONG_OPTION));
                 config.setImageResolution(imageResolution);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(
-                    "Option --image-resolution requires valid integer value.", e);
+                    "Option --image-resolution requires valid double value.", e);
             }
         }
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -267,6 +267,7 @@ public class DocumentProcessor {
         final boolean keepLineBreaks = StaticContainers.isKeepLineBreaks();
         final boolean isDataLoader = StaticContainers.isDataLoader();
         final var isIgnoreCharsWithoutUnicode = StaticContainers.getIsIgnoreCharactersWithoutUnicode();
+        final var imageResolution = StaticContainers.getImageResolution();
 
         // Capture StaticLayoutContainers state (shared mutable — synchronized list for headings)
         final var headings = StaticLayoutContainers.getHeadings();
@@ -288,6 +289,9 @@ public class DocumentProcessor {
             StaticContainers.setIsIgnoreCharactersWithoutUnicode(isIgnoreCharsWithoutUnicode);
             StaticContainers.setFileName(inputPdfName);
             StaticContainers.setPassword(config.getPassword());
+            if (imageResolution != null) {
+                StaticContainers.setImageResolution(imageResolution);
+            }
             // Project StaticLayoutContainers — share the same headings list across workers
             StaticLayoutContainers.setHeadings(headings);
             StaticLayoutContainers.setCurrentContentId(contentId);
@@ -650,6 +654,10 @@ public class DocumentProcessor {
         StaticContainers.setPassword(config.getPassword());
         StaticContainers.setIsDataLoader(true);
         StaticContainers.setIsIgnoreCharactersWithoutUnicode(false);
+        Integer imageResolution = config.getImageResolution();
+        if (imageResolution != null) {
+            StaticContainers.setImageResolution(imageResolution);
+        }
         StaticResources.setIsFontProgramsParsing(true);
         StaticStorages.setIsIgnoreMCIDs(!StaticLayoutContainers.isUseStructTree());
         StaticStorages.setIsAddSpacesBetweenTextPieces(true);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -267,7 +267,6 @@ public class DocumentProcessor {
         final boolean keepLineBreaks = StaticContainers.isKeepLineBreaks();
         final boolean isDataLoader = StaticContainers.isDataLoader();
         final var isIgnoreCharsWithoutUnicode = StaticContainers.getIsIgnoreCharactersWithoutUnicode();
-        final var imageResolution = StaticContainers.getImageResolution();
 
         // Capture StaticLayoutContainers state (shared mutable — synchronized list for headings)
         final var headings = StaticLayoutContainers.getHeadings();
@@ -289,9 +288,6 @@ public class DocumentProcessor {
             StaticContainers.setIsIgnoreCharactersWithoutUnicode(isIgnoreCharsWithoutUnicode);
             StaticContainers.setFileName(inputPdfName);
             StaticContainers.setPassword(config.getPassword());
-            if (imageResolution != null) {
-                StaticContainers.setImageResolution(imageResolution);
-            }
             // Project StaticLayoutContainers — share the same headings list across workers
             StaticLayoutContainers.setHeadings(headings);
             StaticLayoutContainers.setCurrentContentId(contentId);
@@ -573,7 +569,7 @@ public class DocumentProcessor {
                 imagesDirectory = config.getOutputFolder() + File.separator + FileUtils.getBaseName(fileName) + MarkdownSyntax.IMAGES_DIRECTORY_SUFFIX;
             }
             StaticLayoutContainers.setImagesDirectory(imagesDirectory);
-            ImagesUtils imagesUtils = new ImagesUtils();
+            ImagesUtils imagesUtils = new ImagesUtils(config.getImageResolution());
             imagesUtils.write(contents);
         }
         if (config.isGenerateTaggedPDF()) {
@@ -654,10 +650,6 @@ public class DocumentProcessor {
         StaticContainers.setPassword(config.getPassword());
         StaticContainers.setIsDataLoader(true);
         StaticContainers.setIsIgnoreCharactersWithoutUnicode(false);
-        Integer imageResolution = config.getImageResolution();
-        if (imageResolution != null) {
-            StaticContainers.setImageResolution(imageResolution);
-        }
         StaticResources.setIsFontProgramsParsing(true);
         StaticStorages.setIsIgnoreMCIDs(!StaticLayoutContainers.isUseStructTree());
         StaticStorages.setIsAddSpacesBetweenTextPieces(true);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/ImagesUtils.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/ImagesUtils.java
@@ -44,6 +44,7 @@ import java.util.logging.Logger;
 public class ImagesUtils {
     private static final Logger LOGGER = Logger.getLogger(ImagesUtils.class.getCanonicalName());
 
+    private final Double imageResolution;
     /**
      * Tracks whether the images output directory has already been created for this
      * ImagesUtils instance, so we only invoke {@link #createImagesDirectory(String)}
@@ -51,6 +52,10 @@ public class ImagesUtils {
      * (now removed) {@code contrastRatioConsumer} field as a "first call" sentinel.
      */
     private boolean imagesDirectoryInitialized = false;
+
+    public ImagesUtils(Double imageResolution) {
+        this.imageResolution = imageResolution;
+    }
 
     public void createImagesDirectory(String path) {
         // Embedded mode is self-contained: no external image directory is created.
@@ -146,7 +151,7 @@ public class ImagesUtils {
             targetImage = StaticContainers.getImagesUtils().getXObjectImage(imageBox.getPageNumber(), xImageObjectKey);
         }
         if (targetImage == null) {
-            targetImage = StaticContainers.getImagesUtils().getPageSubImage(imageBox);
+            targetImage = StaticContainers.getImagesUtils().getPageSubImage(imageBox, imageResolution);
         }
         if (targetImage == null) {
             return;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/ImagesUtils.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/utils/ImagesUtils.java
@@ -53,6 +53,10 @@ public class ImagesUtils {
      */
     private boolean imagesDirectoryInitialized = false;
 
+    public ImagesUtils () {
+        this(null);
+    }
+
     public ImagesUtils(Double imageResolution) {
         this.imageResolution = imageResolution;
     }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/utils/ImagesUtilsTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/utils/ImagesUtilsTest.java
@@ -21,6 +21,7 @@ import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +47,7 @@ class ImagesUtilsTest {
         try {
             Path path = Paths.get(testPdf.getPath());
             StaticLayoutContainers.setImagesDirectory(outputFolder + File.separator + path.getFileName().toString().substring(0, path.getFileName().toString().length() - 4) + "_images");
-            ImagesUtils imagesUtils = new ImagesUtils(null);
+            ImagesUtils imagesUtils = new ImagesUtils();
             imagesUtils.createImagesDirectory(StaticLayoutContainers.getImagesDirectory());
             // Then - verify images directory was created in createImagesDirectory()
             String expectedImagesDirName = testPdf.getName().substring(0, testPdf.getName().length() - 4) + "_images";
@@ -80,7 +81,7 @@ class ImagesUtilsTest {
             // Then - if ContrastRatioConsumer wasn't initialized,
             // it would be null and cause NPE when used
             Path path = Paths.get(testPdf.getAbsolutePath());
-            ImagesUtils imagesUtils = new ImagesUtils(null);
+            ImagesUtils imagesUtils = new ImagesUtils();
             // Issue #458 hotfix: ImagesUtils no longer keeps a local ContrastRatioConsumer
             // field/getter. Verify the consumer is created in StaticLayoutContainers'
             // ThreadLocal on first writeImage call (same observable semantic as before).
@@ -136,7 +137,7 @@ class ImagesUtilsTest {
             };
             String fileName = tempDir.resolve("flush_image.png").toString();
 
-            ImagesUtils imagesUtils = new ImagesUtils(null);
+            ImagesUtils imagesUtils = new ImagesUtils();
             imagesUtils.writeBufferedImageToFile(tracking, fileName, "png");
 
             assertEquals(1, flushCalls.get(),
@@ -180,7 +181,7 @@ class ImagesUtilsTest {
             // and a bogus directory to force a write failure.
             String fileName = tempDir.resolve("does/not/exist/img.png").toString();
 
-            ImagesUtils imagesUtils = new ImagesUtils(null);
+            ImagesUtils imagesUtils = new ImagesUtils();
             // Should not throw, but MUST still flush.
             imagesUtils.writeBufferedImageToFile(tracking, fileName, "png");
 
@@ -224,7 +225,7 @@ class ImagesUtilsTest {
             };
             String fileName = "embedded/page1_image1.png";
 
-            ImagesUtils imagesUtils = new ImagesUtils(null);
+            ImagesUtils imagesUtils = new ImagesUtils();
             imagesUtils.writeBufferedImageToFile(tracking, fileName, "png");
 
             assertEquals(1, flushCalls.get(),
@@ -263,7 +264,7 @@ class ImagesUtilsTest {
             StaticLayoutContainers.setImagesDirectory(imagesDir);
 
             AtomicInteger createCalls = new AtomicInteger(0);
-            ImagesUtils imagesUtils = new ImagesUtils(null) {
+            ImagesUtils imagesUtils = new ImagesUtils() {
                 @Override
                 public void createImagesDirectory(String path) {
                     createCalls.incrementAndGet();
@@ -334,7 +335,7 @@ class ImagesUtilsTest {
             }
 
             String fileName = tempDir.resolve("retained.png").toString();
-            ImagesUtils imagesUtils = new ImagesUtils(null);
+            ImagesUtils imagesUtils = new ImagesUtils();
 
             WeakReference<BufferedImage> weakRef;
             {
@@ -374,6 +375,64 @@ class ImagesUtilsTest {
                     } catch (IOException e) {
                         // ignore
                     }
+                });
+        }
+    }
+
+    /**
+     * Regression guard for the non‑default DPI path.
+     *
+     * When ImagesUtils is constructed with a custom resolution
+     * (e.g. {@code new ImagesUtils(388.5)}), the subsequent
+     * {@link ImagesUtils#writeImage(ImageChunk)} must scale the
+     * rendered page sub‑image so that its pixel dimensions are
+     * proportional to the bounding‑box size (in points) and the
+     * custom DPI.
+     *
+     * This test uses a 72‑point square bounding box (1 inch) so that
+     * the expected side length in pixels equals the custom DPI value.
+     */
+    @Test
+    void writeImage_withCustomResolution_scalesImageDimensions() throws IOException {
+        StaticLayoutContainers.clearContainers();
+        Path tempDir = Files.createTempDirectory("dpi-regression");
+        File testPdf = new File("../../samples/pdf/lorem.pdf");
+        String outputFolder = tempDir.toString();
+
+        try {
+            Path path = Paths.get(testPdf.getAbsolutePath());
+            StaticLayoutContainers.setImagesDirectory(
+                outputFolder + File.separator +
+                    path.getFileName().toString().substring(0, path.getFileName().toString().length() - 4) +
+                    "_images"
+            );
+            StaticContainers.setPassword("");
+            StaticContainers.setFileName(testPdf.getAbsolutePath());
+
+            double customDpi = 388.5;
+            ImagesUtils imagesUtils = new ImagesUtils(customDpi);
+
+            // 72 points = 1 inch → expected pixels = customDpi
+            ImageChunk imageChunk = new ImageChunk(new BoundingBox(0,72, 72, 0 ,0));
+            imagesUtils.writeImage(imageChunk);
+
+            Path pngPath = Path.of(StaticLayoutContainers.getImagesDirectory(), "imageFile1.png");
+            assertTrue(Files.exists(pngPath), "PNG file must be created with custom DPI");
+
+            BufferedImage image = ImageIO.read(pngPath.toFile());
+            assertNotNull(image, "Generated image must be readable");
+            int expectedPixels = (int) Math.round(customDpi);
+            assertEquals(expectedPixels, image.getWidth(),
+                "Width must equal custom DPI for a 1-inch bounding box");
+            assertEquals(expectedPixels, image.getHeight(),
+                "Height must equal custom DPI for a 1-inch bounding box");
+        } finally {
+            StaticContainers.closeImagesUtils();
+            Files.walk(tempDir)
+                .sorted((a, b) -> b.compareTo(a))
+                .forEach(p -> {
+                    try { Files.deleteIfExists(p); }
+                    catch (IOException ignored) { }
                 });
         }
     }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/utils/ImagesUtilsTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/utils/ImagesUtilsTest.java
@@ -428,12 +428,15 @@ class ImagesUtilsTest {
                 "Height must equal custom DPI for a 1-inch bounding box");
         } finally {
             StaticContainers.closeImagesUtils();
-            Files.walk(tempDir)
-                .sorted((a, b) -> b.compareTo(a))
-                .forEach(p -> {
-                    try { Files.deleteIfExists(p); }
-                    catch (IOException ignored) { }
-                });
+            try (java.util.stream.Stream<Path> paths = Files.walk(tempDir)) {
+                paths.sorted((a, b) -> b.compareTo(a))
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (IOException ignored) {
+                        }
+                    });
+            }
         }
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/utils/ImagesUtilsTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/utils/ImagesUtilsTest.java
@@ -46,7 +46,7 @@ class ImagesUtilsTest {
         try {
             Path path = Paths.get(testPdf.getPath());
             StaticLayoutContainers.setImagesDirectory(outputFolder + File.separator + path.getFileName().toString().substring(0, path.getFileName().toString().length() - 4) + "_images");
-            ImagesUtils imagesUtils = new ImagesUtils();
+            ImagesUtils imagesUtils = new ImagesUtils(null);
             imagesUtils.createImagesDirectory(StaticLayoutContainers.getImagesDirectory());
             // Then - verify images directory was created in createImagesDirectory()
             String expectedImagesDirName = testPdf.getName().substring(0, testPdf.getName().length() - 4) + "_images";
@@ -80,7 +80,7 @@ class ImagesUtilsTest {
             // Then - if ContrastRatioConsumer wasn't initialized,
             // it would be null and cause NPE when used
             Path path = Paths.get(testPdf.getAbsolutePath());
-            ImagesUtils imagesUtils = new ImagesUtils();
+            ImagesUtils imagesUtils = new ImagesUtils(null);
             // Issue #458 hotfix: ImagesUtils no longer keeps a local ContrastRatioConsumer
             // field/getter. Verify the consumer is created in StaticLayoutContainers'
             // ThreadLocal on first writeImage call (same observable semantic as before).
@@ -136,7 +136,7 @@ class ImagesUtilsTest {
             };
             String fileName = tempDir.resolve("flush_image.png").toString();
 
-            ImagesUtils imagesUtils = new ImagesUtils();
+            ImagesUtils imagesUtils = new ImagesUtils(null);
             imagesUtils.writeBufferedImageToFile(tracking, fileName, "png");
 
             assertEquals(1, flushCalls.get(),
@@ -180,7 +180,7 @@ class ImagesUtilsTest {
             // and a bogus directory to force a write failure.
             String fileName = tempDir.resolve("does/not/exist/img.png").toString();
 
-            ImagesUtils imagesUtils = new ImagesUtils();
+            ImagesUtils imagesUtils = new ImagesUtils(null);
             // Should not throw, but MUST still flush.
             imagesUtils.writeBufferedImageToFile(tracking, fileName, "png");
 
@@ -224,7 +224,7 @@ class ImagesUtilsTest {
             };
             String fileName = "embedded/page1_image1.png";
 
-            ImagesUtils imagesUtils = new ImagesUtils();
+            ImagesUtils imagesUtils = new ImagesUtils(null);
             imagesUtils.writeBufferedImageToFile(tracking, fileName, "png");
 
             assertEquals(1, flushCalls.get(),
@@ -263,7 +263,7 @@ class ImagesUtilsTest {
             StaticLayoutContainers.setImagesDirectory(imagesDir);
 
             AtomicInteger createCalls = new AtomicInteger(0);
-            ImagesUtils imagesUtils = new ImagesUtils() {
+            ImagesUtils imagesUtils = new ImagesUtils(null) {
                 @Override
                 public void createImagesDirectory(String path) {
                     createCalls.incrementAndGet();
@@ -334,7 +334,7 @@ class ImagesUtilsTest {
             }
 
             String fileName = tempDir.resolve("retained.png").toString();
-            ImagesUtils imagesUtils = new ImagesUtils();
+            ImagesUtils imagesUtils = new ImagesUtils(null);
 
             WeakReference<BufferedImage> weakRef;
             {

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -25,7 +25,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--image-output <value>', 'Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external');
   program.option('--image-format <value>', 'Output format for extracted images. Values: png, jpeg. Default: png');
   program.option('--image-dir <value>', 'Directory for extracted images (applies only with --image-output external)');
-  program.option('--image-resolution <value>', 'Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288.');
+  program.option('--image-resolution <value>', 'Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0.');
   program.option('--pages <value>', 'Pages to extract (e.g., "1,3,5-7"). Default: all pages');
   program.option('--include-header-footer', 'Include page headers and footers in output');
   program.option('--detect-strikethrough', 'Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)');

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -25,7 +25,6 @@ export function registerCliOptions(program: Command): void {
   program.option('--image-output <value>', 'Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external');
   program.option('--image-format <value>', 'Output format for extracted images. Values: png, jpeg. Default: png');
   program.option('--image-dir <value>', 'Directory for extracted images (applies only with --image-output external)');
-  program.option('--image-resolution <value>', 'Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0.');
   program.option('--pages <value>', 'Pages to extract (e.g., "1,3,5-7"). Default: all pages');
   program.option('--include-header-footer', 'Include page headers and footers in output');
   program.option('--detect-strikethrough', 'Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)');
@@ -39,4 +38,5 @@ export function registerCliOptions(program: Command): void {
   program.option('--hybrid-hancom-ai-image-cache <value>', 'Page image cache backing. Requires --hybrid=hancom-ai. Values: memory (default), disk');
   program.option('--to-stdout', 'Write output to stdout instead of file (single format only)');
   program.option('--threads <value>', 'Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode');
+  program.option('--image-resolution <value>', 'Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0.');
 }

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -25,6 +25,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--image-output <value>', 'Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external');
   program.option('--image-format <value>', 'Output format for extracted images. Values: png, jpeg. Default: png');
   program.option('--image-dir <value>', 'Directory for extracted images (applies only with --image-output external)');
+  program.option('--image-resolution <value>', 'Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288.');
   program.option('--pages <value>', 'Pages to extract (e.g., "1,3,5-7"). Default: all pages');
   program.option('--include-header-footer', 'Include page headers and footers in output');
   program.option('--detect-strikethrough', 'Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -41,8 +41,6 @@ export interface ConvertOptions {
   imageFormat?: string;
   /** Directory for extracted images (applies only with --image-output external) */
   imageDir?: string;
-  /** Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0. */
-  imageResolution?: string;
   /** Pages to extract (e.g., "1,3,5-7"). Default: all pages */
   pages?: string;
   /** Include page headers and footers in output */
@@ -69,6 +67,8 @@ export interface ConvertOptions {
   toStdout?: boolean;
   /** Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode */
   threads?: string;
+  /** Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0. */
+  imageResolution?: string;
 }
 
 /**
@@ -93,7 +93,6 @@ export interface CliOptions {
   imageOutput?: string;
   imageFormat?: string;
   imageDir?: string;
-  imageResolution?: string;
   pages?: string;
   includeHeaderFooter?: boolean;
   detectStrikethrough?: boolean;
@@ -107,6 +106,7 @@ export interface CliOptions {
   hybridHancomAiImageCache?: string;
   toStdout?: boolean;
   threads?: string;
+  imageResolution?: string;
 }
 
 /**
@@ -169,9 +169,6 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   if (cliOptions.imageDir) {
     convertOptions.imageDir = cliOptions.imageDir;
   }
-  if (cliOptions.imageResolution) {
-    convertOptions.imageResolution = cliOptions.imageResolution;
-  }
   if (cliOptions.pages) {
     convertOptions.pages = cliOptions.pages;
   }
@@ -210,6 +207,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.threads) {
     convertOptions.threads = cliOptions.threads;
+  }
+  if (cliOptions.imageResolution) {
+    convertOptions.imageResolution = cliOptions.imageResolution;
   }
 
   return convertOptions;
@@ -287,9 +287,6 @@ export function buildArgs(options: ConvertOptions): string[] {
   if (options.imageDir) {
     args.push('--image-dir', options.imageDir);
   }
-  if (options.imageResolution) {
-    args.push('--image-resolution', options.imageResolution);
-  }
   if (options.pages) {
     args.push('--pages', options.pages);
   }
@@ -328,6 +325,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.threads) {
     args.push('--threads', options.threads);
+  }
+  if (options.imageResolution) {
+    args.push('--image-resolution', options.imageResolution);
   }
 
   return args;

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -41,7 +41,7 @@ export interface ConvertOptions {
   imageFormat?: string;
   /** Directory for extracted images (applies only with --image-output external) */
   imageDir?: string;
-  /** Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288. */
+  /** Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0. */
   imageResolution?: string;
   /** Pages to extract (e.g., "1,3,5-7"). Default: all pages */
   pages?: string;

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -41,6 +41,8 @@ export interface ConvertOptions {
   imageFormat?: string;
   /** Directory for extracted images (applies only with --image-output external) */
   imageDir?: string;
+  /** Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288. */
+  imageResolution?: string;
   /** Pages to extract (e.g., "1,3,5-7"). Default: all pages */
   pages?: string;
   /** Include page headers and footers in output */
@@ -91,6 +93,7 @@ export interface CliOptions {
   imageOutput?: string;
   imageFormat?: string;
   imageDir?: string;
+  imageResolution?: string;
   pages?: string;
   includeHeaderFooter?: boolean;
   detectStrikethrough?: boolean;
@@ -165,6 +168,9 @@ export function buildConvertOptions(cliOptions: CliOptions): ConvertOptions {
   }
   if (cliOptions.imageDir) {
     convertOptions.imageDir = cliOptions.imageDir;
+  }
+  if (cliOptions.imageResolution) {
+    convertOptions.imageResolution = cliOptions.imageResolution;
   }
   if (cliOptions.pages) {
     convertOptions.pages = cliOptions.pages;
@@ -280,6 +286,9 @@ export function buildArgs(options: ConvertOptions): string[] {
   }
   if (options.imageDir) {
     args.push('--image-dir', options.imageDir);
+  }
+  if (options.imageResolution) {
+    args.push('--image-resolution', options.imageResolution);
   }
   if (options.pages) {
     args.push('--pages', options.pages);

--- a/options.json
+++ b/options.json
@@ -145,6 +145,14 @@
       "description": "Directory for extracted images (applies only with --image-output external)"
     },
     {
+      "name": "image-resolution",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": null,
+      "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288."
+    },
+    {
       "name": "pages",
       "shortName": null,
       "type": "string",

--- a/options.json
+++ b/options.json
@@ -150,7 +150,7 @@
       "type": "string",
       "required": false,
       "default": null,
-      "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288."
+      "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0."
     },
     {
       "name": "pages",

--- a/options.json
+++ b/options.json
@@ -145,14 +145,6 @@
       "description": "Directory for extracted images (applies only with --image-output external)"
     },
     {
-      "name": "image-resolution",
-      "shortName": null,
-      "type": "string",
-      "required": false,
-      "default": null,
-      "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0."
-    },
-    {
       "name": "pages",
       "shortName": null,
       "type": "string",
@@ -255,6 +247,14 @@
       "required": false,
       "default": "1",
       "description": "Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode"
+    },
+    {
+      "name": "image-resolution",
+      "shortName": null,
+      "type": "string",
+      "required": false,
+      "default": null,
+      "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0."
     }
   ]
 }

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -172,15 +172,6 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "description": "Directory for extracted images (applies only with --image-output external)",
     },
     {
-        "name": "image-resolution",
-        "python_name": "image_resolution",
-        "short_name": None,
-        "type": "string",
-        "required": False,
-        "default": None,
-        "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0.",
-    },
-    {
         "name": "pages",
         "python_name": "pages",
         "short_name": None,
@@ -296,6 +287,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "required": False,
         "default": "1",
         "description": "Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode",
+    },
+    {
+        "name": "image-resolution",
+        "python_name": "image_resolution",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": None,
+        "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0.",
     },
 ]
 

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -178,7 +178,7 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "type": "string",
         "required": False,
         "default": None,
-        "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288.",
+        "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0.",
     },
     {
         "name": "pages",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -172,6 +172,15 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "description": "Directory for extracted images (applies only with --image-output external)",
     },
     {
+        "name": "image-resolution",
+        "python_name": "image_resolution",
+        "short_name": None,
+        "type": "string",
+        "required": False,
+        "default": None,
+        "description": "Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288.",
+    },
+    {
         "name": "pages",
         "python_name": "pages",
         "short_name": None,

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -67,7 +67,7 @@ def convert(
         image_output: Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external
         image_format: Output format for extracted images. Values: png, jpeg. Default: png
         image_dir: Directory for extracted images (applies only with --image-output external)
-        image_resolution: Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288.
+        image_resolution: Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0.
         pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages
         include_header_footer: Include page headers and footers in output
         detect_strikethrough: Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -29,6 +29,7 @@ def convert(
     image_output: Optional[str] = None,
     image_format: Optional[str] = None,
     image_dir: Optional[str] = None,
+    image_resolution: Optional[str] = None,
     pages: Optional[str] = None,
     include_header_footer: bool = False,
     detect_strikethrough: bool = False,
@@ -66,6 +67,7 @@ def convert(
         image_output: Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external
         image_format: Output format for extracted images. Values: png, jpeg. Default: png
         image_dir: Directory for extracted images (applies only with --image-output external)
+        image_resolution: Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts integer DPI values. Default: 288.
         pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages
         include_header_footer: Include page headers and footers in output
         detect_strikethrough: Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)
@@ -132,6 +134,8 @@ def convert(
         args.extend(["--image-format", image_format])
     if image_dir:
         args.extend(["--image-dir", image_dir])
+    if image_resolution:
+        args.extend(["--image-resolution", image_resolution])
     if pages:
         args.extend(["--pages", pages])
     if include_header_footer:

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -29,7 +29,6 @@ def convert(
     image_output: Optional[str] = None,
     image_format: Optional[str] = None,
     image_dir: Optional[str] = None,
-    image_resolution: Optional[str] = None,
     pages: Optional[str] = None,
     include_header_footer: bool = False,
     detect_strikethrough: bool = False,
@@ -43,6 +42,7 @@ def convert(
     hybrid_hancom_ai_image_cache: Optional[str] = None,
     to_stdout: bool = False,
     threads: Optional[str] = None,
+    image_resolution: Optional[str] = None,
 ) -> None:
     """
     Convert PDF(s) into the requested output format(s).
@@ -67,7 +67,6 @@ def convert(
         image_output: Image output mode. Values: off (no images), embedded (Base64 data URIs), external (file references). Default: external
         image_format: Output format for extracted images. Values: png, jpeg. Default: png
         image_dir: Directory for extracted images (applies only with --image-output external)
-        image_resolution: Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts decimal DPI values (e.g., 288.0). Default: 288.0.
         pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages
         include_header_footer: Include page headers and footers in output
         detect_strikethrough: Detect strikethrough text and wrap with ~~ in Markdown output or <del></del> tag in HTML output (experimental)
@@ -81,6 +80,7 @@ def convert(
         hybrid_hancom_ai_image_cache: Page image cache backing. Requires --hybrid=hancom-ai. Values: memory (default), disk
         to_stdout: Write output to stdout instead of file (single format only)
         threads: Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode
+        image_resolution: Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 288.0). Default: 288.0.
     """
     args: List[str] = []
 
@@ -134,8 +134,6 @@ def convert(
         args.extend(["--image-format", image_format])
     if image_dir:
         args.extend(["--image-dir", image_dir])
-    if image_resolution:
-        args.extend(["--image-resolution", image_resolution])
     if pages:
         args.extend(["--pages", pages])
     if include_header_footer:
@@ -162,5 +160,7 @@ def convert(
         args.append("--to-stdout")
     if threads:
         args.extend(["--threads", threads])
+    if image_resolution:
+        args.extend(["--image-resolution", image_resolution])
 
     run_jar(args, quiet)

--- a/verification/ci-verify.py
+++ b/verification/ci-verify.py
@@ -78,6 +78,7 @@ COVERED_OPTIONS = {
     "--image-output", "--image-format", "--image-dir",
     "--markdown-with-html",
     "--markdown-page-separator", "--text-page-separator", "--html-page-separator",
+    "--image-resolution",
 }
 
 HYBRID_OPTIONS = {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `image-resolution` option to control extracted image rendering DPI (accepts finite positive decimal values; must be strictly greater than 0).
  * Supported via command-line and Python conversion (`image_resolution`).
  * When omitted (`null`), default behavior is preserved (intended default: **288.0 DPI**).
  * Image generation now renders using the configured resolution during output creation.
* **Bug Fixes**
  * Added a DPI regression test to verify custom-resolution image scaling.
* **Chores**
  * Updated CI option coverage to include the new `--image-resolution` flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->