### PR TITLE
Fix issue with duplicated content ids

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
@@ -24,7 +24,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
 
 public class StaticLayoutContainers {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
@@ -24,12 +24,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
 
 public class StaticLayoutContainers {
     protected static final Logger LOGGER = Logger.getLogger(StaticLayoutContainers.class.getCanonicalName());
 
-    private static final ThreadLocal<Long> currentContentId = new ThreadLocal<>();
+    private static final AtomicLong currentContentId = new AtomicLong(0);
     private static final ThreadLocal<List<SemanticHeading>> headings = new ThreadLocal<>();
     private static final ThreadLocal<Integer> imageIndex = new ThreadLocal<>();
     private static final ThreadLocal<Boolean> isUseStructTree = new ThreadLocal<>();

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class StaticLayoutContainers {
     protected static final Logger LOGGER = Logger.getLogger(StaticLayoutContainers.class.getCanonicalName());
 
-    private static final AtomicLong currentContentId = new AtomicLong(0);
+    private static final ThreadLocal<Long> currentContentId = new ThreadLocal<>();
     private static final ThreadLocal<List<SemanticHeading>> headings = new ThreadLocal<>();
     private static final ThreadLocal<Integer> imageIndex = new ThreadLocal<>();
     private static final ThreadLocal<Boolean> isUseStructTree = new ThreadLocal<>();
@@ -57,7 +57,9 @@ public class StaticLayoutContainers {
     }
 
     public static long incrementContentId() {
-        return currentContentId.getAndIncrement();
+        long id = getCurrentContentId();
+        StaticLayoutContainers.setCurrentContentId(id + 1);
+        return id;
     }
 
     public static void setCurrentContentId(long currentContentId) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/containers/StaticLayoutContainers.java
@@ -57,9 +57,7 @@ public class StaticLayoutContainers {
     }
 
     public static long incrementContentId() {
-        long id = getCurrentContentId();
-        StaticLayoutContainers.setCurrentContentId(id + 1);
-        return id;
+        return currentContentId.getAndIncrement();
     }
 
     public static void setCurrentContentId(long currentContentId) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/TableRowSerializer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/json/serializers/TableRowSerializer.java
@@ -36,6 +36,7 @@ public class TableRowSerializer extends StdSerializer<TableBorderRow> {
         jsonGenerator.writeStartObject();
         jsonGenerator.writeStringField(JsonName.TYPE, JsonName.ROW_TYPE);
         jsonGenerator.writeNumberField(JsonName.ROW_NUMBER, row.getRowNumber() + 1);
+        jsonGenerator.writeNumberField(JsonName.ID, row.getRecognizedStructureId());
         jsonGenerator.writeArrayFieldStart(JsonName.CELLS);
         TableBorderCell[] cells = row.getCells();
         for (int columnNumber = 0; columnNumber < cells.length; columnNumber++) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/CaptionProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/CaptionProcessor.java
@@ -15,12 +15,15 @@
  */
 package org.opendataloader.pdf.processors;
 
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.SemanticCaption;
 import org.verapdf.wcag.algorithms.entities.SemanticFigure;
 import org.verapdf.wcag.algorithms.entities.SemanticTextNode;
 import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
 import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.CaptionUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.NodeUtils;
 
@@ -50,6 +53,18 @@ public class CaptionProcessor {
         for (IObject content : contents) {
             if (content == null) {
                 continue;
+            }
+            if (content instanceof TableBorder) {
+                TableBorder tableBorder = (TableBorder) content;
+                for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
+                    TableBorderRow row = tableBorder.getRow(rowNumber);
+                    for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
+                        TableBorderCell tableBorderCell = row.getCell(colNumber);
+                        if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
+                            processCaptions(tableBorderCell.getContents());
+                        }
+                    }
+                }
             }
             if (content instanceof SemanticTextNode) {
                 SemanticTextNode textNode = (SemanticTextNode) content;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/CaptionProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/CaptionProcessor.java
@@ -56,15 +56,7 @@ public class CaptionProcessor {
             }
             if (content instanceof TableBorder) {
                 TableBorder tableBorder = (TableBorder) content;
-                for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
-                    TableBorderRow row = tableBorder.getRow(rowNumber);
-                    for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
-                        TableBorderCell tableBorderCell = row.getCell(colNumber);
-                        if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
-                            processCaptions(tableBorderCell.getContents());
-                        }
-                    }
-                }
+                processCaptionsInTable(tableBorder);
             }
             if (content instanceof SemanticTextNode) {
                 SemanticTextNode textNode = (SemanticTextNode) content;
@@ -110,6 +102,18 @@ public class CaptionProcessor {
 //                }
 //            }
 //        }
+    }
+
+    private static void processCaptionsInTable(TableBorder tableBorder) {
+        for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
+            TableBorderRow row = tableBorder.getRow(rowNumber);
+            for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
+                TableBorderCell tableBorderCell = row.getCell(colNumber);
+                if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
+                    processCaptions(tableBorderCell.getContents());
+                }
+            }
+        }
     }
 
     private static boolean isImageSubtle(ImageChunk imageChunk) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -44,11 +44,15 @@ import org.verapdf.gf.model.impl.sa.GFSAPDFDocument;
 import org.verapdf.parser.PDFFlavour;
 import org.verapdf.pd.PDDocument;
 import org.verapdf.tools.StaticResources;
-import org.verapdf.wcag.algorithms.entities.IObject;
-import org.verapdf.wcag.algorithms.entities.SemanticTextNode;
+import org.verapdf.wcag.algorithms.entities.*;
 import org.verapdf.wcag.algorithms.entities.content.LineChunk;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+import org.verapdf.wcag.algorithms.entities.lists.ListItem;
+import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.tables.TableBordersCollection;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
 import org.verapdf.wcag.algorithms.semanticalgorithms.consumers.LinesPreprocessingConsumer;
 import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
 import org.verapdf.xmp.containers.StaticXmpCoreContainers;
@@ -272,6 +276,7 @@ public class DocumentProcessor {
 
         // Capture StaticLayoutContainers state (shared mutable — synchronized list for headings)
         final var headings = StaticLayoutContainers.getHeadings();
+        final long contentId = StaticLayoutContainers.getCurrentContentId();
         final boolean useStructTree = StaticLayoutContainers.isUseStructTree();
         final var embeddedImageBytesMap = StaticLayoutContainers.getEmbeddedImageBytesMap();
 
@@ -291,6 +296,7 @@ public class DocumentProcessor {
             StaticContainers.setPassword(config.getPassword());
             // Project StaticLayoutContainers — share the same headings list across workers
             StaticLayoutContainers.setHeadings(headings);
+            StaticLayoutContainers.setCurrentContentId(contentId);
             StaticLayoutContainers.setIsUseStructTree(useStructTree);
             StaticLayoutContainers.setEmbeddedImageBytesMap(embeddedImageBytesMap);
             if (textLineSpaceRatio != null) {
@@ -792,8 +798,47 @@ public class DocumentProcessor {
      * @param contents the list of content objects
      */
     public static void setIDs(List<IObject> contents) {
+        setIDs(contents, false);
+    }
+
+    public static void setIDs(List<IObject> contents, boolean isHybridMode) {
         for (IObject object : contents) {
-            object.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+            if (object.getRecognizedStructureId() == null) {
+                object.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+            }
+            if (!isHybridMode) {
+                if (object instanceof TableBorder) {
+                    TableBorder tableBorder = (TableBorder) object;
+                    for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
+                        TableBorderRow row = tableBorder.getRow(rowNumber);
+                        row.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+                        for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
+                            TableBorderCell tableBorderCell = row.getCell(colNumber);
+                            if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
+                                tableBorderCell.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+                                setIDs(tableBorderCell.getContents());
+                            }
+                        }
+                    }
+                } else if (object instanceof PDFList) {
+                    for (ListItem listItem : ((PDFList) object).getListItems()) {
+                        listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+                        setIDs(listItem.getContents());
+                    }
+                } else if (object instanceof SemanticTOC) {
+                    for (IObject tocItem : ((SemanticTOC) object).getTOCItems()) {
+                        if (tocItem instanceof SemanticTOCI) {
+                            SemanticTOCI toci = (SemanticTOCI) tocItem;
+                            toci.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+                            setIDs(toci.getContents());
+                        } else {
+                            //
+                        }
+                    }
+                } else if (object instanceof SemanticHeaderOrFooter) {
+                    setIDs(((SemanticHeaderOrFooter) object).getContents());
+                }
+            }
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -272,7 +272,6 @@ public class DocumentProcessor {
 
         // Capture StaticLayoutContainers state (shared mutable — synchronized list for headings)
         final var headings = StaticLayoutContainers.getHeadings();
-        final long contentId = StaticLayoutContainers.getCurrentContentId();
         final boolean useStructTree = StaticLayoutContainers.isUseStructTree();
         final var embeddedImageBytesMap = StaticLayoutContainers.getEmbeddedImageBytesMap();
 
@@ -292,7 +291,6 @@ public class DocumentProcessor {
             StaticContainers.setPassword(config.getPassword());
             // Project StaticLayoutContainers — share the same headings list across workers
             StaticLayoutContainers.setHeadings(headings);
-            StaticLayoutContainers.setCurrentContentId(contentId);
             StaticLayoutContainers.setIsUseStructTree(useStructTree);
             StaticLayoutContainers.setEmbeddedImageBytesMap(embeddedImageBytesMap);
             if (textLineSpaceRatio != null) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -807,38 +807,42 @@ public class DocumentProcessor {
                 object.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
             }
             if (!isHybridMode) {
-                if (object instanceof TableBorder) {
-                    TableBorder tableBorder = (TableBorder) object;
-                    for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
-                        TableBorderRow row = tableBorder.getRow(rowNumber);
-                        row.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
-                        for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
-                            TableBorderCell tableBorderCell = row.getCell(colNumber);
-                            if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
-                                tableBorderCell.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
-                                setIDs(tableBorderCell.getContents());
-                            }
-                        }
+                setIDsInComplexObject(object);
+            }
+        }
+    }
+
+    public static void setIDsInComplexObject(IObject object) {
+        if (object instanceof TableBorder) {
+            TableBorder tableBorder = (TableBorder) object;
+            for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
+                TableBorderRow row = tableBorder.getRow(rowNumber);
+                row.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+                for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
+                    TableBorderCell tableBorderCell = row.getCell(colNumber);
+                    if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
+                        tableBorderCell.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+                        setIDs(tableBorderCell.getContents());
                     }
-                } else if (object instanceof PDFList) {
-                    for (ListItem listItem : ((PDFList) object).getListItems()) {
-                        listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
-                        setIDs(listItem.getContents());
-                    }
-                } else if (object instanceof SemanticTOC) {
-                    for (IObject tocItem : ((SemanticTOC) object).getTOCItems()) {
-                        if (tocItem instanceof SemanticTOCI) {
-                            SemanticTOCI toci = (SemanticTOCI) tocItem;
-                            toci.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
-                            setIDs(toci.getContents());
-                        } else {
-                            //
-                        }
-                    }
-                } else if (object instanceof SemanticHeaderOrFooter) {
-                    setIDs(((SemanticHeaderOrFooter) object).getContents());
                 }
             }
+        } else if (object instanceof PDFList) {
+            for (ListItem listItem : ((PDFList) object).getListItems()) {
+                listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+                setIDs(listItem.getContents());
+            }
+        } else if (object instanceof SemanticTOC) {
+            for (IObject tocItem : ((SemanticTOC) object).getTOCItems()) {
+                if (tocItem instanceof SemanticTOCI) {
+                    SemanticTOCI toci = (SemanticTOCI) tocItem;
+                    toci.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+                    setIDs(toci.getContents());
+                } else {
+                    //
+                }
+            }
+        } else if (object instanceof SemanticHeaderOrFooter) {
+            setIDs(((SemanticHeaderOrFooter) object).getContents());
         }
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HeaderFooterProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HeaderFooterProcessor.java
@@ -132,7 +132,6 @@ public class HeaderFooterProcessor {
             }
             SemanticHeaderOrFooter semanticHeaderOrFooter = new SemanticHeaderOrFooter(isHeaderDetection ? SemanticType.HEADER : SemanticType.FOOTER);
             semanticHeaderOrFooter.addContents(headerContents);
-            semanticHeaderOrFooter.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
             headersOrFooters.add(semanticHeaderOrFooter);
         }
         return headersOrFooters;
@@ -142,7 +141,6 @@ public class HeaderFooterProcessor {
         List<IObject> newContents = ParagraphProcessor.processParagraphs(contents);
         newContents = ListProcessor.processListsFromTextNodes(newContents);
         HeadingProcessor.processHeadings(newContents, false);
-        DocumentProcessor.setIDs(newContents);
         CaptionProcessor.processCaptions(newContents);
         return newContents;
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -16,6 +16,7 @@
 package org.opendataloader.pdf.processors;
 
 import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.opendataloader.pdf.entities.EnrichedImageChunk;
 import org.opendataloader.pdf.entities.SemanticFormula;
 import org.opendataloader.pdf.entities.SemanticPicture;
@@ -754,7 +755,7 @@ public class HybridDocumentProcessor {
                         for (IObject obj : pageContents) {
                             oldIds.add(obj.getRecognizedStructureId());
                         }
-                        DocumentProcessor.setIDs(pageContents);
+                        DocumentProcessor.setIDs(pageContents, true);
                         rekeyMetadata(transformer, oldIds, pageContents);
                         results.put(page0, pageContents);
                     } else {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -480,6 +480,21 @@ public class ListProcessor {
         return true;
     }
 
+    public static void checkNeighborListsInTable(TableBorder tableBorder) {
+        for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
+            TableBorderRow row = tableBorder.getRow(rowNumber);
+            for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
+                TableBorderCell tableBorderCell = row.getCell(colNumber);
+                if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
+                    List<List<IObject>> contentsList = new ArrayList<>(1);
+                    contentsList.add(tableBorderCell.getContents());
+                    checkNeighborLists(contentsList);
+                    tableBorderCell.setContents(contentsList.get(0));
+                }
+            }
+        }
+    }
+
     public static void checkNeighborLists(List<List<IObject>> contents) {
         PDFList previousList = null;
         SemanticTextNode middleContent = null;
@@ -488,17 +503,7 @@ public class ListProcessor {
             for (IObject content : pageContents) {
                 if (content instanceof TableBorder) {
                     TableBorder tableBorder = (TableBorder) content;
-                    for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
-                        TableBorderRow row = tableBorder.getRow(rowNumber);
-                        for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
-                            TableBorderCell tableBorderCell = row.getCell(colNumber);
-                            if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
-                                List<List<IObject>> contentsList = new ArrayList<>(1);
-                                contentsList.add(tableBorderCell.getContents());
-                                checkNeighborLists(contentsList);
-                            }
-                        }
-                    }
+                    checkNeighborListsInTable(tableBorder);
                 }
                 if (content instanceof PDFList) {
                     PDFList currentList = (PDFList) content;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -135,7 +135,6 @@ public class ListProcessor {
             PDFList list = calculateList(interval, index, interval.getNumberOfListItems() - 1, contents.get(isTableCell ? 0 : currentPageNumber));
             for (ListItem listItem : list.getListItems()) {
                 listItem.setContents(processListItemContent(listItem.getContents()));
-                listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
             }
             if (previousList != null) {
                 PDFList.setListConnected(previousList, list);
@@ -287,6 +286,7 @@ public class ListProcessor {
                 addContentToLastPageListItem(nextIndex, currentInfo, pageContents, listItem);
             }
             listItem.setLabelLength(currentInfo.getLabelLength());
+            listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
             list.add(listItem);
         }
         if (list.getListItems().isEmpty()) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.opendataloader.pdf.processors;
 
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.opendataloader.pdf.utils.BulletedParagraphUtils;
 import org.verapdf.as.ASAtom;
 import org.verapdf.wcag.algorithms.entities.INode;
@@ -134,6 +135,7 @@ public class ListProcessor {
             PDFList list = calculateList(interval, index, interval.getNumberOfListItems() - 1, contents.get(isTableCell ? 0 : currentPageNumber));
             for (ListItem listItem : list.getListItems()) {
                 listItem.setContents(processListItemContent(listItem.getContents()));
+                listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
             }
             if (previousList != null) {
                 PDFList.setListConnected(previousList, list);

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ListProcessor.java
@@ -31,6 +31,9 @@ import org.verapdf.wcag.algorithms.entities.lists.PDFList;
 import org.verapdf.wcag.algorithms.entities.lists.TextListInterval;
 import org.verapdf.wcag.algorithms.entities.lists.info.ListItemInfo;
 import org.verapdf.wcag.algorithms.entities.lists.info.ListItemTextInfo;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorder;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderCell;
+import org.verapdf.wcag.algorithms.entities.tables.tableBorders.TableBorderRow;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ChunksMergeUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ListLabelsUtils;
 import org.verapdf.wcag.algorithms.semanticalgorithms.utils.ListUtils;
@@ -146,7 +149,6 @@ public class ListProcessor {
     private static List<IObject> processListItemContent(List<IObject> contents) {
         List<IObject> newContents = ParagraphProcessor.processParagraphs(contents);
         newContents = ListProcessor.processListsFromTextNodes(newContents);
-        DocumentProcessor.setIDs(newContents);
         List<List<IObject>> contentsList = new ArrayList<>(1);
         contentsList.add(newContents);
         ListProcessor.checkNeighborLists(contentsList);
@@ -155,7 +157,7 @@ public class ListProcessor {
     }
 
     private static void processTextNodeListItemContent(List<IObject> contents) {
-        DocumentProcessor.setIDs(contents);
+        DocumentProcessor.setIDs(contents, true);
     }
 
     private static List<TextListInterval> getTextLabelListIntervals(List<List<IObject>> contents) {
@@ -256,6 +258,10 @@ public class ListProcessor {
     }
 
     private static PDFList calculateList(TextListInterval interval, int startIndex, int endIndex, List<IObject> pageContents) {
+        return calculateList(interval, startIndex, endIndex, pageContents, false);
+    }
+
+    private static PDFList calculateList(TextListInterval interval, int startIndex, int endIndex, List<IObject> pageContents, boolean isHybrid) {
         PDFList list = new PDFList();
         list.setNumberingStyle(interval.getNumberingStyle());
         list.setCommonPrefix(interval.getCommonPrefix());
@@ -286,7 +292,9 @@ public class ListProcessor {
                 addContentToLastPageListItem(nextIndex, currentInfo, pageContents, listItem);
             }
             listItem.setLabelLength(currentInfo.getLabelLength());
-            listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+            if (isHybrid) {
+                listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+            }
             list.add(listItem);
         }
         if (list.getListItems().isEmpty()) {
@@ -401,6 +409,10 @@ public class ListProcessor {
     }
 
     public static List<IObject> processListsFromTextNodes(List<IObject> contents) {
+        return processListsFromTextNodes(contents, false);
+    }
+
+    public static List<IObject> processListsFromTextNodes(List<IObject> contents, boolean isHybrid) {
         List<SemanticTextNode> textNodes = new ArrayList<>();
         List<Integer> textNodesIndexes = new ArrayList<>();
         for (int index = 0; index < contents.size(); index++) {
@@ -420,9 +432,11 @@ public class ListProcessor {
                 continue;
             }
             textListInterval.setCommonSuffixLengthToAllInfos();
-            PDFList list = calculateList(textListInterval, 0, interval.getNumberOfListItems() - 1, contents);
-            for (ListItem listItem : list.getListItems()) {
-                processTextNodeListItemContent(listItem.getContents());
+            PDFList list = calculateList(textListInterval, 0, interval.getNumberOfListItems() - 1, contents, isHybrid);
+            if (isHybrid) {
+                for (ListItem listItem : list.getListItems()) {
+                    processTextNodeListItemContent(listItem.getContents());
+                }
             }
         }
         return DocumentProcessor.removeNullObjectsFromList(contents);
@@ -472,6 +486,20 @@ public class ListProcessor {
         for (List<IObject> pageContents : contents) {
             DocumentProcessor.setIndexesForContentsList(pageContents);
             for (IObject content : pageContents) {
+                if (content instanceof TableBorder) {
+                    TableBorder tableBorder = (TableBorder) content;
+                    for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
+                        TableBorderRow row = tableBorder.getRow(rowNumber);
+                        for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
+                            TableBorderCell tableBorderCell = row.getCell(colNumber);
+                            if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
+                                List<List<IObject>> contentsList = new ArrayList<>(1);
+                                contentsList.add(tableBorderCell.getContents());
+                                checkNeighborLists(contentsList);
+                            }
+                        }
+                    }
+                }
                 if (content instanceof PDFList) {
                     PDFList currentList = (PDFList) content;
                     if (previousList != null) {

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableBorderProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableBorderProcessor.java
@@ -167,6 +167,7 @@ public class TableBorderProcessor {
 
     static TableBorder normalizeAndProcessTableBorder(List<IObject> rawPageContents, TableBorder tableBorder, int pageNumber) {
         TableBorder normalizedTable = TableStructureNormalizer.normalize(rawPageContents, tableBorder);
+        normalizedTable.setRecognizedStructureId(null);
         processTableBorderContents(normalizedTable, pageNumber);
         return normalizedTable;
     }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableBorderProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableBorderProcessor.java
@@ -15,7 +15,6 @@
  */
 package org.opendataloader.pdf.processors;
 
-import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.content.LineArtChunk;
 import org.verapdf.wcag.algorithms.entities.content.LineChunk;
@@ -175,10 +174,8 @@ public class TableBorderProcessor {
     private static void processTableBorderContents(TableBorder tableBorder, int pageNumber) {
         for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
             TableBorderRow row = tableBorder.getRow(rowNumber);
-            row.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
             for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
                 TableBorderCell tableBorderCell = row.getCell(colNumber);
-                tableBorderCell.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
                 if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
                     tableBorderCell.setContents(processTableCellContent(tableBorderCell.getContents(), pageNumber));
                 }
@@ -196,11 +193,6 @@ public class TableBorderProcessor {
         newContents = ParagraphProcessor.processParagraphs(newContents);
         newContents = ListProcessor.processListsFromTextNodes(newContents);
         HeadingProcessor.processHeadings(newContents, true);
-        DocumentProcessor.setIDs(newContents);
-        CaptionProcessor.processCaptions(newContents);
-        contentsList.set(0, newContents);
-        ListProcessor.checkNeighborLists(contentsList);
-        newContents = contentsList.get(0);
         return newContents;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableBorderProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableBorderProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.opendataloader.pdf.processors;
 
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.content.LineArtChunk;
 import org.verapdf.wcag.algorithms.entities.content.LineChunk;
@@ -174,8 +175,10 @@ public class TableBorderProcessor {
     private static void processTableBorderContents(TableBorder tableBorder, int pageNumber) {
         for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
             TableBorderRow row = tableBorder.getRow(rowNumber);
+            row.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
             for (int colNumber = 0; colNumber < tableBorder.getNumberOfColumns(); colNumber++) {
                 TableBorderCell tableBorderCell = row.getCell(colNumber);
+                tableBorderCell.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
                 if (tableBorderCell.getRowNumber() == rowNumber && tableBorderCell.getColNumber() == colNumber) {
                     tableBorderCell.setContents(processTableCellContent(tableBorderCell.getContents(), pageNumber));
                 }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableOfContentsProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableOfContentsProcessor.java
@@ -91,7 +91,6 @@ public class TableOfContentsProcessor {
 
     private static List<IObject> processTOCItemContent(List<IObject> contents) {
         List<IObject> newContents = ParagraphProcessor.processParagraphs(contents);
-        DocumentProcessor.setIDs(newContents);
         return newContents;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TaggedDocumentProcessor.java
@@ -55,7 +55,6 @@ public class TaggedDocumentProcessor {
             if (!shouldProcessPage(pageNumber)) {
                 continue;
             }
-            DocumentProcessor.setIDs(artifacts.get(pageNumber));
             contents.get(pageNumber).addAll(artifacts.get(pageNumber));
         }
         for (int pageNumber = 0; pageNumber < totalPages; pageNumber++) {
@@ -64,6 +63,7 @@ public class TaggedDocumentProcessor {
             }
             List<IObject> pageContents = TextLineProcessor.processTextLines(contents.get(pageNumber));
             contents.set(pageNumber, ParagraphProcessor.processParagraphs(pageContents));
+            DocumentProcessor.setIDs(contents.get(pageNumber));
         }
         return contents;
     }
@@ -150,13 +150,15 @@ public class TaggedDocumentProcessor {
     private static void addObjectToContent(IObject object) {
         Integer pageNumber = object.getPageNumber();
         if (pageNumber != null && shouldProcessPage(pageNumber)) {
+            if (!(object instanceof TextChunk) && object.getRecognizedStructureId() == null) {
+                object.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+            }
             if (contentsStack.isEmpty()) {
                 contents.get(pageNumber).add(object);
             } else {
                 contentsStack.peek().add(object);
             }
         }
-        object.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
     }
 
     private static void processParagraph(INode paragraph) {
@@ -231,7 +233,6 @@ public class TaggedDocumentProcessor {
                 listItem.getContents().add(content);
             }
         }
-        listItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
         return listItem;
     }
 
@@ -306,6 +307,7 @@ public class TaggedDocumentProcessor {
         }
         TableBorder tableBorder = new TableBorder(tableBoundingBox, createRowsForTable(table, numberOfRows, numberOfColumns),
             numberOfRows, numberOfColumns);
+        tableBorder.setRecognizedStructureId(null);
         setBoundingBoxesForTableRowsAndTableCells(tableBorder);
         addObjectToContent(tableBorder);
     }
@@ -370,14 +372,15 @@ public class TaggedDocumentProcessor {
             }
         }
         if (!textBlock.isEmpty()) {
-            cell.getContents().add(ParagraphProcessor.createParagraphFromTextBlock(textBlock));
+            SemanticParagraph newParagraph = ParagraphProcessor.createParagraphFromTextBlock(textBlock);
+            newParagraph.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
+            cell.getContents().add(newParagraph);
         }
         BoundingBox cellBoundingBox = new MultiBoundingBox();
         for (IObject content : cell.getContents()) {
             cellBoundingBox.union(content.getBoundingBox());
         }
         cell.setBoundingBox(cellBoundingBox);
-        cell.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
     }
 
     private static void processChildContents(INode elem, List<IObject> contents) {
@@ -399,7 +402,6 @@ public class TaggedDocumentProcessor {
                 if (rows[rowNumber].getCell(colNumber) == null) {
                     TableBorderCell cell = new TableBorderCell(rowNumber, colNumber, 1, 1, 0L);
                     cell.setSemanticType(SemanticType.TABLE_CELL);
-                    cell.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
                     rows[rowNumber].getCells()[colNumber] = cell;
                 }
             }
@@ -469,7 +471,6 @@ public class TaggedDocumentProcessor {
                 tocItem.getContents().add(content);
             }
         }
-        tocItem.setRecognizedStructureId(StaticLayoutContainers.incrementContentId());
         return tocItem;
     }
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,7 +58,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <verapdf.version>1.31.155</verapdf.version>
+        <verapdf.version>1.31.160</verapdf.version>
         <verapdf.wcag.algs.version>1.31.43</verapdf.wcag.algs.version>
         <jackson.databind.version>2.22.1</jackson.databind.version>
         <junit.jupiter.version>6.1.2</junit.jupiter.version>


### PR DESCRIPTION
Add ids to ListItem, TableRow and TableCell

<!-- Thank you for your contribution! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Serialized table rows now include their recognized structure ID in the `id` field.
  - IDs are assigned more consistently across nested document content, including tables, lists, headers, footers, and table of contents items.
  - Hybrid processing now supports dedicated handling for nested structures and list items.

- **Bug Fixes**
  - Improved recursive processing of captions and lists inside table cells.
  - Prevented unnecessary IDs from being assigned to text chunks and selected container elements.
  - Improved table and nested-content structure consistency in exported results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->