### PR TITLE
fix(core): fail fast when the temporary directory is not writable

### DIFF
--- a/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
+++ b/java/opendataloader-pdf-cli/src/main/java/org/opendataloader/pdf/cli/CLIMain.java
@@ -21,6 +21,7 @@ import org.opendataloader.pdf.api.OpenDataLoaderPDF;
 import org.opendataloader.pdf.api.cli.CLIOptions;
 import org.opendataloader.pdf.exceptions.EncryptedTaggedPdfNotSupportedException;
 import org.opendataloader.pdf.exceptions.InvalidPdfFileException;
+import org.opendataloader.pdf.exceptions.TempDirectoryNotWritableException;
 import org.verapdf.exceptions.InvalidPasswordException;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 
@@ -37,6 +38,20 @@ public class CLIMain {
     private static final String HELP = "[options] <INPUT FILE OR FOLDER>...\n Options:";
 
     private enum InputSource { CLI_ARGUMENT, DIRECTORY_CHILD }
+
+    /**
+     * Unwinds the traversal when the environment itself is unusable, so a batch
+     * run reports the cause once instead of once per file. Unchecked so it can
+     * pass through {@code processDirectory} without widening its signature.
+     */
+    private static final class EnvironmentNotUsableException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        private EnvironmentNotUsableException(Throwable cause) {
+            super(cause.getMessage(), cause);
+        }
+    }
 
     /**
      * Result of processing a path: whether all files succeeded, and how many
@@ -110,6 +125,9 @@ public class CLIMain {
                     hasFailure = true;
                 }
             }
+        } catch (EnvironmentNotUsableException exception) {
+            System.out.println("Error: " + exception.getMessage());
+            return 3;
         } finally {
             // Release resources (e.g., hybrid client thread pools)
             OpenDataLoaderPDF.shutdown();
@@ -243,6 +261,10 @@ public class CLIMain {
         } catch (EncryptedTaggedPdfNotSupportedException exception) {
             System.out.println("Error: " + exception.getMessage());
             return false;
+        } catch (TempDirectoryNotWritableException exception) {
+            // Environment failure, not a problem with this file: every remaining
+            // file would fail the same way. Abort instead of repeating it per file.
+            throw new EnvironmentNotUsableException(exception);
         } catch (Exception exception) {
             LOGGER.log(Level.SEVERE, "Exception during processing file " + file.getAbsolutePath() + ": " +
                 exception.getMessage());

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/exceptions/TempDirectoryNotWritableException.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/exceptions/TempDirectoryNotWritableException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.exceptions;
+
+import java.io.IOException;
+
+/**
+ * Thrown when the JVM temporary directory is not writable.
+ *
+ * <p>PDF processing streams anything larger than a small in-memory threshold
+ * through a temporary file — Standard 14 font metrics, embedded font programs,
+ * CMaps and decoded content streams all take that path. A PDF stream has no
+ * size bound while memory does, so spilling to disk is by design and cannot be
+ * avoided by buffering.
+ *
+ * <p>This is an environment failure rather than a problem with any one input
+ * file: every file in a batch would hit it. Callers processing multiple files
+ * should stop rather than retry per file.
+ *
+ * <p>Read-only containers, restricted CI runners, sandboxes and a misconfigured
+ * {@code TMPDIR} are the usual causes.
+ *
+ * <p>Public entry points that may surface this exception:
+ * <ul>
+ *   <li>{@code OpenDataLoaderPDF.processFile(String, Config)}</li>
+ *   <li>{@code DocumentProcessor.processFile(String, Config)}</li>
+ *   <li>{@code DocumentProcessor.processFileWithResult(String, Config)}</li>
+ *   <li>{@code DocumentProcessor.extractContents(String, Config)}</li>
+ *   <li>{@code DocumentProcessor.preprocessing(String, Config)}</li>
+ *   <li>{@code AutoTagger.tag(String, Config, Float)}</li>
+ * </ul>
+ */
+public class TempDirectoryNotWritableException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TempDirectoryNotWritableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -54,6 +54,7 @@ import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainer
 import org.verapdf.xmp.containers.StaticXmpCoreContainers;
 
 import org.opendataloader.pdf.exceptions.InvalidPdfFileException;
+import org.opendataloader.pdf.exceptions.TempDirectoryNotWritableException;
 
 import java.io.File;
 import java.io.IOException;
@@ -612,10 +613,12 @@ public class DocumentProcessor {
      *
      * @param pdfName the path to the PDF file
      * @param config the configuration settings
-     * @throws IOException if unable to read the PDF file
+     * @throws IOException if unable to read the PDF file, or if the JVM
+     *         temporary directory is not writable
      */
     public static void preprocessing(String pdfName, Config config) throws IOException {
         LOGGER.log(Level.INFO, () -> "File name: " + pdfName);
+        validateTempDirWritable();
         validatePdfMagicNumber(pdfName);
         updateStaticContainers(config);
         PDDocument pdDocument;
@@ -690,6 +693,60 @@ public class DocumentProcessor {
         if (indexOfBytes(head, marker) < 0) {
             throw new InvalidPdfFileException(
                 "'" + displayName(pdfName) + "' is not a valid PDF file (missing %PDF- header).");
+        }
+    }
+
+    /**
+     * Verifies the JVM temporary directory is writable.
+     *
+     * <p>veraPDF streams anything larger than a small in-memory threshold
+     * through a temporary file: the Standard 14 font metrics embedded in the
+     * jar, embedded font programs, CMaps and decoded content streams all take
+     * that path. A PDF stream has no size bound while memory does, so writing
+     * to disk is by design and cannot be avoided by buffering.
+     *
+     * <p>When the temporary directory is not writable those reads fail deep
+     * inside veraPDF, where the failure is logged at {@code FINE} and
+     * swallowed. Processing then continues on missing data and surfaces as an
+     * unrelated {@code NullPointerException}, or — worse — completes with
+     * exit code 0 while silently dropping most of the text. Failing up front
+     * keeps a broken environment from being reported as a successful run.
+     *
+     * <p>Runs per file rather than once per JVM. The answer is not stable for
+     * the lifetime of the process — {@code java.io.tmpdir} is a mutable system
+     * property, and the directory itself can be remounted read-only, filled up
+     * or have its permissions revoked. Caching a success would let a
+     * long-running embedder latch onto a stale {@code true} and silently return
+     * to the very data loss this guards against. One create-and-delete against
+     * a working directory is negligible next to parsing a PDF.
+     *
+     * @throws TempDirectoryNotWritableException if the temporary directory
+     *         cannot be written to
+     */
+    private static void validateTempDirWritable() throws TempDirectoryNotWritableException {
+        String tempDir = System.getProperty("java.io.tmpdir");
+        Path probe = null;
+        try {
+            // Resolve java.io.tmpdir explicitly rather than calling the no-arg
+            // Files.createTempFile: that one resolves the directory once when the
+            // JVM starts, so it would ignore a -Djava.io.tmpdir override applied
+            // later and probe a different directory than veraPDF ends up using.
+            // RuntimeException covers InvalidPathException from a malformed override.
+            probe = Files.createTempFile(Path.of(tempDir), "opendataloader-", ".probe");
+        } catch (IOException | RuntimeException e) {
+            throw new TempDirectoryNotWritableException(
+                "Cannot write to the temporary directory '" + tempDir + "'."
+                + " PDF processing needs it to read font metrics and decode content streams."
+                + " Point java.io.tmpdir or the TMPDIR environment variable at a writable"
+                + " directory, or grant write access to this one.", e);
+        } finally {
+            if (probe != null) {
+                try {
+                    Files.deleteIfExists(probe);
+                } catch (IOException e) {
+                    LOGGER.log(Level.FINE, "Could not delete temporary directory probe file " + probe, e);
+                }
+            }
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -725,28 +725,25 @@ public class DocumentProcessor {
      */
     private static void validateTempDirWritable() throws TempDirectoryNotWritableException {
         String tempDir = System.getProperty("java.io.tmpdir");
-        Path probe = null;
         try {
             // Resolve java.io.tmpdir explicitly rather than calling the no-arg
             // Files.createTempFile: that one resolves the directory once when the
             // JVM starts, so it would ignore a -Djava.io.tmpdir override applied
             // later and probe a different directory than veraPDF ends up using.
             // RuntimeException covers InvalidPathException from a malformed override.
-            probe = Files.createTempFile(Path.of(tempDir), "opendataloader-", ".probe");
+            Path probe = Files.createTempFile(Path.of(tempDir), "opendataloader-", ".probe");
+            // Deleting is part of what is being verified, not just cleanup: veraPDF
+            // removes its spill files, so a directory that allows creation but
+            // refuses deletion (a sticky bit the process does not own, say) would
+            // accumulate one file per stream. Failing here also keeps the probe
+            // itself from leaking.
+            Files.delete(probe);
         } catch (IOException | RuntimeException e) {
             throw new TempDirectoryNotWritableException(
-                "Cannot write to the temporary directory '" + tempDir + "'."
+                "Cannot use the temporary directory '" + tempDir + "'."
                 + " PDF processing needs it to read font metrics and decode content streams."
                 + " Point java.io.tmpdir or the TMPDIR environment variable at a writable"
                 + " directory, or grant write access to this one.", e);
-        } finally {
-            if (probe != null) {
-                try {
-                    Files.deleteIfExists(probe);
-                } catch (IOException e) {
-                    LOGGER.log(Level.FINE, "Could not delete temporary directory probe file " + probe, e);
-                }
-            }
         }
     }
 

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorTempDirTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorTempDirTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.processors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.exceptions.InvalidPdfFileException;
+import org.opendataloader.pdf.exceptions.TempDirectoryNotWritableException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Regression tests for the temporary-directory precondition.
+ *
+ * <p>veraPDF spills anything past a small in-memory threshold to a temporary
+ * file — Standard 14 font metrics, embedded font programs, CMaps and decoded
+ * content streams. When that directory is unwritable those reads fail deep
+ * inside veraPDF, are logged at {@code FINE} and swallowed, and processing
+ * either dies with an unrelated NullPointerException or completes with exit
+ * code 0 while silently dropping most of the text. The guard must fail up
+ * front with a message naming the directory and the way out.
+ */
+class DocumentProcessorTempDirTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * Relies on POSIX permissions to make a directory unwritable, which does
+     * not translate to Windows ACLs. Also skipped for root, who bypasses the
+     * permission bits entirely.
+     */
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    @ResourceLock(Resources.SYSTEM_PROPERTIES)
+    void preprocessingRejectsUnwritableTempDirWithTypedException() throws IOException {
+        Path unwritable = Files.createDirectory(tempDir.resolve("unwritable"),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("r-x------")));
+        // Reported as skipped rather than passed, so a vacuous run is visible in CI.
+        assumeTrue(!Files.isWritable(unwritable), "running as root: permission bits do not apply");
+
+        Path pdf = validPdf();
+        String originalTempDir = System.getProperty("java.io.tmpdir");
+        TempDirectoryNotWritableException thrown;
+        try {
+            System.setProperty("java.io.tmpdir", unwritable.toString());
+            thrown = assertThrows(
+                TempDirectoryNotWritableException.class,
+                () -> DocumentProcessor.preprocessing(pdf.toString(), new Config()));
+        } finally {
+            System.setProperty("java.io.tmpdir", originalTempDir);
+        }
+
+        String message = thrown.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains(unwritable.toString()),
+            "message should name the offending directory so the user can fix it, but was: " + message);
+        assertTrue(message.contains("java.io.tmpdir") && message.contains("TMPDIR"),
+            "message should tell the user how to point at a writable directory, but was: " + message);
+        assertNotNull(thrown.getCause(), "underlying IOException should be preserved for diagnostics");
+    }
+
+    /**
+     * The guard must stay invisible in a normal environment. Uses a file with
+     * no {@code %PDF-} header so the magic-number check — which runs
+     * immediately after this one and needs no veraPDF state — stops
+     * preprocessing right there: reaching {@code InvalidPdfFileException}
+     * proves the temporary-directory check passed, without opening a
+     * PDDocument or populating the static containers that a later test in the
+     * same JVM would inherit.
+     */
+    @Test
+    void preprocessingAcceptsWritableTempDir() throws IOException {
+        Path notAPdf = tempDir.resolve("not-a-pdf.pdf");
+        Files.write(notAPdf, "definitely not a pdf".getBytes(StandardCharsets.US_ASCII));
+
+        assertThrows(
+            InvalidPdfFileException.class,
+            () -> DocumentProcessor.preprocessing(notAPdf.toString(), new Config()),
+            "a writable temporary directory must let preprocessing reach the magic-number check");
+    }
+
+    private Path validPdf() throws IOException {
+        Path pdf = tempDir.resolve("minimal.pdf");
+        Files.write(pdf, "%PDF-1.4\n%%EOF\n".getBytes(StandardCharsets.US_ASCII));
+        return pdf;
+    }
+}


### PR DESCRIPTION
## Objective

- An unwritable temp directory fails conversion with an unrelated NPE

## Approach

- veraPDF writes large streams to disk; memory cannot replace it
- So check the directory up front and refuse to start

## Evidence

Ran the CLI on `samples/pdf/1901.03003.pdf`, unwritable then normal tmpdir.

| Scenario | Expected | Actual |
|---|---|---|
| Unwritable, before | — | NPE, or exit 0 with 73KB of 292KB (0/367 paragraphs) |
| Unwritable, after | Refuse | No output, exit 3, names dir and settings |
| Unwritable, batch of 20 | Once | Reported once, aborted |
| Normal | No change | Exit 0, output byte-for-byte identical |
| Full suite | Pass | `BUILD SUCCESS`, 0 failures |
| checkstyle / spotbugs | No new | 166 / 63, unchanged |

## Note

Conversion still needs a fixed environment. This only stops the tool from
blaming the PDF. The swallowed exception is in `org.verapdf:parser`, logged
at `FINE` — worth reporting upstream separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Detects when the configured temporary directory cannot be written to before processing PDFs.
  * Provides a clear error message with remediation guidance instead of repeating the failure for each file.
  * CLI processing now stops cleanly and returns an appropriate error status when this environment issue occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->