### PR TITLE
perf(hybrid): skip the OCR layout pass when ocr-strategy is off

### DIFF
--- a/java/opendataloader-pdf-cli/pom.xml
+++ b/java/opendataloader-pdf-cli/pom.xml
@@ -60,12 +60,14 @@
             <artifactId>wcag-algorithms</artifactId>
         </dependency>
         <!-- CLIMainTest and FormatLogRegressionTest build fixture PDFs with
-             PDDocument / PDPage / StandardProtectionPolicy. Test-scope only: no
-             main code here touches PDFBox. -->
+             PDDocument / PDPage / StandardProtectionPolicy. No main code here
+             touches PDFBox, but the scope must stay compile: core reaches
+             PDFBox at runtime (HancomAIClient, PDFWriter), and declaring it
+             test-scope here downgrades that transitive compile dependency and
+             drops the artifact out of the shaded CLI jar. -->
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -195,7 +195,9 @@ public class CLIOptions {
             "hybrid-hancom-ai-ocr-strategy";
     private static final String HYBRID_HANCOM_AI_OCR_STRATEGY_DESC =
             "OCR strategy. Requires --hybrid=hancom-ai. "
-            + "Values: off (stream-only), auto (default; stream first, OCR fallback), force (OCR-only)";
+            + "Values: off (default; stream-only, uses the cheaper OCR-free layout "
+            + "module), auto (stream first, OCR fallback), force (OCR-only). "
+            + "Scanned documents need auto or force";
 
     private static final String HYBRID_HANCOM_AI_IMAGE_CACHE_LONG_OPTION =
             "hybrid-hancom-ai-image-cache";
@@ -289,7 +291,7 @@ public class CLIOptions {
             new OptionDefinition(HYBRID_HANCOM_AI_REGIONLIST_STRATEGY_LONG_OPTION, null, "string",
                     "table-first", HYBRID_HANCOM_AI_REGIONLIST_STRATEGY_DESC, true),
             new OptionDefinition(HYBRID_HANCOM_AI_OCR_STRATEGY_LONG_OPTION, null, "string",
-                    "auto", HYBRID_HANCOM_AI_OCR_STRATEGY_DESC, true),
+                    HybridConfig.OCR_OFF, HYBRID_HANCOM_AI_OCR_STRATEGY_DESC, true),
             new OptionDefinition(HYBRID_HANCOM_AI_IMAGE_CACHE_LONG_OPTION, null, "string",
                     "memory", HYBRID_HANCOM_AI_IMAGE_CACHE_DESC, true),
             // "string" rather than a numeric type: the option table only knows

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAIClient.java
@@ -56,7 +56,9 @@ import java.util.logging.Logger;
  * <p>Pipeline:
  * <ol>
  *   <li>pdf2img — convert each page to PNG image</li>
- *   <li>DOCUMENT_LAYOUT_WITH_OCR — layout analysis + OCR on full PDF</li>
+ *   <li>layout on the full PDF — DOCUMENT_LAYOUT_ANALYSIS, or
+ *       DOCUMENT_LAYOUT_WITH_OCR when the OCR strategy needs the text
+ *       (see {@link #layoutModule()})</li>
  *   <li>TABLE_STRUCTURE_RECOGNITION — crop each Table/Regionlist from page image, send to TSR individually</li>
  *   <li>IMAGE_CAPTIONING_EN — crop each visual region (Figure/Chart/Image) and caption it in English</li>
  *   <li>FORMULA_RECOGNITION — crop each Equation region and read it as LaTeX</li>
@@ -101,8 +103,30 @@ public class HancomAIClient implements HybridClient {
      */
     private static final String CAPTION_MODULE = "IMAGE_CAPTIONING_EN";
 
-    /** Layout + OCR module: the required first pass every other pass reads. */
-    private static final String LAYOUT_MODULE = "DOCUMENT_LAYOUT_WITH_OCR";
+    /**
+     * Layout module that also returns OCR text, used when the OCR strategy
+     * asks for it.
+     */
+    private static final String LAYOUT_MODULE_WITH_OCR = "DOCUMENT_LAYOUT_WITH_OCR";
+
+    /**
+     * Layout-only module: geometry with no {@code ocrtext} and no
+     * {@code words[]}. Roughly 4x cheaper than the OCR variant, which is the
+     * whole point of preferring it when the text is going to come from the PDF
+     * content stream anyway.
+     */
+    private static final String LAYOUT_MODULE_DLA_ONLY = "DOCUMENT_LAYOUT_ANALYSIS";
+
+    /**
+     * Key the layout result is filed under in the merged response.
+     *
+     * <p>Deliberately not the wire module name: which layout module runs is a
+     * per-call decision (see {@link #layoutModule()}), while this key is a
+     * fixed contract with {@link HancomAISchemaTransformer}. Keeping them
+     * separate means switching layout modules cannot silently empty the
+     * transformer's input.
+     */
+    static final String LAYOUT_RESULT_KEY = "DOCUMENT_LAYOUT_WITH_OCR";
 
     /** Formula module; returns LaTeX in a {@code formula} field. */
     private static final String FORMULA_MODULE = "FORMULA_RECOGNITION";
@@ -189,6 +213,21 @@ public class HancomAIClient implements HybridClient {
         m.put("FORMULA_RECOGNITION", "formula");
         m.put("CHART_IMAGE_UNDERSTANDING", "chart");
         MODULE_SHORT = java.util.Collections.unmodifiableMap(m);
+    }
+
+    /**
+     * The layout module this call should use.
+     *
+     * <p>With {@code --hybrid-hancom-ai-ocr-strategy off} the text comes from
+     * the PDF content stream, so paying for OCR would buy nothing: the
+     * layout-only module returns the same geometry for a fraction of the cost.
+     * {@code auto} needs the OCR text to compare the stream against, and
+     * {@code force} uses it outright, so both keep the OCR variant.
+     */
+    private String layoutModule() {
+        return config != null && HybridConfig.OCR_OFF.equals(config.getOcrStrategy())
+            ? LAYOUT_MODULE_DLA_ONLY
+            : LAYOUT_MODULE_WITH_OCR;
     }
 
     private static String sha256ShortHex(byte[] data) {
@@ -307,11 +346,14 @@ public class HancomAIClient implements HybridClient {
             // so this is the only place that catches it on that path.
             if (HancomPageRenumber.pagesOf(dlaOcrResult).isEmpty()) {
                 throw new IOException(
-                    "Hancom AI DOCUMENT_LAYOUT_WITH_OCR returned empty result — "
+                    "Hancom AI " + layoutModule() + " returned empty result — "
                     + "backend unavailable or rejected the document");
             }
-            merged.set(LAYOUT_MODULE, dlaOcrResult);
-            addTimings(timingsNode, LAYOUT_MODULE, dlaOcrResult);
+            merged.set(LAYOUT_RESULT_KEY, dlaOcrResult);
+            // Timings are filed under the module actually called, not the fixed
+            // result key: the two layout modules differ ~2.7x in cost, so a
+            // shared label would compare unlike things across runs.
+            addTimings(timingsNode, layoutModule(), dlaOcrResult);
 
             // Step 2: Table Structure — crop each Table region from page image, send to TSR individually
             long tsrStartMs = System.currentTimeMillis();
@@ -434,7 +476,7 @@ public class HancomAIClient implements HybridClient {
         // limit exists to refuse.
         boolean wholeDocument = pages0Based.size() == resolved.pageCount;
         if (wholeDocument && (chunk <= 0 || pages0Based.size() <= chunk)) {
-            JsonNode whole = callModule(pdfBytes, LAYOUT_MODULE);
+            JsonNode whole = callModule(pdfBytes, layoutModule());
             // Page numbers are already absolute on this path — the backend saw
             // the whole file — so there is nothing to renumber, but the pages
             // still have to be accounted for. A reply covering fewer pages than
@@ -460,7 +502,7 @@ public class HancomAIClient implements HybridClient {
             JsonNode sliceResult = null;
             try {
                 byte[] slicePdf = HancomPdfPageSlicer.extractPages(pdfBytes, slice);
-                sliceResult = callModule(slicePdf, LAYOUT_MODULE, slice);
+                sliceResult = callModule(slicePdf, layoutModule(), slice);
             } catch (IOException | RuntimeException e) {
                 // A slice that fails to build or send is a per-slice problem:
                 // losing 20 pages must not cost the other 200, so the failure is

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -394,7 +394,6 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
 
         // Get DLA+OCR results (primary source for layout + text)
         JsonNode dlaOcr = json.get(HancomAIClient.LAYOUT_RESULT_KEY);
-        JsonNode tables = json.get("TABLE_STRUCTURE_RECOGNITION");
         JsonNode figureCaptions = json.get("FIGURE_CAPTIONS");
         JsonNode formulaResults = json.get("FORMULA_RESULTS");
 
@@ -677,14 +676,22 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 break;
 
             case LABEL_REGIONLIST:
+                // Not routed through dropEmpty: a list's items come from
+                // splitting the region text on newlines, so with no text there
+                // is nothing to build items from and createListFromText returns
+                // null regardless. A text-free label 7 region is therefore lost
+                // even under a geometry-only layout module — enrichment fills
+                // existing nodes but cannot invent the list structure. Tracked
+                // separately; keeping the plain check here states the limit
+                // instead of implying the region survives.
                 if (HybridConfig.REGIONLIST_LIST_ONLY.equals(regionlistStrategy)) {
                     // list-only: always treat as list, skip TSR check
-                    iobj = dropEmpty(text) ? null : createListFromText(text, bbox);
+                    iobj = createListFromText(text, bbox);
                 } else {
                     // table-first (default): if TSR covers it, skip (table handled separately)
                     if (hasOverlappingTsr(bbox, tsrTableBboxes)) return null;
                     // No TSR data — treat as list (parse text by newlines into ListItems)
-                    iobj = dropEmpty(text) ? null : createListFromText(text, bbox);
+                    iobj = createListFromText(text, bbox);
                 }
                 break;
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HancomAISchemaTransformer.java
@@ -56,7 +56,11 @@ import java.util.regex.Pattern;
  *
  * <p>The merged JSON from {@link HancomAIClient} contains results from three modules:
  * <ul>
- *   <li>{@code DOCUMENT_LAYOUT_WITH_OCR} — objects with label + bbox + ocrtext</li>
+ *   <li>{@code DOCUMENT_LAYOUT_WITH_OCR} — objects with label + bbox, plus
+ *       {@code ocrtext} and {@code words[]} when the layout module ran OCR.
+ *       With {@code --hybrid-hancom-ai-ocr-strategy off} the layout module
+ *       returns geometry only and the text is filled in later from the PDF
+ *       content stream; the key is fixed either way.</li>
  *   <li>{@code TABLE_STRUCTURE_RECOGNITION} — table cells with html + bbox</li>
  *   <li>{@code IMAGE_CAPTIONING_EN} — per-figure captions (English)</li>
  *   <li>{@code FORMULA_RECOGNITION} — per-equation LaTeX</li>
@@ -314,6 +318,20 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     }
 
     private int pictureIndex;
+
+    /**
+     * True when the layout response carried no per-object text at all.
+     *
+     * <p>{@code DOCUMENT_LAYOUT_ANALYSIS} returns geometry only — no
+     * {@code ocrtext}, no {@code words[]} — so every text region arrives empty
+     * and the text is supplied later from the PDF content stream by
+     * {@code HybridDocumentProcessor}. Dropping empty regions here, as is right
+     * when OCR ran and genuinely found nothing, would discard the very regions
+     * that enrichment is about to fill: it matches Java TextChunks to a region's
+     * bbox, so the region must survive this far to receive its text.
+     */
+    private boolean layoutTextAbsent;
+
     private String regionlistStrategy = HybridConfig.REGIONLIST_TABLE_FIRST;
     private Map<Long, ElementMetadata> elementMetadataMap = new LinkedHashMap<>();
     private Map<Integer, List<OcrWordInfo>> ocrWordsByPage = new HashMap<>();
@@ -375,13 +393,14 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         ocrWordsByPage.clear();
 
         // Get DLA+OCR results (primary source for layout + text)
-        JsonNode dlaOcr = json.get("DOCUMENT_LAYOUT_WITH_OCR");
+        JsonNode dlaOcr = json.get(HancomAIClient.LAYOUT_RESULT_KEY);
         JsonNode tables = json.get("TABLE_STRUCTURE_RECOGNITION");
         JsonNode figureCaptions = json.get("FIGURE_CAPTIONS");
         JsonNode formulaResults = json.get("FORMULA_RESULTS");
 
         // Determine page count from DLA results
         List<JsonNode> dlaPages = extractPages(dlaOcr);
+        layoutTextAbsent = !anyObjectCarriesText(dlaPages);
         int numPages = Math.max(dlaPages.size(), pageHeights != null ?
             pageHeights.keySet().stream().mapToInt(Integer::intValue).max().orElse(0) : 0);
 
@@ -539,7 +558,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
         // When the caller passes a raw single-page DLA node (no wrapper), rewrap it so
         // extractPages() can find it; otherwise transform() sees no pages and returns empty.
         JsonNode wrapped = pageContent;
-        if (pageContent != null && pageContent.get("DOCUMENT_LAYOUT_WITH_OCR") == null) {
+        if (pageContent != null && pageContent.get(HancomAIClient.LAYOUT_RESULT_KEY) == null) {
             ObjectNode page = pageContent.isObject()
                 ? ((ObjectNode) pageContent).deepCopy()
                 : JsonNodeFactory.instance.objectNode();
@@ -547,7 +566,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             ArrayNode pages = JsonNodeFactory.instance.arrayNode();
             pages.add(page);
             ObjectNode root = JsonNodeFactory.instance.objectNode();
-            root.set("DOCUMENT_LAYOUT_WITH_OCR", pages);
+            root.set(HancomAIClient.LAYOUT_RESULT_KEY, pages);
             wrapped = root;
         }
 
@@ -560,6 +579,43 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
     /**
      * Transforms a single DLA object to an IObject based on its label.
      */
+    /**
+     * Whether any object in the layout response carries text.
+     *
+     * <p>Decided from the response rather than from the configured module name:
+     * what matters downstream is whether text actually arrived, and a layout
+     * module that stops returning it would otherwise change behaviour silently.
+     * A document whose every region is legitimately empty reads the same as a
+     * text-free module here, which is harmless — there is no text to drop.
+     */
+    private static boolean anyObjectCarriesText(List<JsonNode> dlaPages) {
+        for (JsonNode page : dlaPages) {
+            JsonNode objects = page.get("objects");
+            if (objects == null || !objects.isArray()) continue;
+            for (JsonNode obj : objects) {
+                if (obj.hasNonNull("ocrtext") && !obj.get("ocrtext").asText("").isEmpty()) {
+                    return true;
+                }
+                JsonNode words = obj.get("words");
+                if (words != null && words.isArray() && words.size() > 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether a region carrying no text should be dropped.
+     *
+     * <p>Only when the layout module supplied text for this document: an empty
+     * region then means OCR looked and found nothing. When the module returns
+     * geometry only, the region is kept so stream enrichment can fill it.
+     */
+    private boolean dropEmpty(String text) {
+        return text.isEmpty() && !layoutTextAbsent;
+    }
+
     private IObject transformObject(JsonNode obj, int pageIndex, int objectIndex,
                                      double pageHeight,
                                      Map<String, String> figureCaptionMap,
@@ -595,16 +651,16 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             }
 
             case LABEL_LIST_TEXT:
-                iobj = text.isEmpty() ? null : createListItem(text, bbox);
+                iobj = dropEmpty(text) ? null : createListItem(text, bbox);
                 break;
 
             case LABEL_TABLE_NAME:
             case LABEL_FIGURE_NAME:
-                iobj = text.isEmpty() ? null : createCaption(text, bbox);
+                iobj = dropEmpty(text) ? null : createCaption(text, bbox);
                 break;
 
             case LABEL_FOOTNOTE:
-                iobj = text.isEmpty() ? null : createFootnote(text, bbox);
+                iobj = dropEmpty(text) ? null : createFootnote(text, bbox);
                 break;
 
             case LABEL_PARA_TEXT:
@@ -617,18 +673,18 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
                 // explicit cases keeps the routing intent visible and prevents
                 // future silent misrouting if the default branch behavior
                 // changes.
-                iobj = text.isEmpty() ? null : createParagraph(text, bbox);
+                iobj = dropEmpty(text) ? null : createParagraph(text, bbox);
                 break;
 
             case LABEL_REGIONLIST:
                 if (HybridConfig.REGIONLIST_LIST_ONLY.equals(regionlistStrategy)) {
                     // list-only: always treat as list, skip TSR check
-                    iobj = text.isEmpty() ? null : createListFromText(text, bbox);
+                    iobj = dropEmpty(text) ? null : createListFromText(text, bbox);
                 } else {
                     // table-first (default): if TSR covers it, skip (table handled separately)
                     if (hasOverlappingTsr(bbox, tsrTableBboxes)) return null;
                     // No TSR data — treat as list (parse text by newlines into ListItems)
-                    iobj = text.isEmpty() ? null : createListFromText(text, bbox);
+                    iobj = dropEmpty(text) ? null : createListFromText(text, bbox);
                 }
                 break;
 
@@ -662,7 +718,7 @@ public class HancomAISchemaTransformer implements HybridSchemaTransformer {
             }
 
             default:
-                iobj = text.isEmpty() ? null : createParagraph(text, bbox);
+                iobj = dropEmpty(text) ? null : createParagraph(text, bbox);
                 break;
         }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/HybridConfig.java
@@ -79,7 +79,14 @@ public class HybridConfig {
     /** OCR strategy: force (OCR only, skip stream-based enrichment). */
     public static final String OCR_FORCE = "force";
 
-    private String ocrStrategy = OCR_AUTO;
+    /**
+     * Default {@link #OCR_OFF}: text is taken from the PDF content stream, so
+     * the layout pass can use the cheaper OCR-free module. On a born-digital
+     * corpus this is ~4x cheaper than running OCR whose output the stream text
+     * then replaces. Scanned documents, which have no stream text to use, need
+     * {@link #OCR_AUTO} or {@link #OCR_FORCE}.
+     */
+    private String ocrStrategy = OCR_OFF;
 
     /** Page image cache strategy: "memory" (default) or "disk". */
     private String imageCache = "memory";
@@ -377,8 +384,9 @@ public class HybridConfig {
      * Sets the OCR strategy for enrichment fallback.
      *
      * <ul>
-     *   <li>{@code "off"}: stream-based enrichment only, no OCR fallback</li>
-     *   <li>{@code "auto"} (default): try stream enrichment first, fall back to OCR words when no match</li>
+     *   <li>{@code "off"} (default): stream-based enrichment only, no OCR
+     *       fallback; the layout pass then uses the cheaper OCR-free module</li>
+     *   <li>{@code "auto"}: try stream enrichment first, fall back to OCR words when no match</li>
      *   <li>{@code "force"}: skip stream enrichment, always use OCR words</li>
      * </ul>
      *

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAIPageChunkingTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/HancomAIPageChunkingTest.java
@@ -82,6 +82,73 @@ class HancomAIPageChunkingTest {
             new OkHttpClient(), mapper, config);
     }
 
+    private HancomAIClient clientWithOcrStrategy(String ocrStrategy) {
+        HybridConfig config = new HybridConfig();
+        config.setOcrStrategy(ocrStrategy);
+        return new HancomAIClient(
+            server.url("").toString().replaceAll("/$", ""),
+            new OkHttpClient(), mapper, config);
+    }
+
+    /**
+     * The module name in the next recorded request's multipart body.
+     */
+    private String nextRequestModule() throws Exception {
+        String body = nextRequestBody();
+        int at = body.indexOf("OPEN_API_NAME");
+        assertThat(at).as("request carries a module name").isGreaterThanOrEqualTo(0);
+        String after = body.substring(at);
+        int blank = after.indexOf("\r\n\r\n");
+        String value = after.substring(blank + 4);
+        return value.substring(0, value.indexOf("\r\n")).trim();
+    }
+
+    /**
+     * With OCR off the text comes from the PDF content stream, so the layout
+     * pass must ask for the cheaper module that returns geometry only. Asserted
+     * on the wire because that request is what the cost is paid for.
+     */
+    @Test
+    void ocrOffRequestsTheLayoutOnlyModule() throws Exception {
+        enqueueLayoutSlices(1);
+
+        clientWithOcrStrategy(HybridConfig.OCR_OFF)
+            .convert(requestFor(pdfWithPages(1), pages1Indexed(1, 1)));
+
+        assertThat(nextRequestModule()).isEqualTo("DOCUMENT_LAYOUT_ANALYSIS");
+    }
+
+    /**
+     * auto compares stream text against OCR text, so it must keep asking for the
+     * module that returns both. force uses the OCR text outright.
+     */
+    @Test
+    void ocrAutoAndForceRequestTheModuleThatReturnsText() throws Exception {
+        enqueueLayoutSlices(1);
+        clientWithOcrStrategy(HybridConfig.OCR_AUTO)
+            .convert(requestFor(pdfWithPages(1), pages1Indexed(1, 1)));
+        assertThat(nextRequestModule()).isEqualTo("DOCUMENT_LAYOUT_WITH_OCR");
+
+        enqueueLayoutSlices(1);
+        clientWithOcrStrategy(HybridConfig.OCR_FORCE)
+            .convert(requestFor(pdfWithPages(1), pages1Indexed(1, 1)));
+        assertThat(nextRequestModule()).isEqualTo("DOCUMENT_LAYOUT_WITH_OCR");
+    }
+
+    /**
+     * Whichever module ran, the transformer reads the layout result under one
+     * fixed key. A mismatch here would silently empty its input.
+     */
+    @Test
+    void layoutResultKeyDoesNotDependOnTheModule() throws Exception {
+        enqueueLayoutSlices(1);
+
+        HybridClient.HybridResponse response = clientWithOcrStrategy(HybridConfig.OCR_OFF)
+            .convert(requestFor(pdfWithPages(1), pages1Indexed(1, 1)));
+
+        assertThat(response.getJson().has(HancomAIClient.LAYOUT_RESULT_KEY)).isTrue();
+    }
+
     /** A PDF whose page <i>i</i> is {@code 100 + i} points wide. */
     private static byte[] pdfWithPages(int count) throws IOException {
         try (PDDocument doc = new PDDocument()) {
@@ -366,13 +433,14 @@ class HancomAIPageChunkingTest {
             requestIds.add(body.substring(at, body.indexOf("\r\n", at)));
         }
         // Absolute 0-based first and last page of each slice.
-        assertThat(requestIds.get(0)).endsWith("-dla-ocr-p0-1");
-        assertThat(requestIds.get(1)).endsWith("-dla-ocr-p2-3");
+        assertThat(requestIds.get(0)).endsWith("-dla-p0-1");
+        assertThat(requestIds.get(1)).endsWith("-dla-p2-3");
     }
 
     /**
-     * An unsliced document keeps the request id it always had, so existing
-     * recordings and log greps still match.
+     * An unsliced document's request id carries no page-range suffix, so it
+     * stays distinguishable from a slice of the same document. The module slug
+     * tracks the layout module in use ("dla" for DOCUMENT_LAYOUT_ANALYSIS).
      */
     @Test
     void unslicedRequestIdIsUnchanged() throws Exception {
@@ -382,7 +450,7 @@ class HancomAIPageChunkingTest {
 
         String body = nextRequestBody();
         int at = body.indexOf("odl-");
-        assertThat(body.substring(at, body.indexOf("\r\n", at))).endsWith("-dla-ocr");
+        assertThat(body.substring(at, body.indexOf("\r\n", at))).endsWith("-dla");
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/OcrStrategyTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/OcrStrategyTest.java
@@ -44,9 +44,11 @@ public class OcrStrategyTest {
     class HybridConfigOcrStrategy {
 
         @Test
-        void defaultOcrStrategy_isAuto() {
+        void defaultOcrStrategy_isOff() {
+            // Text comes from the PDF content stream by default, which lets the
+            // layout pass use the cheaper OCR-free module.
             HybridConfig config = new HybridConfig();
-            assertThat(config.getOcrStrategy()).isEqualTo(HybridConfig.OCR_AUTO);
+            assertThat(config.getOcrStrategy()).isEqualTo(HybridConfig.OCR_OFF);
         }
 
         @Test

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -34,7 +34,7 @@ export function registerCliOptions(program: Command): void {
   program.option('--hybrid-timeout <value>', 'Hybrid backend request timeout in milliseconds (0 = no timeout). Default: 0');
   program.option('--hybrid-fallback', 'Opt in to Java fallback on hybrid backend error (default: disabled)');
   program.option('--hybrid-hancom-ai-regionlist-strategy <value>', 'DLA label 7 (regionlist) handling. Requires --hybrid=hancom-ai. Values: table-first (default; check TSR overlap), list-only (skip TSR, always treat as list)');
-  program.option('--hybrid-hancom-ai-ocr-strategy <value>', 'OCR strategy. Requires --hybrid=hancom-ai. Values: off (stream-only), auto (default; stream first, OCR fallback), force (OCR-only)');
+  program.option('--hybrid-hancom-ai-ocr-strategy <value>', 'OCR strategy. Requires --hybrid=hancom-ai. Values: off (default; stream-only, uses the cheaper OCR-free layout module), auto (stream first, OCR fallback), force (OCR-only). Scanned documents need auto or force');
   program.option('--hybrid-hancom-ai-image-cache <value>', 'Page image cache backing. Requires --hybrid=hancom-ai. Values: memory (default), disk');
   program.option('--hybrid-hancom-ai-layout-page-chunk <value>', 'Pages per layout request. Requires --hybrid=hancom-ai. The backend accepts at most 30 pages per request, so longer documents are sliced; 0 disables slicing and sends every page in one request. Default: 20');
   program.option('--to-stdout', 'Write output to stdout instead of file (single format only)');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -59,7 +59,7 @@ export interface ConvertOptions {
   hybridFallback?: boolean;
   /** DLA label 7 (regionlist) handling. Requires --hybrid=hancom-ai. Values: table-first (default; check TSR overlap), list-only (skip TSR, always treat as list) */
   hybridHancomAiRegionlistStrategy?: string;
-  /** OCR strategy. Requires --hybrid=hancom-ai. Values: off (stream-only), auto (default; stream first, OCR fallback), force (OCR-only) */
+  /** OCR strategy. Requires --hybrid=hancom-ai. Values: off (default; stream-only, uses the cheaper OCR-free layout module), auto (stream first, OCR fallback), force (OCR-only). Scanned documents need auto or force */
   hybridHancomAiOcrStrategy?: string;
   /** Page image cache backing. Requires --hybrid=hancom-ai. Values: memory (default), disk */
   hybridHancomAiImageCache?: string;

--- a/options.json
+++ b/options.json
@@ -221,8 +221,8 @@
       "shortName": null,
       "type": "string",
       "required": false,
-      "default": "auto",
-      "description": "OCR strategy. Requires --hybrid=hancom-ai. Values: off (stream-only), auto (default; stream first, OCR fallback), force (OCR-only)"
+      "default": "off",
+      "description": "OCR strategy. Requires --hybrid=hancom-ai. Values: off (default; stream-only, uses the cheaper OCR-free layout module), auto (stream first, OCR fallback), force (OCR-only). Scanned documents need auto or force"
     },
     {
       "name": "hybrid-hancom-ai-image-cache",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -258,8 +258,8 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "short_name": None,
         "type": "string",
         "required": False,
-        "default": "auto",
-        "description": "OCR strategy. Requires --hybrid=hancom-ai. Values: off (stream-only), auto (default; stream first, OCR fallback), force (OCR-only)",
+        "default": "off",
+        "description": "OCR strategy. Requires --hybrid=hancom-ai. Values: off (default; stream-only, uses the cheaper OCR-free layout module), auto (stream first, OCR fallback), force (OCR-only). Scanned documents need auto or force",
     },
     {
         "name": "hybrid-hancom-ai-image-cache",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -78,7 +78,7 @@ def convert(
         hybrid_timeout: Hybrid backend request timeout in milliseconds (0 = no timeout). Default: 0
         hybrid_fallback: Opt in to Java fallback on hybrid backend error (default: disabled)
         hybrid_hancom_ai_regionlist_strategy: DLA label 7 (regionlist) handling. Requires --hybrid=hancom-ai. Values: table-first (default; check TSR overlap), list-only (skip TSR, always treat as list)
-        hybrid_hancom_ai_ocr_strategy: OCR strategy. Requires --hybrid=hancom-ai. Values: off (stream-only), auto (default; stream first, OCR fallback), force (OCR-only)
+        hybrid_hancom_ai_ocr_strategy: OCR strategy. Requires --hybrid=hancom-ai. Values: off (default; stream-only, uses the cheaper OCR-free layout module), auto (stream first, OCR fallback), force (OCR-only). Scanned documents need auto or force
         hybrid_hancom_ai_image_cache: Page image cache backing. Requires --hybrid=hancom-ai. Values: memory (default), disk
         hybrid_hancom_ai_layout_page_chunk: Pages per layout request. Requires --hybrid=hancom-ai. The backend accepts at most 30 pages per request, so longer documents are sliced; 0 disables slicing and sends every page in one request. Default: 20
         to_stdout: Write output to stdout instead of file (single format only)


### PR DESCRIPTION
Two separable changes to the `hancom-ai` hybrid backend. The first is an unrelated packaging bug found while trying to produce a baseline for the second.

## 1. `fix(cli)`: PDFBox missing from the shaded jar

Declaring `pdfbox` as `test` scope in the CLI pom downgraded the transitive compile dependency from core, dropping the artifact from the shaded jar entirely — only `pdfbox-io` survived, while `Loader` and `PDDocument` did not.

Every `--hybrid=hancom-ai` run on the packaged jar died with:

```
NoClassDefFoundError: org/apache/pdfbox/Loader
  at HancomAIClient.resolvePages(HancomAIClient.java:556)
```

Local builds pass because the test classpath still has PDFBox, so only the packaged artifact is affected.

Core reaches PDFBox at runtime (`HancomAIClient`, `PDFWriter`, `PDFStreamWriter`, `HancomPdfPageSlicer`), so the dependency has to stay compile-scoped here even though no CLI main code imports it. Verified `dependency:tree` reports `pdfbox`/`fontbox`/`pdfbox-io` 3.0.4 at compile with a single copy each, and that both classes are present in the shaded jar.

## 2. `perf(hybrid)`: default OCR strategy to `off`, skip the OCR layout pass

`DOCUMENT_LAYOUT_ANALYSIS` returns the same geometry as `DOCUMENT_LAYOUT_WITH_OCR` with no `ocrtext` and no `words[]`. Measured against the real backend, same document, 5 runs each:

| module | median | range |
|---|---|---|
| `DOCUMENT_LAYOUT_ANALYSIS` | **2063 ms** | 2043–2077 |
| `DOCUMENT_LAYOUT_WITH_OCR` | **5522 ms** | 5489–5636 |

Ranges do not overlap. With `ocr-strategy off` the text comes from the PDF content stream, so that OCR text was paid for and then thrown away. `layoutModule()` now derives the module from the strategy: `off` sends the layout-only module, `auto` and `force` keep the OCR variant (auto needs it as the similarity baseline, force uses it outright).

### Why the default flips

OCR does not earn its cost for tagged-pdf, which is the primary use of this backend. MCIDs can only be attached to glyphs already present in the content stream — `ChunksWriter.processString` rewrites existing `COSString` bytes and requires a font and a `StreamInfo`; nothing in `autotagging` synthesises text or inserts an invisible text layer. So OCR text has no route into the PDF.

Measured on an image-only PDF (`chinese_scan.pdf`), all three strategies produce a **byte-identical** tagged-pdf: `Document` + `Figure`, **zero MCIDs**. `force` adds no tags over `off`. On a mixed document (`PDFUA-Ref-2-09_Scanned.pdf`) `auto` differs from `off` by 2 list items; 22 of 26 tag kinds are identical.

### Two supporting fixes, both required for `off` to work

- Regions arriving with no text are kept when the layout response carried no text anywhere, so stream enrichment has a node to fill. Dropping them lost every paragraph, heading and caption (markdown fell 54%). The decision is made from the response rather than the module name, so a module that stops returning text cannot change behaviour silently; empty regions are still dropped when OCR ran and genuinely found nothing.
- `LAYOUT_RESULT_KEY` fixes the merged-JSON key the transformer reads. Without it, changing the module silently empties the transformer's input and yields an empty document. Timings stay filed under the module actually called, since the two differ ~2.7x and a shared label would compare unlike things across runs.

## Verification

- **854 tests pass** (825 core + 29 CLI), including 3 new tests pinning module selection and the result-key contract.
- **No regression on the OCR paths**: `auto` reproduces the previous output byte for byte.
- On a born-digital document, output is unchanged except a table header that DLA-only orders correctly (`Average Annual Growth` vs the previous `Average Growth Annual`).
- `npm run sync` run; `options.json` and the Node/Python bindings are regenerated.

## Known gap (pre-existing, unchanged by this PR)

The hybrid path never calls `HiddenTextProcessor` — its only call site is in `DocumentProcessor`, and `HybridDocumentProcessor.filterAllPages` stops at `ContentFilterProcessor`. Low-contrast text is therefore not filtered on this path. Under `auto`, the stream-vs-OCR similarity check incidentally suppressed invisible stream text; `off` removes that side effect. Worth fixing separately rather than relying on it.

Also unchanged and worth separate attention: the layout response is read via an unbounded `readTree`, and `HybridClientFactory`'s client cache is keyed on backend type only, so the first caller's `HybridConfig` is reused — a choice that now selects the wire module.

**Checklist:**

- [x] Documentation has been updated, if necessary. <!-- CLI help text + regenerated options.json / Node / Python bindings -->
- [ ] Examples have been added, if necessary. <!-- not applicable -->
- [x] Tests have been added, if necessary. <!-- 3 new tests; 2 existing assertions updated for the new default -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hybrid PDF processing now defaults to OCR-free layout analysis, using PDF text when available.
  * OCR can be enabled with `auto` or `force` for scanned documents.
  * Geometry-only layout results preserve empty regions for subsequent PDF content enrichment.

* **Bug Fixes**
  * Improved layout module selection and result handling across OCR strategies.
  * Ensured PDF CLI packaging includes required PDF processing functionality.

* **Documentation**
  * Updated CLI options, configuration references, and Python documentation to clarify OCR behavior and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->