### PR TITLE
Fix veraPDF artifact memory retention

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/DocumentProcessor.java
@@ -316,7 +316,10 @@ public class DocumentProcessor {
         LOGGER.log(Level.INFO, "Processing {0} pages with {1} threads", new Object[]{pagesToProcessCount, parallelism});
 
         try {
-            // Loop 1: ContentFilter per-page (largest bottleneck)
+            // Loop 1: ContentFilter per-page (largest bottleneck).
+            // Drop unused text/images from veraPDF artifacts by identity.
+            // Reused non-lines stay; LineChunks stay for loop 2.
+            // Skipped --pages: null live contents drops non-lines, keeps LineChunks.
             pool.submit(() ->
                 IntStream.range(0, totalPages).parallel().forEach(pageNumber -> {
                     try {
@@ -325,8 +328,10 @@ public class DocumentProcessor {
                             List<IObject> pageContents = ContentFilterProcessor.getFilteredContents(inputPdfName,
                                 (List) pageArtifacts[pageNumber], pageNumber, config);
                             contents.set(pageNumber, pageContents);
+                            pruneArtifactsToLiveChunks(pageArtifacts[pageNumber], pageContents, pageNumber);
                         } else {
                             contents.set(pageNumber, new ArrayList<>());
+                            pruneArtifactsToLiveChunks(pageArtifacts[pageNumber], null, pageNumber);
                         }
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
@@ -372,6 +377,11 @@ public class DocumentProcessor {
                     contents.set(pageNumber, pageContents);
                 })
             ).get();
+
+            // Main thread only: LineChunks leave artifacts after strikethrough.
+            // Do not prune inside the parallel loop — parseLines walks all pages.
+            // Skipped pages drop LineChunks here too (already in LinesCollection).
+            pruneLineChunksFromArtifacts(pageArtifacts, totalPages);
 
             if (structured) {
                 // Cross-page operations (must be sequential)
@@ -533,6 +543,70 @@ public class DocumentProcessor {
 
     private static boolean shouldProcessPage(int pageNumber, Set<Integer> pagesToProcess) {
         return pagesToProcess == null || pagesToProcess.contains(pageNumber);
+    }
+
+    /**
+     * After content-filter: drop veraPDF artifact entries that are not still
+     * referenced from {@code liveContents}, except {@link LineChunk}s. Identity
+     * ({@code ==}), not {@code equals}. Unused text/images leave artifacts;
+     * reused non-lines stay. Merged/split {@code TextChunk}s are not copied into
+     * veraPDF. {@code LineChunk}s stay until
+     * {@link #pruneLineChunksFromArtifacts} after loop 2 so a lazy
+     * {@code parseLines} can still see them. This method is only used from the
+     * local {@code processDocument} path.
+     *
+     * @param liveContents filtered page contents, or {@code null} for a skipped
+     *                     {@code --pages} page (drop every non-{@link LineChunk})
+     */
+    @SuppressWarnings("unchecked")
+    static void pruneArtifactsToLiveChunks(List<?> artifacts, List<IObject> liveContents,
+                                           int pageNumber) {
+        if (artifacts == null) {
+            return;
+        }
+        try {
+            if (liveContents == null || liveContents.isEmpty()) {
+                ((List<Object>) artifacts).removeIf(chunk -> !(chunk instanceof LineChunk));
+                return;
+            }
+            Set<Object> live = Collections.newSetFromMap(new IdentityHashMap<>());
+            for (IObject object : liveContents) {
+                if (object != null) {
+                    live.add(object);
+                }
+            }
+            ((List<Object>) artifacts).removeIf(chunk ->
+                !(chunk instanceof LineChunk) && !live.contains(chunk));
+        } catch (UnsupportedOperationException e) {
+            LOGGER.log(Level.WARNING,
+                "Could not prune veraPDF artifacts on page {0}: unmodifiable list",
+                pageNumber + 1);
+        }
+    }
+
+    /**
+     * After loop 2 strikethrough: drop every {@link LineChunk} from per-page
+     * artifact lists, including skipped pages. Call on the main thread after the
+     * parallel loop finishes. {@code LinesCollection} keeps the live line rules.
+     */
+    @SuppressWarnings("unchecked")
+    static void pruneLineChunksFromArtifacts(List<?>[] pageArtifacts, int totalPages) {
+        if (pageArtifacts == null) {
+            return;
+        }
+        for (int pageNumber = 0; pageNumber < totalPages; pageNumber++) {
+            List<?> artifacts = pageArtifacts[pageNumber];
+            if (artifacts == null) {
+                continue;
+            }
+            try {
+                ((List<Object>) artifacts).removeIf(chunk -> chunk instanceof LineChunk);
+            } catch (UnsupportedOperationException e) {
+                LOGGER.log(Level.WARNING,
+                    "Could not prune veraPDF line artifacts on page {0}: unmodifiable list",
+                    pageNumber + 1);
+            }
+        }
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorArtifactPruneTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/DocumentProcessorArtifactPruneTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.processors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opendataloader.pdf.api.Config;
+import org.opendataloader.pdf.api.OutputWriter;
+import org.opendataloader.pdf.containers.StaticLayoutContainers;
+import org.verapdf.pd.PDDocument;
+import org.verapdf.tools.StaticResources;
+import org.verapdf.wcag.algorithms.entities.content.LineChunk;
+import org.verapdf.wcag.algorithms.entities.content.LinesCollection;
+import org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.SortedSet;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class DocumentProcessorArtifactPruneTest {
+
+    private static final String SAMPLE_PDF = "../../samples/pdf/1901.03003.pdf";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void localExtractionPrunesArtifactsAndKeepsLaterProcessingWorking() throws Exception {
+        File pdf = new File(SAMPLE_PDF);
+        assumeTrue(pdf.exists(), "Sample PDF not found: " + pdf.getAbsolutePath());
+
+        Config config = new Config();
+        config.setOutputFolder(tempDir.toString());
+        config.setDetectStrikethrough(true);
+        config.setGenerateJSON(false);
+        config.setGenerateMarkdown(true);
+        config.setImageOutput("off");
+
+        int artifactsBefore;
+        try {
+            DocumentProcessor.preprocessing(pdf.getAbsolutePath(), config);
+            artifactsBefore = artifactCount();
+        } finally {
+            closeCurrentPdf();
+        }
+
+        try {
+            ExtractionResult result = DocumentProcessor.extractContents(pdf.getAbsolutePath(), config);
+            assertFalse(result.getContents().isEmpty(), "Expected extracted contents");
+
+            int artifactsAfter = artifactCount();
+            assertTrue(artifactsAfter < artifactsBefore,
+                "Expected pruning to reduce veraPDF artifacts: before=" + artifactsBefore
+                    + " after=" + artifactsAfter);
+
+            LinesCollection lines = StaticContainers.getLinesCollection();
+            assertNotNull(lines, "Line cache must remain available after pruning");
+            int cachedLines = 0;
+            int pages = StaticContainers.getDocument().getNumberOfPages();
+            for (int page = 0; page < pages; page++) {
+                for (Object artifact : StaticContainers.getDocument().getArtifacts(page)) {
+                    assertFalse(artifact instanceof LineChunk,
+                        "Line artifacts should be pruned after strikethrough processing");
+                }
+
+                SortedSet<LineChunk> horizontal = lines.getHorizontalLines(page);
+                SortedSet<LineChunk> vertical = lines.getVerticalLines(page);
+                SortedSet<LineChunk> squares = lines.getSquares(page);
+                assertSame(horizontal, lines.getHorizontalLines(page));
+                assertSame(vertical, lines.getVerticalLines(page));
+                assertSame(squares, lines.getSquares(page));
+                cachedLines += horizontal.size() + vertical.size() + squares.size();
+            }
+            assertTrue(cachedLines > 0, "Expected cached lines to survive artifact pruning");
+
+            OutputWriter.writeOutputs(pdf.getAbsolutePath(), result, config);
+            Path markdown = tempDir.resolve("1901.03003.md");
+            assertTrue(Files.isRegularFile(markdown) && Files.size(markdown) > 0,
+                "Later Markdown generation should still work after pruning");
+        } finally {
+            closeCurrentPdf();
+        }
+    }
+
+    private static int artifactCount() {
+        int count = 0;
+        int pages = StaticContainers.getDocument().getNumberOfPages();
+        for (int page = 0; page < pages; page++) {
+            List<?> artifacts = StaticContainers.getDocument().getArtifacts(page);
+            count += artifacts == null ? 0 : artifacts.size();
+        }
+        return count;
+    }
+
+    private static void closeCurrentPdf() throws IOException {
+        PDDocument document = StaticResources.getDocument();
+        if (document != null) {
+            document.close();
+        }
+        StaticResources.clear();
+        StaticContainers.updateContainers(null);
+        StaticLayoutContainers.clearContainers();
+    }
+}


### PR DESCRIPTION
## Description

During local PDF extraction, veraPDF retains the original artifact list for
every page after content filtering completes.

OpenDataLoader copies these artifacts into its filtered content structure, where
some chunks are discarded, merged, or replaced. The original objects nevertheless
remain reachable through veraPDF's per-page lists and cannot be garbage-collected.
This retained memory accumulates across pages and becomes significant for
documents containing thousands of pages.

This change:

- removes artifacts no longer referenced by filtered contents;
- compares objects by identity because different chunks can compare as equal;
- keeps reused text and image chunks;
- retains `LineChunk` objects until line and strikethrough processing completes;
- removes the remaining line artifacts afterward;
- prunes artifacts from pages excluded using `--pages`;
- leaves unmodifiable artifact lists unchanged with a warning.



## Motivation

The issue was reproduced using
`Bullinger - Decades - Henry Bullinger.pdf`, an approximately 21 MB PDF
containing **4,730 pages**.

The page count is important because veraPDF maintains artifacts for every page.
For smaller documents, the retained objects may not be noticeable. For
documents with thousands of pages, they create substantial GC pressure and can
make extraction impractical under production memory limits.

The Bullinger PDF was used only as a local performance fixture and is not
included in this PR. The automated test uses an existing repository fixture.

## Memory measurements

The comparison used:

- Eclipse Temurin JDK 21.0.12.1
- a fresh JVM for every run
- `-Xms512m -Xmx8g`
- one processing thread
- Markdown output with images disabled
- three runs with pruning and three runs without pruning

This comparison measures JVM **live heap**, not RSS or total process memory.

At each checkpoint, temporary measurement code requested three explicit full
collections with `System.gc()`. GC logging confirmed that these completed as
`Pause Full (System.gc())` collections. Used heap was then read from
`MemoryMXBean`.

Values below are averages across three runs:

| Forced-GC checkpoint | Without pruning | With pruning | Reduction |
|---|---:|---:|---:|
| After preprocessing | 1,889.9 MiB | 1,890.4 MiB | No meaningful difference |
| After content filtering | 2,487.7 MiB | 815.9 MiB | 1,671.8 MiB (67.2%) |
| After line/table processing | 2,778.2 MiB | 1,106.6 MiB | 1,671.6 MiB (60.2%) |
| After local processing | 2,797.6 MiB | 1,126.1 MiB | 1,671.5 MiB (59.7%) |
| After Markdown output | 2,797.5 MiB | 1,126.1 MiB | 1,671.4 MiB (59.7%) |
| After resource cleanup | 997.4 MiB | 998.5 MiB | Effectively equal |

```mermaid
xychart-beta
    title "Live heap: without pruning vs. with pruning"
    x-axis ["Preprocessing", "Content filter", "Line/table", "Output", "Cleanup"]
    y-axis "Live heap (MiB)" 0 --> 3000
    line [1889.9, 2487.7, 2778.2, 2797.5, 997.4]
    line [1890.4, 815.9, 1106.6, 1126.1, 998.5]
```

The approximately **1.67 GiB difference remains stable** from content filtering
through output generation. After the PDF resources and static containers are
cleared, both variants converge to approximately 998 MiB. This indicates that
the difference comes from the artifact graph retained through veraPDF.

The largest forced-GC stage-boundary value was reduced from approximately
2,798 MiB to 1,890 MiB. These are live-heap checkpoints, not a claim about the
absolute instantaneous peak between checkpoints.

### Representative logs

Without pruning:

```text
HEAP_AFTER_GC checkpoint=after-preprocessing used_mib=1889.5
HEAP_AFTER_GC checkpoint=after-content-filter used_mib=2487.3
HEAP_AFTER_GC checkpoint=after-line-table-processing used_mib=2777.8
HEAP_AFTER_GC checkpoint=after-output used_mib=2797.1
HEAP_AFTER_GC checkpoint=after-resource-cleanup used_mib=997.2
```

With pruning:

```text
HEAP_AFTER_GC checkpoint=after-preprocessing used_mib=1890.5
HEAP_AFTER_GC checkpoint=after-content-filter used_mib=815.9
HEAP_AFTER_GC checkpoint=after-line-table-processing used_mib=1106.4
HEAP_AFTER_GC checkpoint=after-output used_mib=1126.2
HEAP_AFTER_GC checkpoint=after-resource-cleanup used_mib=998.4
```

The generated Markdown was byte-for-byte identical between pruning and
non-pruning runs.

The pruning toggle, explicit-GC calls, checkpoint logging, and GC logging were
temporary measurement tools and are not included in the submitted code.

## veraPDF integration trade-off

Mutating a collection owned by veraPDF is not an ideal long-term API boundary.
An explicit veraPDF lifecycle API for releasing processed artifacts would be
preferable.

The current API does not provide a setter or release method. Wrapping the
document would not release references held by the underlying implementation,
and closing it earlier is unsafe because later output processing still needs
PDF resources.

Clearing the complete lists is also unsafe because reused chunks and line
artifacts may still be needed. This implementation therefore performs a limited
identity-based prune and delays removal of line chunks until their consumers
have completed.

Although this approach could be considered experimental, its scope is limited
to the local extraction path and it provides a substantial practical benefit.
For the tested 4,730-page document, it reduced the live heap retained during
later processing by approximately 1.67 GiB. This additional memory headroom can
make large-document extraction viable under production memory limits and reduce
the risk of excessive garbage collection or out-of-memory failures.

If veraPDF introduces an explicit artifact lifecycle API, this implementation
should be updated to use that API.
## Processing-path safety

Pruning applies only to the local extraction path.

Tagged PDFs using the structure tree are routed through
`TaggedDocumentProcessor`, while hybrid processing is routed through
`HybridDocumentProcessor`. Those processors do not enter the local
`processDocument` method where pruning occurs

## Testing

Added `DocumentProcessorArtifactPruneTest`, using the existing
`samples/pdf/1901.03003.pdf` fixture.

The test verifies that:

- pruning reduces the number of retained artifacts;
- line artifacts remain available until line processing completes;
- `LineChunk` objects are removed afterward;
- `LinesCollection` remains populated and stable;
- Markdown generation still succeeds after pruning.

Command:

```bash
mvn -pl opendataloader-pdf-core test \
  -Dtest=DocumentProcessorArtifactPruneTest
```

Result:

```text
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

**Checklist:**

- [ ] Documentation has been updated, if necessary. Not applicable—no public API or behavior changes.
- [ ] Examples have been added, if necessary. Not applicable—no user-facing feature was added.
- [x] Tests have been added, if necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced temporary PDF artifact data retained during document processing.
  * Preserved line information needed for subsequent extraction and Markdown generation.
  * Improved handling when artifact collections cannot be modified, with a warning instead of failing processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->