### PR TITLE
ci: sync reference docs to homepage staging branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,6 @@ jobs:
           destination-github-username: 'opendataloader-project'
           destination-repository-name: 'opendataloader.org'
           target-directory: 'apps/v1/content/docs/reference'
-          target-branch: main
+          target-branch: staging
         env:
           API_TOKEN_GITHUB: ${{ secrets.HOMEPAGE_SYNC_TOKEN }}


### PR DESCRIPTION
## What

Release pushed generated CLI/schema reference docs straight to `opendataloader.org` `main`, which auto-deploys production on push. A release therefore published docs with no review step.

## Change

- `target-branch: main` → `staging` on the docs push step in `.github/workflows/release.yml`
- `staging` deploys as a preview, so docs land reviewable and reach production through the normal `staging` → `main` promotion

## Note

Reference docs for a release now wait on `staging` — promoting `staging` → `main` on the homepage repo is what publishes them to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reference documentation synchronization to publish to the homepage’s staging branch instead of the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->