### PR TITLE
Drop the enforcer ignore that muted the wcag-algorithms range

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -158,8 +158,8 @@
               than four numbers copied into this file.
 
               Only wcag-algorithms stays a range in the released pom, which is
-              why it is pinned separately above and excluded from the enforcer
-              rule below.
+              why it is pinned separately above. That pin is what keeps the
+              enforcer rule below satisfied.
             -->
             <dependency>
                 <groupId>org.verapdf</groupId>
@@ -337,23 +337,19 @@
                         </goals>
                         <configuration>
                             <rules>
+                                <!--
+                                  No <ignores>. wcag-validation declares
+                                  wcag-algorithms as a range, but the pin in
+                                  <properties> replaces it before this rule sees
+                                  the graph, so the rule passes as configured.
+                                  Ignoring the coordinate would only suppress the
+                                  failure that the pin's removal is supposed to
+                                  cause: without the pin the range resolves to
+                                  whatever is newest upstream rather than the
+                                  version we tested.
+                                -->
                                 <banDynamicVersions>
                                     <allowSnapshots>false</allowSnapshots>
-                                    <!--
-                                      wcag-validation declares wcag-algorithms as
-                                      a range. Redundant while the pin in
-                                      <properties> stands, since dependency-
-                                      Management replaces the range before this
-                                      rule inspects the graph. Retained so that
-                                      dropping the pin fails loudly on the range
-                                      instead of silently drifting: with the pin
-                                      removed the range resolves to whatever is
-                                      newest upstream, not to the version we
-                                      tested against.
-                                    -->
-                                    <ignores>
-                                        <ignore>org.verapdf:wcag-algorithms</ignore>
-                                    </ignores>
                                 </banDynamicVersions>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Follow-up to #697, addressing CodeRabbit's review comment on that PR.

## The problem

#697 added `org.verapdf:wcag-algorithms` to `banDynamicVersions.ignores`, with a comment arguing it was redundant while the pin stood but would make a dropped pin "fail loudly on the range instead of silently drifting."

That reasoning was backwards. CodeRabbit flagged it, and measuring the three states confirms it:

| `<ignores>` | pin | result |
|---|---|---|
| removed | present | rule **passes** — the entry was doing nothing |
| removed | removed | rule **FAILS**: `wcag-algorithms:1.31.44 (compile) via wcag-validation:1.31.160 is referenced with a banned dynamic version [1.31.0,1.32.0-RC)` |
| present | removed | rule **passes** — drift is silent |

The pin replaces the range before the rule inspects the graph, so the ignore never contributed anything while the pin was in place. Its only effect was to suppress the exact failure that made the safeguard worth having. Note the resolved version in row 2 is **1.31.44**, not the pinned 1.31.43 — concrete evidence the pin is load-bearing and that a silent drift is a real outcome, not a hypothetical.

## Change

Remove the `<ignores>` block and replace the comment with one that states why no ignore belongs there.

Also corrects a stale line in the BOM-import comment that said wcag-algorithms is "excluded from the enforcer rule below" — it is the pin, not an exclusion, that keeps the rule satisfied.

## Verification

- 851 tests pass (822 core + 29 cli)
- `BanDynamicVersions` passes on all three modules with no ignores
- Failure mode confirmed by temporarily removing the pin, as tabulated above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Maven Enforcer configuration guidance.
  - Removed outdated guidance about ignoring `wcag-algorithms`.
  - Documented that the pinned version satisfies dynamic-version enforcement requirements.
  - Updated dependency-management notes to explain why the version must remain pinned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->