### PR TITLE
fix: avoid emitting empty tables from line-only content

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableBorderProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableBorderProcessor.java
@@ -69,9 +69,11 @@ public class TableBorderProcessor {
 
             List<IObject> newContents = new ArrayList<>();
             Set<TableBorder> processedTableBorders = new LinkedHashSet<>();
+            Map<TableBorder, List<IObject>> tableBorderContents = new HashMap<>();
             for (IObject content : contents) {
                 TableBorder tableBorder = addContentToTableBorder(content);
                 if (tableBorder != null) {
+                    tableBorderContents.computeIfAbsent(tableBorder, key -> new ArrayList<>()).add(content);
                     if (content instanceof LineChunk && tableBorder.isOneCellTable()) {
                         continue;
                     }
@@ -98,7 +100,8 @@ public class TableBorderProcessor {
             for (TableBorder border : processedTableBorders) {
                 StaticContainers.getTableBordersCollection().removeTableBorder(border, pageNumber);
                 TableBorder normalizedTable = normalizeAndProcessTableBorder(contents, border, pageNumber);
-                normalizedTables.put(border, normalizedTable);
+                normalizedTables.put(border,
+                    TableStructureNormalizer.hasMeaningfulContent(normalizedTable) ? normalizedTable : null);
                 // Remove the outer table while processing its contents, then restore the page index
                 // with the final instance so later lookups still see the normalized table.
 //                StaticContainers.getTableBordersCollection().getTableBorders(pageNumber).add(normalizedTable);
@@ -106,7 +109,19 @@ public class TableBorderProcessor {
             for (int index = 0; index < newContents.size(); index++) {
                 IObject content = newContents.get(index);
                 if (content instanceof TableBorder && normalizedTables.containsKey(content)) {
-                    newContents.set(index, normalizedTables.get(content));
+                    TableBorder normalizedTable = normalizedTables.get(content);
+                    if (normalizedTable == null) {
+                        newContents.remove(index);
+                        List<IObject> originalContents = tableBorderContents.get(content);
+                        if (originalContents != null) {
+                            newContents.addAll(index, originalContents);
+                            index += originalContents.size() - 1;
+                        } else {
+                            index--;
+                        }
+                    } else {
+                        newContents.set(index, normalizedTable);
+                    }
                 }
             }
             return newContents;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableStructureNormalizer.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/TableStructureNormalizer.java
@@ -317,6 +317,20 @@ class TableStructureNormalizer {
         return count;
     }
 
+    static boolean hasMeaningfulContent(TableBorder tableBorder) {
+        for (int rowNumber = 0; rowNumber < tableBorder.getNumberOfRows(); rowNumber++) {
+            TableBorderRow row = tableBorder.getRow(rowNumber);
+            for (int columnNumber = 0; columnNumber < tableBorder.getNumberOfColumns(); columnNumber++) {
+                TableBorderCell cell = row.getCell(columnNumber);
+                if (cell != null && cell.getRowNumber() == rowNumber && cell.getColNumber() == columnNumber &&
+                        hasMeaningfulContent(cell.getContents())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private static boolean hasMeaningfulContent(List<IObject> contents) {
         if (contents == null) {
             return false;

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/TableBorderProcessorTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/TableBorderProcessorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.verapdf.wcag.algorithms.entities.IObject;
 import org.verapdf.wcag.algorithms.entities.SemanticParagraph;
 import org.verapdf.wcag.algorithms.entities.content.ImageChunk;
+import org.verapdf.wcag.algorithms.entities.content.LineChunk;
 import org.verapdf.wcag.algorithms.entities.content.TextChunk;
 import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
 import org.verapdf.wcag.algorithms.entities.tables.TableBordersCollection;
@@ -174,6 +175,34 @@ public class TableBorderProcessorTest {
         Assertions.assertEquals(2, resultBorder.getNumberOfRows());
         Assertions.assertEquals("r1c1", ((SemanticParagraph) resultBorder.getCell(0, 0).getContents().get(0)).getValue());
         Assertions.assertEquals("r2c2", ((SemanticParagraph) resultBorder.getCell(1, 1).getContents().get(0)).getValue());
+    }
+
+    @Test
+    public void testLineOnlyGridIsNotEmittedAsEmptyTable() {
+        StaticContainers.setIsIgnoreCharactersWithoutUnicode(false);
+        StaticContainers.setIsDataLoader(true);
+        StaticLayoutContainers.setCurrentContentId(350L);
+        TableBordersCollection tableBordersCollection = new TableBordersCollection();
+        StaticContainers.setTableBordersCollection(tableBordersCollection);
+
+        TableBorder tableBorder = createTable(0, 10.0, 10.0, 110.0, 110.0, 4, 4, 35L);
+        SortedSet<TableBorder> tables = new TreeSet<>(new TableBorder.TableBordersComparator());
+        tables.add(tableBorder);
+        tableBordersCollection.getTableBorders().add(tables);
+
+        List<IObject> contents = new ArrayList<>();
+        for (double y = 25.0; y < 100.0; y += 25.0) {
+            contents.add(new LineChunk(0, 15.0, y, 105.0, y));
+        }
+        for (double x = 25.0; x < 100.0; x += 25.0) {
+            contents.add(new LineChunk(0, x, 15.0, x, 105.0));
+        }
+
+        List<IObject> processedContents = TableBorderProcessor.processTableBorders(contents, 0);
+
+        Assertions.assertEquals(contents.size(), processedContents.size());
+        Assertions.assertTrue(processedContents.stream().noneMatch(TableBorder.class::isInstance));
+        Assertions.assertTrue(processedContents.stream().allMatch(LineChunk.class::isInstance));
     }
 
     @Test


### PR DESCRIPTION
Resolves #695

### Summary

- Do not emit a table structure when every detected cell contains only line graphics or no meaningful content.
- Restore the original line objects so the table processor does not silently consume the page content.
- Add a regression test covering a line-only grid and keep existing content-bearing table behavior unchanged.

### Validation

- git diff --check — passed on the local upstream snapshot.
- Local Java/Maven test command — not run: this Windows environment has neither java nor mvn installed.
- The branch is based directly on upstream main at 455e0b7ef764316e42509e7551d392a92b863d22; GitHub Actions should provide the compile and test validation.

### Checklist

- [x] Documentation is not required for this internal processing fix.
- [x] Examples are not required.
- [x] A regression test has been added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented line-only table grids from being emitted as empty tables.
  * Preserved the original grid content and its position when a normalized table has no meaningful content.

* **Tests**
  * Added coverage to verify that line-based grids remain intact and are not converted into empty table objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->