### PR TITLE
chore(deps): unify Node 24 / pnpm 11 and fix postcss override

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify deploy credentials

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,13 +75,11 @@ jobs:
       - name: Set up Node.js and pnpm
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9
 
       # =================================================================
       # 2. BUILD & TEST

--- a/.github/workflows/test-benchmark.yml
+++ b/.github/workflows/test-benchmark.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Setup pnpm
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Build & Test All
         run: ./scripts/build-all.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,12 @@ To suggest a new feature:
 
 4. **Build** the project:
 
-   **Prerequisites:** Java 11+, Maven, Python 3.10+, uv, Node.js 20+, pnpm
+   **Prerequisites:** Java 11+, Maven, Python 3.10+, uv, Node.js 24 (current active LTS), pnpm via `corepack enable pnpm`
+
+   Node 24 and pnpm 11.21.0 are what CI builds against. Enabling Corepack once
+   picks the pnpm version up from the `packageManager` field, so there is no
+   global install and no version to remember. Node must be >=22.13 — pnpm 11
+   refuses to install on anything older.
    See the [Development Workflow guide](https://opendataloader.org/docs/development-workflow) for OS-specific install instructions.
 
    ```bash

--- a/node/opendataloader-pdf/package.json
+++ b/node/opendataloader-pdf/package.json
@@ -45,8 +45,9 @@
     "url": "https://github.com/opendataloader-project/opendataloader-pdf/issues"
   },
   "homepage": "https://github.com/opendataloader-project/opendataloader-pdf#readme",
+  "packageManager": "pnpm@11.21.0",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.13"
   },
   "publishConfig": {
     "access": "public"
@@ -68,13 +69,7 @@
     "vite": "^8.0.8",
     "vitest": "^4.1.4"
   },
-  "pnpm": {
-    "overrides": {
-      "minimatch@<10.2.3": ">=10.2.3",
-      "flatted@<3.4.2": ">=3.4.2",
-      "postcss@<8.5.10": ">=8.5.10"
-    }
-  },
+
   "files": [
     "dist",
     "lib",

--- a/node/opendataloader-pdf/pnpm-lock.yaml
+++ b/node/opendataloader-pdf/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   minimatch@<10.2.3: '>=10.2.3'
   flatted@<3.4.2: '>=3.4.2'
-  postcss@<8.5.10: '>=8.5.10'
+  postcss@<8.5.23: '>=8.5.23'
 
 importers:
 
@@ -43,7 +43,7 @@ importers:
         version: 3.9.5
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.18)(tsx@4.20.5)(typescript@6.0.3)
+        version: 8.5.1(postcss@8.5.26)(tsx@4.20.5)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -493,36 +493,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -584,66 +590,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1074,24 +1093,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1148,8 +1171,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1210,7 +1233,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.23'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -1223,8 +1246,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1348,7 +1371,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.23'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -2378,7 +2401,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -2426,16 +2449,16 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.18)(tsx@4.20.5):
+  postcss-load-config@6.0.1(postcss@8.5.26)(tsx@4.20.5):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.26
       tsx: 4.20.5
 
-  postcss@8.5.18:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2569,7 +2592,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.18)(tsx@4.20.5)(typescript@6.0.3):
+  tsup@8.5.1(postcss@8.5.26)(tsx@4.20.5)(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -2580,7 +2603,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.18)(tsx@4.20.5)
+      postcss-load-config: 6.0.1(postcss@8.5.26)(tsx@4.20.5)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -2589,7 +2612,7 @@ snapshots:
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.26
       typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
@@ -2623,7 +2646,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.26
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/node/opendataloader-pdf/pnpm-workspace.yaml
+++ b/node/opendataloader-pdf/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+# pnpm 11 no longer reads the "pnpm" field in package.json, so overrides and
+# build allowlists live here. See https://pnpm.io/settings
+allowBuilds:
+  esbuild: true
+
+overrides:
+  minimatch@<10.2.3: '>=10.2.3'
+  flatted@<3.4.2: '>=3.4.2'
+  postcss@<8.5.23: '>=8.5.23'

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "opendataloader-pdf-workspace",
   "private": true,
   "description": "OpenDataLoader PDF - Monorepo workspace",
+  "packageManager": "pnpm@11.21.0",
+  "engines": {
+    "node": ">=22.13"
+  },
   "scripts": {
     "build-java": "bash scripts/build-java.sh",
     "export-options": "npm run build-java && java -Djava.awt.headless=true -Dapple.awt.UIElement=true -jar java/opendataloader-pdf-cli/target/opendataloader-pdf-cli-0.0.0.jar --export-options > options.json",


### PR DESCRIPTION
Resolves Dependabot alert **#99** (postcss) and unifies the toolchain so local, CI, and release all resolve the same versions.

## Why now

Node 20 reached **EOL 2026-04-30**, and pnpm 11 requires Node >=22.13. The two are coupled — pnpm 11 cannot be adopted without moving off Node 20 first.

## The actual bug this fixes

`postcss` #99 was never a version problem. The three overrides live in `package.json` under `pnpm.overrides`, which **pnpm 11 no longer reads** — it warns the field is ignored. Consequences split by version:

| pnpm | reads `pnpm.overrides`? | result |
|---|---|---|
| 9 (was pinned in `release.yml`) | yes | pins held |
| 10.34.5 (what `test-benchmark.yml` actually got) | yes | pins held |
| 11+ (any dev on Node 22+) | **no** | `--frozen-lockfile` dies with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` |

So CI was protected only *incidentally*: `node-version: '20'` capped pnpm at 10.34.5, because `npm install -g pnpm` resolves `latest` (11.21.0) but falls back on the `engines` constraint. Meanwhile any developer on Node 22+ got pnpm 11 and a hard install failure. Moving the overrides to `pnpm-workspace.yaml` is what actually resolves #99 — and raising the pin to `>=8.5.23` is only effective once the file is read at all.

## Changes

- add `packageManager: "pnpm@11.21.0"` to **both** the root and `node/opendataloader-pdf` manifests
- `engines.node`: `>=20.19.0` → `>=22.13` (pnpm 11 floor)
- CI `node-version`: `20` → `24` in `preflight`, `release`, `test-benchmark`
- `release.yml`: drop `version: 9` from `action-setup` — it now reads `packageManager`
- `test-benchmark.yml`: `npm install -g pnpm` → `pnpm/action-setup@v6`
- move `pnpm.overrides` + `allowBuilds` to `pnpm-workspace.yaml`
- `postcss` override `<8.5.10` → `<8.5.23`, resolving **8.5.18 → 8.5.26** (#99)
- `CONTRIBUTING.md`: prerequisites said "Node.js 20+", now wrong

**No workflow pins a pnpm version anymore.** Local and CI cannot drift apart.

### Why the root manifest also needs `packageManager`

`pnpm/action-setup` runs at the **repo root**. With the field only in `node/opendataloader-pdf/`, it falls back to whatever pnpm is on PATH. Reproduced locally: `pnpm --version` gave **11.7.0** at the root but **11.21.0** under `node/`. Without the root entry this PR would have shipped a silently wrong pnpm in CI.

### Node 24, not 26

Node 26.7.0 is the newest release but is **not LTS yet** (scheduled 2026-10-28). Node 24 is the current **active LTS (Krypton)**, EOL 2028-04-30.

## Verification (pnpm 11.21.0, Node 24)

- `pnpm install --frozen-lockfile` — passes
- `pnpm run build` — ESM/CJS/DTS all emitted
- `pnpm test` — **33 passed**
- `pnpm lint` — clean
- built CLI runs (`node dist/cli.js --help`)
- `pnpm publish --dry-run` — packaging intact
- published tarball does **not** contain `pnpm-workspace.yaml` (overrides must not ship to consumers)
- overrides verified applied: postcss **8.5.26**, minimatch **10.2.5**, flatted **3.4.2**

## Review notes

A security pass over the diff returned no supply-chain regression:
- all three overrides preserved character-for-character; postcss **strengthened**. The old `>=8.5.10` floor did *not* clear GHSA-fxqj-rqcc-2cmp (fixed range `<8.5.23`) — 8.5.22 still returns that advisory
- lockfile changes are 2 forward bumps only: postcss 8.5.18→8.5.26, nanoid 3.3.16→3.3.18. **No downgrades, no new packages.** The nanoid bump incidentally clears GHSA-2v37-7h3g-55p8
- remaining diff lines are additive `libc: [glibc|musl]` metadata that pnpm 11 records on existing platform binaries — no version or integrity hash changed
- all sources remain the official npm registry; no credential or registry-auth changes
- `allowBuilds` **narrows** rather than grants: there was previously no allowlist at all, so `esbuild` already ran postinstall unrestricted

Not applicable to this repo: Vercel's pnpm 6–10 limit. This repo has no Vercel deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s supported Node.js version to 22.13 or later.
  * Standardized package management on pnpm 11.21.0 via Corepack.
  * Updated automated workflows to use Node.js 24 and the supported pnpm setup.
  * Added workspace build permissions and package version safeguards.
* **Documentation**
  * Updated contributor setup instructions with the new Node.js, Corepack, and pnpm requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->