### PR TITLE
fix(test): sync lorem.json sample with pdfua_tag output

### DIFF
--- a/samples/json/lorem.json
+++ b/samples/json/lorem.json
@@ -7,6 +7,7 @@
   "modification date" : "D:20251010112501+09'00'",
   "kids" : [ {
     "type" : "heading",
+    "pdfua_tag" : "H1",
     "id" : 1,
     "level" : "Doctitle",
     "page number" : 1,
@@ -18,6 +19,7 @@
     "content" : "Lorem Ipsum"
   }, {
     "type" : "paragraph",
+    "pdfua_tag" : "P",
     "id" : 2,
     "page number" : 1,
     "bounding box" : [ 85.034, 567.936, 502.306, 659.761 ],


### PR DESCRIPTION
Fixes the `test-benchmark` failure on `main` (run [31687680444](https://github.com/opendataloader-project/opendataloader-pdf/actions/runs/31687680444)). Two-line change to a sample fixture.

## What broke

`build-all.sh` runs java → python → node. Java and Python passed (97 tests), then the Node stage died on its **first** command:

```
[3/3] Node.js: Building and testing...
[ERR_PNPM_UNCLEAN_WORKING_TREE] Working tree is not clean. Commit or stash your changes.
```

That is `pnpm version` at `scripts/build-all.sh:69`.

## Root cause — a stale fixture, not the toolchain

`866e5d9` ("feat(json): emit per-node ai_score + pdfua_tag") changed `JsonName.java` and `SerializerUtil.java` but **did not regenerate `samples/json/lorem.json`**. The committed sample has been out of date since.

This never failed a test because `IntegrationTest` writes its output *into* `samples/json/` and then compares the file against itself:

```java
config.setOutputFolder("../../samples/json");
DocumentProcessor.processFile(pdfFile.getAbsolutePath(), config);
// ...then reads jsonFile and resultJson — same path
```

So the only symptom was `samples/json/lorem.json` left modified in the working tree after every Java build.

## Why it only started failing now

`pnpm version` refuses to run on a dirty tree in pnpm 11 — **even with `--no-git-tag-version --allow-same-version`**. pnpm 10 did not check. The last green run logged `using pnpm v10.34.5`; the failing run has no such line at all, because it never reached install.

So #682 (Node 24 / pnpm 11) did not *cause* this — it surfaced a fixture drift that had been latent since `866e5d9`. Confirmed by checking out `c678f53` (the commit before the toolchain change) and running `build-java.sh`: `M samples/json/lorem.json`, identically.

## The change

Regenerated output adds exactly the two tags `866e5d9` introduced:

```diff
     "type" : "heading",
+    "pdfua_tag" : "H1",
```
```diff
     "type" : "paragraph",
+    "pdfua_tag" : "P",
```

**No other value changed** — no bounding boxes, no ids, no content. `lorem.json` is the only file in `samples/json/`.

## Verification

- `build-java.sh` run twice in a row now leaves the tree **clean** (was: `M samples/json/lorem.json` every time)
- `pnpm version 0.0.0 --no-git-tag-version --allow-same-version` — succeeds (was the failing command)
- **full `scripts/build-all.sh` completes**: Java, Python 97 tests, Node 33 tests, exit 0

## Follow-up worth considering (not in this PR)

`IntegrationTest` comparing a fixture against output it just overwrote means fixture drift cannot fail the test — it only shows up as a dirty tree. Writing to a temp dir and comparing against the committed fixture would have caught this at `866e5d9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added PDF/UA semantic tags to sample headings and paragraphs, improving accessibility metadata for supported PDF workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->