### PR TITLE
Fix IllegalArgumentException in Comparator for sortPageContents

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -853,25 +853,33 @@ public class DocumentProcessor {
             if (b2 == null) {
                 return -1;
             }
-            if (!Objects.equals(b1.getPageNumber(), b2.getPageNumber())) {
-                return b1.getPageNumber() - b2.getPageNumber();
+
+            int cmp;
+            cmp = Integer.compare(b1.getPageNumber(), b2.getPageNumber());
+            if (cmp != 0) {
+                return cmp;
             }
-            if (!Objects.equals(b1.getLastPageNumber(), b2.getLastPageNumber())) {
-                return b1.getLastPageNumber() - b2.getLastPageNumber();
+            cmp = Integer.compare(b1.getLastPageNumber(), b2.getLastPageNumber());
+            if (cmp != 0) {
+                return cmp;
             }
-            if (!Objects.equals(b1.getTopY(), b2.getTopY())) {
-                return b2.getTopY() - b1.getTopY() > 0 ? 1 : -1;
+
+            cmp = Double.compare(b2.getTopY(), b1.getTopY());
+            if (cmp != 0) {
+                return cmp;
             }
-            if (!Objects.equals(b1.getLeftX(), b2.getLeftX())) {
-                return b1.getLeftX() - b2.getLeftX() > 0 ? 1 : -1;
+            cmp = Double.compare(b1.getLeftX(), b2.getLeftX());
+            if (cmp != 0) {
+                return cmp;
             }
-            if (!Objects.equals(b1.getBottomY(), b2.getBottomY())) {
-                return b1.getBottomY() - b2.getBottomY() > 0 ? 1 : -1;
+            cmp = Double.compare(b1.getBottomY(), b2.getBottomY());
+            if (cmp != 0) {
+                return cmp;
             }
-            if (!Objects.equals(b1.getRightX(), b2.getRightX())) {
-                return b1.getRightX() - b2.getRightX() > 0 ? 1 : -1;
+            cmp = Double.compare(b1.getRightX(), b2.getRightX());
+            {
+                return cmp;
             }
-            return 0;
         });
         return sortedContents;
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of page content sorting in PDF processing, ensuring more reliable handling of coordinate-based ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->