### PR TITLE
fix(release): let pnpm version run on the version-injected tree

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -66,7 +66,7 @@ echo "[3/3] Node.js: Building and testing..."
 echo "----------------------------------------"
 
 cd "$ROOT_DIR/node/opendataloader-pdf"
-pnpm version "$VERSION" --no-git-tag-version --allow-same-version
+pnpm version "$VERSION" --no-git-tag-version --allow-same-version --no-git-checks
 "$SCRIPT_DIR/build-node.sh"
 
 echo "[3/3] Node.js: Done"


### PR DESCRIPTION
## Objective

Unblock the Release workflow. The `v2.5.1` tag build [failed](https://github.com/opendataloader-project/opendataloader-pdf/actions/runs/32090962447) at *Build and test all packages*, so every publish step was skipped. The tag exists but nothing shipped:

| target | expected | actual |
|---|---|---|
| GitHub Release | v2.5.1 | `release not found` |
| npm `@opendataloader/pdf` | 2.5.1 | 2.5.0 |
| PyPI `opendataloader-pdf` | 2.5.1 | HTTP 404 |

Maven Central deploy, the CLI ZIP, and the reference-docs push to `opendataloader.org` were skipped too. No partial publish to reconcile — this is a clean re-release once merged.

## Approach

`build-all.sh` injects the release version into each ecosystem before building it: `mvn versions:set` (Java), `sed` (Python), `pnpm version` (Node). Java and Python run first, so by the Node stage the tree necessarily has modifications — `mvn versions:set` rewrites `java/pom.xml` plus the `cli` and `core` poms, and `sed` rewrites `pyproject.toml`.

pnpm 11 added a clean-working-tree gate to `version` and aborts:

```
[ERR_PNPM_UNCLEAN_WORKING_TREE] Working tree is not clean. Commit or stash your changes.
```

pnpm 10 had no such gate, which is why this appeared only after a7789b8 moved CI from pnpm 10 to 11. Release runs on tag push only, so `v2.5.1` was the first tag to hit that combination.

`--no-git-checks` is the narrowest fix. The gate exists to stop `pnpm version` from sweeping uncommitted work into its implicit version commit/tag — and `--no-git-tag-version`, already on the same line, disables both, so nothing the gate protects applies here. The dirty tree is this script's own deliberate output from three lines earlier. `release.yml:132` already publishes with `pnpm publish --no-git-checks`, so the pipeline established this pattern.

### Why not just clean the tree

c9de934 fixed a real instance of this failure — a stale `samples/json/lorem.json` rewritten by every Java build. That fix **is** in `v2.5.1` and does hold: a full `mvn clean install` now leaves the tree clean. What remains is the version injection itself, which no amount of sample regeneration removes. The gate has to be opted out of rather than satisfied.

## Evidence

Local, pnpm 11.21.0 (matching the pinned `packageManager`), with the Java and Python manifests dirtied to reproduce the CI state:

- **Reproduced:** `pnpm version 2.5.1 --no-git-tag-version --allow-same-version` → `ERR_PNPM_UNCLEAN_WORKING_TREE`
- **Fixed:** same command with `--no-git-checks` → `0.0.0 → 2.5.1`
- **A/B on one tree:** without the flag fails, with it succeeds — isolating the flag as the cause
- `build-node.sh` then builds and passes **33/33** tests
- Confirmed `mvn versions:set` alone dirties 3 poms; a full Java build adds nothing further
- Confirmed `pnpm install --frozen-lockfile` has no such gate (succeeds on a dirty tree) — the failure is `version`, not `install`
- Only `pnpm version` call site in the repo

Reviewed by two independent subagents (correctness + security):

- `--no-git-checks` and `--no-git-tag-version` read **independent** option fields (`gitChecks` vs `gitTagVersion`), so the flag is required, not redundant
- pnpm 11 has exactly three clean-tree gates: `publish` (already opted out at `release.yml:132`) and the two `version` paths. None on `install`, `build`, or `test`
- No downstream release step depends on tree cleanliness — all consume build outputs by path
- Security verdict: **neutral**. The gate is a developer ergonomics net, not a supply-chain control; it never inspects *what* the dirt is and does not gate the publish that ships bytes
- Slightly *reduces* cross-ecosystem mismatch risk: previously `set -e` halted mid-injection with Java/Python bumped and Node not

`test-benchmark.yml:53` also calls `build-all.sh`, so PR CI exercises the fixed path directly.

## Out of scope

Pre-existing, not touched here, surfaced during review:

- **`release.yml:88` — unquoted `${{ env.VERSION }}` interpolated into `run:`, with no semver validation on the tag-derived value.** A command-injection sink reachable by anyone who can push a tag. Worth its own PR.
- Floating major tags on first-party actions (the one third-party action *is* correctly SHA-pinned).
- `build-all.sh` leaves poms modified after a local run (`-DgenerateBackupPoms=false`, no cleanup trap).
- `python/opendataloader-pdf-mcp/pyproject.toml` is never version-bumped — latent, as it isn't published by `release.yml`.

## Re-release

Merging only fixes the script; `v2.5.1` must be re-tagged (or bumped to `v2.5.2`) to actually ship. Flagging for a maintainer decision rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js version update process to run without Git checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->