### PR TITLE
feat(tagging): keep background vectors, order /ParentTree, and give captions their own level

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/FilterConfig.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/FilterConfig.java
@@ -23,13 +23,15 @@ import java.util.regex.Pattern;
 
 /**
  * Configuration class for content filtering options.
- * Controls filtering of hidden text, out-of-page content, tiny text, and hidden OCGs.
+ * Controls filtering of hidden text, out-of-page content, tiny text, hidden OCGs,
+ * and background vector graphics.
  */
 public class FilterConfig {
     private boolean filterHiddenText = false;
     private boolean filterOutOfPage = true;
     private boolean filterTinyText = true;
     private boolean filterHiddenOCG = true;
+    private boolean filterBackgrounds = true;
     private boolean filterSensitiveData = false;
     private final List<SanitizationRule> filterRules;
 
@@ -155,6 +157,30 @@ public class FilterConfig {
      */
     public void setFilterHiddenOCG(boolean filterHiddenOCG) {
         this.filterHiddenOCG = filterHiddenOCG;
+    }
+
+    /**
+     * Checks if the processor should remove page-sized vector graphics detected
+     * as backgrounds.
+     *
+     * @return true if filter is enabled, false otherwise.
+     */
+    public boolean isFilterBackgrounds() {
+        return filterBackgrounds;
+    }
+
+    /**
+     * Enables or disables removal of vector graphics detected as backgrounds.
+     *
+     * <p>Background detection is a size heuristic, so a large chart or diagram
+     * drawn with vector operators can be classified as a background and dropped
+     * before tagging. Disable this filter to keep every {@code LineArtChunk} in
+     * the content list, at the cost of also keeping real page backgrounds.
+     *
+     * @param filterBackgrounds true to enable filter, false to disable.
+     */
+    public void setFilterBackgrounds(boolean filterBackgrounds) {
+        this.filterBackgrounds = filterBackgrounds;
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/api/cli/CLIOptions.java
@@ -89,7 +89,7 @@ public class CLIOptions {
     // ===== Content Safety =====
     private static final String CONTENT_SAFETY_OFF_LONG_OPTION = "content-safety-off";
     private static final String CONTENT_SAFETY_OFF_DESC = "Disable content safety filters. "
-            + "Values: all, hidden-text, off-page, tiny, hidden-ocg";
+            + "Values: all, hidden-text, off-page, tiny, hidden-ocg, background";
 
     // ===== Sanitize =====
     private static final String SANITIZE_LONG_OPTION = "sanitize";
@@ -486,13 +486,13 @@ public class CLIOptions {
         String[] optionValues = commandLine.getOptionValues(CONTENT_SAFETY_OFF_LONG_OPTION);
         if (optionValues == null || optionValues.length == 0) {
             throw new IllegalArgumentException(
-                    "Option --content-safety-off requires at least one value. Supported values: all, hidden-text, off-page, tiny, hidden-ocg");
+                    "Option --content-safety-off requires at least one value. Supported values: all, hidden-text, off-page, tiny, hidden-ocg, background");
         }
 
         Set<String> values = parseOptionValues(optionValues);
         if (values.isEmpty()) {
             throw new IllegalArgumentException(
-                    "Option --content-safety-off requires at least one value. Supported values: all, hidden-text, off-page, tiny, hidden-ocg");
+                    "Option --content-safety-off requires at least one value. Supported values: all, hidden-text, off-page, tiny, hidden-ocg, background");
         }
 
         for (String value : values) {
@@ -509,6 +509,9 @@ public class CLIOptions {
                 case "hidden-ocg":
                     config.getFilterConfig().setFilterHiddenOCG(false);
                     break;
+                case "background":
+                    config.getFilterConfig().setFilterBackgrounds(false);
+                    break;
                 case "sensitive-data":
                     System.err.println("Warning: '--content-safety-off sensitive-data' is deprecated and has no effect. "
                             + "Sensitive data sanitization is now opt-in. "
@@ -519,10 +522,11 @@ public class CLIOptions {
                     config.getFilterConfig().setFilterOutOfPage(false);
                     config.getFilterConfig().setFilterTinyText(false);
                     config.getFilterConfig().setFilterHiddenOCG(false);
+                    config.getFilterConfig().setFilterBackgrounds(false);
                     break;
                 default:
                     throw new IllegalArgumentException(String.format(
-                            "Unsupported value '%s'. Supported values: all, hidden-text, off-page, tiny, hidden-ocg",
+                            "Unsupported value '%s'. Supported values: all, hidden-text, off-page, tiny, hidden-ocg, background",
                             value));
             }
         }

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -56,8 +56,12 @@ public class AutoTaggingProcessor {
     private static final String ANNOTATION_REPLACEMENT_TEXT = "Annotation";
     // Namespace for PDF 2.0-only structure types (FENote, etc.), created in createStructTreeRoot.
     private static COSObject pdf2_0Namespace;
-    // Caption elements keyed by their linked content ID (Raman's approach from #377)
-    private static final Map<Long, SemanticCaption> structElementIdToCaptionMap = new HashMap<>();
+    // Caption elements keyed by their linked content ID (Raman's approach from #377).
+    // A list, not a single caption: a float can legitimately carry one caption
+    // above it and one below — a figure titled "Figure 3.3 ..." over the image
+    // with "Source: ..." under it is ordinary. A plain put kept only the last of
+    // them and silently deleted the other's text.
+    private static final Map<Long, List<SemanticCaption>> structElementIdToCaptionMap = new HashMap<>();
     private static boolean isPDF2_0 = false;
     private static final Map<BoundingBox, PDAnnotation> annotationBBoxesMap = new LinkedHashMap<>();
     private static int currentStructParent = 0;
@@ -288,8 +292,10 @@ public class AutoTaggingProcessor {
         // First pass: collect Caption → linkedContentId mappings
         for (IObject content : contents) {
             if (content instanceof SemanticCaption) {
-                structElementIdToCaptionMap.put(
-                    ((SemanticCaption) content).getLinkedContentId(), (SemanticCaption) content);
+                SemanticCaption caption = (SemanticCaption) content;
+                structElementIdToCaptionMap
+                    .computeIfAbsent(caption.getLinkedContentId(), key -> new ArrayList<>())
+                    .add(caption);
             }
         }
         // Second pass: create struct elements (skipping Captions — they are attached by addCaptionIfPresent)
@@ -316,12 +322,70 @@ public class AutoTaggingProcessor {
      * of the struct element based on spatial position.
      */
     private static void addCaptionIfPresent(IObject content, COSObject linkedObject, COSDocument cosDocument) {
-        Long linkedContentId = content.getRecognizedStructureId();
-        if (linkedContentId != null && structElementIdToCaptionMap.containsKey(linkedContentId)) {
-            SemanticCaption caption = structElementIdToCaptionMap.get(linkedContentId);
-            boolean isFirst = isCaptionFirstChild(caption.getBoundingBox(), content.getBoundingBox());
-            createCaptionStructElem(caption, linkedObject, cosDocument, isFirst);
+        addCaptionIfPresent(content, linkedObject, cosDocument, linkedObject);
+    }
+
+    /**
+     * As above, but putting the Caption under {@code captionParent}.
+     *
+     * <p>They differ only for a captioned figure, which is wrapped in a Sect so
+     * the Figure and Caption are siblings. Table and L keep the caption as their
+     * own child: ISO 32000-1 Table 337 lists Caption among their permitted
+     * children, which is the {@code <table><caption>} shape, and a table's
+     * caption is not competing with an /Alt the way a figure's is.
+     */
+    private static void addCaptionIfPresent(IObject content, COSObject linkedObject, COSDocument cosDocument,
+                                            COSObject captionParent) {
+        List<SemanticCaption> captions = captionsFor(content);
+        if (captions.isEmpty()) {
+            return;
         }
+        // At most one caption on each side. PDF/UA-2 8.2.5.27.1 is checked as
+        // kidsStandardTypes.indexOf('&Caption&') < 0 — the joined child types may
+        // not contain a Caption with a sibling on both sides. So Caption/Figure,
+        // Figure/Caption and Caption/Figure/Caption all pass, while two captions
+        // on the same side do not. A caller that supplies several per side is
+        // asking for a tree this rule rejects, so the extras are dropped here
+        // rather than written out to fail validation.
+        SemanticCaption above = null;
+        SemanticCaption below = null;
+        for (SemanticCaption caption : captions) {
+            if (isCaptionFirstChild(caption.getBoundingBox(), content.getBoundingBox())) {
+                if (above == null) {
+                    above = caption;
+                }
+            } else if (below == null) {
+                below = caption;
+            }
+        }
+        // Below first: each insertion is relative to linkedObject, so placing the
+        // trailing caption before the leading one keeps both on the right side of
+        // it regardless of insertion order.
+        if (below != null) {
+            addOneCaption(below, linkedObject, cosDocument, captionParent, false);
+        }
+        if (above != null) {
+            addOneCaption(above, linkedObject, cosDocument, captionParent, true);
+        }
+    }
+
+    private static void addOneCaption(SemanticCaption caption, COSObject linkedObject,
+                                      COSDocument cosDocument, COSObject captionParent,
+                                      boolean isFirst) {
+        if (captionParent == linkedObject) {
+            createCaptionStructElem(caption, captionParent, cosDocument, isFirst);
+        } else {
+            createCaptionStructElemBeside(caption, captionParent, linkedObject, cosDocument, isFirst);
+        }
+    }
+
+    /** The Captions linked to this element, empty when it has none. */
+    private static List<SemanticCaption> captionsFor(IObject content) {
+        Long linkedContentId = content.getRecognizedStructureId();
+        if (linkedContentId == null) {
+            return Collections.emptyList();
+        }
+        return structElementIdToCaptionMap.getOrDefault(linkedContentId, Collections.emptyList());
     }
 
     /**
@@ -780,12 +844,78 @@ public class AutoTaggingProcessor {
         processTextNode(caption, captionObject);
     }
 
+    /**
+     * Creates a Caption as {@code parent}'s child, next to {@code sibling}.
+     *
+     * <p>{@code isFirstChild} on addStructElement cannot express this: it inserts
+     * at index 0 of the parent, which is only the same thing while the parent
+     * holds nothing else. For a figure's Sect that is true today, but the
+     * placement has to follow the sibling rather than the parent's start —
+     * otherwise adding anything else to the Sect silently moves the caption away
+     * from its figure, and reading order is the entire reason its position
+     * matters. 8.2.5.27.1 also wants Caption first or last among its siblings.
+     */
+    private static void createCaptionStructElemBeside(SemanticCaption caption, COSObject parent,
+                                                      COSObject sibling, COSDocument cosDocument,
+                                                      boolean before) {
+        COSObject captionObject = addStructElement(parent, cosDocument, TaggedPDFConstants.CAPTION,
+            caption.getPageNumber());
+        COSObject kids = parent.getKey(ASAtom.K);
+        if (kids.getType() == COSObjType.COS_ARRAY) {
+            // Identity, not equals. COSIndirect.equals compares getDirect(), and
+            // COSDictionary.equals is a deep key-set-and-values comparison, so two
+            // struct elements built the same way — same /S, /Type and /Pg, which is
+            // exactly what two Figures on one page look like before their kids are
+            // attached — compare equal. A value search then returns the first of
+            // them and the caption is inserted beside the wrong sibling.
+            int siblingIndex = -1;
+            for (int i = 0; i < kids.size(); i++) {
+                if (kids.at(i) == sibling) {
+                    siblingIndex = i;
+                    break;
+                }
+            }
+            if (siblingIndex >= 0) {
+                // addStructElement appended it; move it to the wanted slot. The
+                // caption is last, so removing it cannot shift the sibling.
+                kids.remove(kids.size() - 1);
+                kids.insert(before ? siblingIndex : siblingIndex + 1, captionObject);
+            }
+        }
+        processTextNode(caption, captionObject);
+    }
+
     private static void createFigureStructElem(ImageChunk image, COSObject parent, COSDocument cosDocument) {
         createFigureStructElemReturning(image, parent, cosDocument);
     }
 
     private static COSObject createFigureStructElemReturning(ImageChunk image, COSObject parent, COSDocument cosDocument) {
-        COSObject figureObject = addStructElement(parent, cosDocument, TaggedPDFConstants.FIGURE, image.getPageNumber());
+        // A captioned figure is wrapped so the Figure and its Caption are
+        // siblings rather than the caption living inside the figure. Nesting is
+        // legal — PDF/UA-2 does not list Caption among Figure's forbidden
+        // children — but it puts the caption's text in the figure's subtree,
+        // where ISO 32000-1 14.9.4 makes the figure's own /Alt stand in for
+        // everything below it, and readers disagree about which to announce.
+        //
+        // Sect, not Div. Caption is forbidden under 33 element types including
+        // Document, so lifting it to the figure's parent unwrapped fails Table 5
+        // Document-Caption.1 on any document whose figures sit at the top level.
+        // Div looked like the fix and is not: veraPDF's
+        // PDStructElem.isPassThroughTag treats Div, Part and NonStruct as
+        // transparent, and parentStandardType walks past them, so a Caption
+        // inside a Div still reports Document as its parent. Verified by
+        // building it — correct tree, correct /P pointers, same failure. Sect is
+        // absent from that list and forbids neither Caption nor Figure.
+        //
+        // Only captioned figures are wrapped: an extra level around a bare
+        // figure would add depth that carries no grouping.
+        COSObject figureParent = parent;
+        if (!captionsFor(image).isEmpty()) {
+            figureParent = addStructElement(parent, cosDocument, TaggedPDFConstants.SECT,
+                image.getPageNumber());
+            cosDocument.addChangedObject(figureParent);
+        }
+        COSObject figureObject = addStructElement(figureParent, cosDocument, TaggedPDFConstants.FIGURE, image.getPageNumber());
         double[] bbox = {image.getLeftX(), image.getBottomY(), image.getRightX(), image.getTopY()};
         addAttributeToStructElem(figureObject, ASAtom.LAYOUT, ASAtom.BBOX, COSArray.construct(4, bbox));
         // PDF/UA-1 rule 7.3-1 / PDF/UA-2 rule 8.2.5.28.2-1: every Figure must
@@ -808,7 +938,8 @@ public class AutoTaggingProcessor {
         setStringEntry(altText, figureObject, IMAGE_REPLACEMENT_TEXT, ASAtom.ALT, true);
         cosDocument.addChangedObject(figureObject);
         processImageNode(image, figureObject);
-        addCaptionIfPresent(image, figureObject, cosDocument);
+        // Into the Sect when there is one, so the caption lands beside the figure.
+        addCaptionIfPresent(image, figureObject, cosDocument, figureParent);
         return figureObject;
     }
 

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/AutoTaggingProcessor.java
@@ -206,19 +206,28 @@ public class AutoTaggingProcessor {
         structTreeRoot.setKey(ASAtom.PARENT_TREE, parentTree);
         COSObject nums = COSArray.construct();
         parentTree.setKey(ASAtom.NUMS, nums);
-        int nextKey = 0;
+
+        // A number tree's keys must ascend (ISO 32000-1 7.9.7), because a reader
+        // binary-searches /Nums. Page keys and annotation keys are allocated
+        // from one counter and interleave, so writing each group in its own pass
+        // emitted descending runs: the search then missed entries that were
+        // present, and Acrobat showed no structure tag for the page's content.
+        // Collect both groups, then write once in key order. The spec constrains
+        // the emitted order, not the allocation order, so nothing upstream of
+        // here changes.
+        Map<Integer, COSObject> byKey = new TreeMap<>();
         for (Map.Entry<OperatorStreamKey, List<COSObject>> entry : structParents.entrySet()) {
-            int key = structParentsIntegers.get(entry.getKey());
-            nums.add(COSInteger.construct(key));
             COSObject array = COSArray.construct();
             for (COSObject structParent : entry.getValue()) {
                 array.add(structParent);
             }
-            nums.add(array);
-            if (key >= nextKey) nextKey = key + 1;
+            byKey.put(structParentsIntegers.get(entry.getKey()), array);
         }
-        // Add single-entry annotations (Link annotations) to parent tree
-        for (Map.Entry<Integer, COSObject> entry : annotationStructParents.entrySet()) {
+        // Single-entry annotations (Link annotations).
+        byKey.putAll(annotationStructParents);
+
+        int nextKey = 0;
+        for (Map.Entry<Integer, COSObject> entry : byKey.entrySet()) {
             nums.add(COSInteger.construct(entry.getKey()));
             nums.add(entry.getValue());
             if (entry.getKey() >= nextKey) nextKey = entry.getKey() + 1;

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/ContentFilterProcessor.java
@@ -82,7 +82,9 @@ public class ContentFilterProcessor {
                 new Object[]{pageNumber + 1, replacementCharRatio});
         }
         TextProcessor.replaceUndefinedCharacters(pageContents, config.getReplaceInvalidChars());
-        processBackgrounds(pageNumber, pageContents);
+        if (config.getFilterConfig().isFilterBackgrounds()) {
+            processBackgrounds(pageNumber, pageContents);
+        }
         return pageContents;
     }
 

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/FilterConfigTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/FilterConfigTest.java
@@ -15,6 +15,15 @@ class FilterConfigTest {
         assertTrue(config.isFilterOutOfPage());
         assertTrue(config.isFilterTinyText());
         assertTrue(config.isFilterHiddenOCG());
+        assertTrue(config.isFilterBackgrounds());
         assertFalse(config.isFilterSensitiveData());
+    }
+
+    @Test
+    void backgroundFilterCanBeDisabledToKeepVectorGraphics() {
+        FilterConfig config = new FilterConfig();
+        config.setFilterBackgrounds(false);
+
+        assertFalse(config.isFilterBackgrounds());
     }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsContentSafetyTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/api/cli/CLIOptionsContentSafetyTest.java
@@ -99,4 +99,28 @@ class CLIOptionsContentSafetyTest {
         assertTrue(config.getFilterConfig().isFilterSensitiveData(),
                 "--sanitize should win over deprecated --content-safety-off sensitive-data");
     }
+
+    @Test
+    void contentSafetyOffBackgroundKeepsVectorGraphics() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp", "--content-safety-off", "background");
+        assertFalse(config.getFilterConfig().isFilterBackgrounds(),
+                "--content-safety-off background should disable the background filter");
+        // The other filters are untouched by this value.
+        assertTrue(config.getFilterConfig().isFilterTinyText());
+        assertTrue(config.getFilterConfig().isFilterOutOfPage());
+    }
+
+    @Test
+    void contentSafetyOffAllAlsoDisablesBackgroundFilter() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp", "--content-safety-off", "all");
+        assertFalse(config.getFilterConfig().isFilterBackgrounds(),
+                "'all' should cover every filter, including backgrounds");
+    }
+
+    @Test
+    void backgroundFilterIsOnByDefault() throws Exception {
+        Config config = parseArgs("--output-dir", "/tmp");
+        assertTrue(config.getFilterConfig().isFilterBackgrounds(),
+                "background removal stays on unless explicitly disabled");
+    }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/BackgroundFilterTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/BackgroundFilterTest.java
@@ -16,11 +16,10 @@
 package org.opendataloader.pdf.processors;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.opendataloader.pdf.api.Config;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -79,8 +78,7 @@ class BackgroundFilterTest {
     }
 
     @Test
-    void disablingTheBackgroundFilterKeepsThePageSizedVector() throws IOException {
-        Path dir = Files.createTempDirectory("bgfilter");
+    void disablingTheBackgroundFilterKeepsThePageSizedVector(@TempDir Path dir) throws IOException {
         Path pdf = writePageSizedVectorPdf(dir);
 
         long kept = countLineArt(pdf, false, dir);
@@ -90,17 +88,6 @@ class BackgroundFilterTest {
                 "with the background filter off, at least one more LineArtChunk should survive; "
                         + "kept=" + kept + " removed=" + removed);
         assertTrue(kept > 0, "the page-covering rectangle should be present when the filter is off");
-
-        deleteRecursively(dir.toFile());
     }
 
-    private static void deleteRecursively(File f) {
-        File[] children = f.listFiles();
-        if (children != null) {
-            for (File c : children) {
-                deleteRecursively(c);
-            }
-        }
-        f.delete();
-    }
 }

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/BackgroundFilterTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/BackgroundFilterTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.processors;
+
+import org.junit.jupiter.api.Test;
+import org.opendataloader.pdf.api.Config;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end check that {@code --content-safety-off background} keeps vector
+ * graphics that the size heuristic would otherwise classify as a page
+ * background.
+ *
+ * <p>The fixture draws one filled rectangle covering most of the page, which
+ * {@code ContentFilterProcessor.isBackground} matches (width &gt; 50% and
+ * height &gt; 10% of the page). With the filter on, that {@code LineArtChunk}
+ * is removed before tagging; with it off, it survives into the contents.
+ */
+class BackgroundFilterTest {
+
+    /** One-page PDF whose only mark is a page-covering filled rectangle. */
+    private static Path writePageSizedVectorPdf(Path dir) throws IOException {
+        Path file = dir.resolve("page-sized-vector.pdf");
+        try (org.apache.pdfbox.pdmodel.PDDocument doc = new org.apache.pdfbox.pdmodel.PDDocument()) {
+            org.apache.pdfbox.pdmodel.PDPage page = new org.apache.pdfbox.pdmodel.PDPage(
+                    org.apache.pdfbox.pdmodel.common.PDRectangle.LETTER);
+            doc.addPage(page);
+            try (org.apache.pdfbox.pdmodel.PDPageContentStream cs =
+                         new org.apache.pdfbox.pdmodel.PDPageContentStream(doc, page)) {
+                // Covers 90% of the width and 92% of the height, so isBackground()
+                // matches on both of its clauses.
+                cs.setNonStrokingColor(0.5f, 0.5f, 0.5f);
+                cs.addRect(30, 30, 550, 730);
+                cs.fill();
+            }
+            doc.save(file.toFile());
+        }
+        return file;
+    }
+
+    private static long countLineArt(Path pdf, boolean filterBackgrounds, Path outDir)
+            throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(outDir.toString());
+        config.setGenerateJSON(false);
+        config.getFilterConfig().setFilterBackgrounds(filterBackgrounds);
+
+        DocumentProcessor.preprocessing(pdf.toString(), config);
+        List<org.verapdf.wcag.algorithms.entities.IObject> page =
+                ContentFilterProcessor.getFilteredContents(
+                        pdf.toString(),
+                        org.verapdf.wcag.algorithms.semanticalgorithms.containers.StaticContainers
+                                .getDocument().getArtifacts(0),
+                        0,
+                        config);
+        return page.stream()
+                .filter(o -> o instanceof org.verapdf.wcag.algorithms.entities.content.LineArtChunk)
+                .count();
+    }
+
+    @Test
+    void disablingTheBackgroundFilterKeepsThePageSizedVector() throws IOException {
+        Path dir = Files.createTempDirectory("bgfilter");
+        Path pdf = writePageSizedVectorPdf(dir);
+
+        long kept = countLineArt(pdf, false, dir);
+        long removed = countLineArt(pdf, true, dir);
+
+        assertTrue(kept > removed,
+                "with the background filter off, at least one more LineArtChunk should survive; "
+                        + "kept=" + kept + " removed=" + removed);
+        assertTrue(kept > 0, "the page-covering rectangle should be present when the filter is off");
+
+        deleteRecursively(dir.toFile());
+    }
+
+    private static void deleteRecursively(File f) {
+        File[] children = f.listFiles();
+        if (children != null) {
+            for (File c : children) {
+                deleteRecursively(c);
+            }
+        }
+        f.delete();
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/CaptionPlacementTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/CaptionPlacementTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.processors;
+
+import org.junit.jupiter.api.Test;
+import org.verapdf.as.ASAtom;
+import org.verapdf.cos.COSArray;
+import org.verapdf.cos.COSDictionary;
+import org.verapdf.cos.COSDocument;
+import org.verapdf.cos.COSIndirect;
+import org.verapdf.cos.COSName;
+import org.verapdf.cos.COSObject;
+import org.verapdf.pd.structure.PDStructElem;
+import org.verapdf.tools.TaggedPDFConstants;
+import org.verapdf.wcag.algorithms.entities.geometry.BoundingBox;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where a Caption sits relative to what it describes.
+ *
+ * <p>A captioned figure is wrapped in a Sect so the Figure and its Caption are
+ * siblings. Nesting the caption inside the figure is legal, but it puts the
+ * caption's text in the figure's subtree, where ISO 32000-1 14.9.4 makes the
+ * figure's own {@code /Alt} stand in for everything below it. Table and L keep
+ * their captions as children — ISO 32000-1 Table 337 permits that, and a table's
+ * caption competes with no /Alt.
+ *
+ * <p>The wrapper cannot be Div, and that is the part worth a test rather than a
+ * comment: Div satisfies every rule in the profile's own descriptions, so the
+ * mistake is invisible to a reading of the spec. It fails because veraPDF walks
+ * past Div when it computes a parent.
+ */
+class CaptionPlacementTest {
+
+    private static BoundingBox box(double x0, double y0, double x1, double y1) {
+        return new BoundingBox(0, x0, y0, x1, y1);
+    }
+
+    /** The spatial rule that decides before-or-after, exercised directly. */
+    private static boolean captionComesFirst(BoundingBox caption, BoundingBox parent)
+            throws Exception {
+        Method m = AutoTaggingProcessor.class
+                .getDeclaredMethod("isCaptionFirstChild", BoundingBox.class, BoundingBox.class);
+        m.setAccessible(true);
+        return (Boolean) m.invoke(null, caption, parent);
+    }
+
+    /**
+     * The wrapper must not be a tag veraPDF treats as transparent.
+     *
+     * <p>Div, Part and NonStruct are pass-through: {@code parentStandardType}
+     * loops past them, so a Caption inside a Div reports Document as its parent
+     * and still fails Table 5 Document-Caption.1. Measured — the tree and every
+     * /P pointer were correct and the document failed anyway. Whatever wrapper
+     * this code picks has to stay off that list.
+     */
+    @Test
+    void theWrapperIsNotAPassThroughTag() {
+        assertFalse(PDStructElem.isPassThroughTag(TaggedPDFConstants.SECT),
+                "Sect must remain a real parent for the caption to be inside it");
+
+        assertTrue(PDStructElem.isPassThroughTag(TaggedPDFConstants.DIV),
+                "Div is transparent, which is why it cannot be the wrapper");
+        assertTrue(PDStructElem.isPassThroughTag(TaggedPDFConstants.PART),
+                "Part is transparent for the same reason");
+    }
+
+    @Test
+    void aCaptionAboveItsFigureIsPlacedBeforeIt() throws Exception {
+        // PDF coordinates: y grows upward, so "above" is a larger y.
+        BoundingBox figure = box(100, 400, 300, 600);
+        BoundingBox caption = box(100, 610, 300, 630);
+
+        assertTrue(captionComesFirst(caption, figure),
+                "a caption whose centre sits above the figure's top edge precedes it");
+    }
+
+    @Test
+    void aCaptionBelowItsFigureIsPlacedAfterIt() throws Exception {
+        BoundingBox figure = box(100, 400, 300, 600);
+        BoundingBox caption = box(100, 370, 300, 390);
+
+        assertFalse(captionComesFirst(caption, figure),
+                "a caption whose centre sits below the figure's bottom edge follows it");
+    }
+
+    /**
+     * A caption overlapping its figure vertically falls back to horizontal
+     * order, so the outcome stays defined rather than depending on which
+     * element happened to be built first.
+     */
+    @Test
+    void aCaptionOverlappingItsFigureFallsBackToHorizontalOrder() throws Exception {
+        BoundingBox figure = box(300, 400, 500, 600);
+
+        assertTrue(captionComesFirst(box(100, 450, 250, 550), figure),
+                "a caption to the left comes first");
+        assertFalse(captionComesFirst(box(550, 450, 700, 550), figure),
+                "a caption to the right comes last");
+    }
+
+    /**
+     * A missing box must not throw: the caller has no fallback if it does, and
+     * an unplaced caption is dropped from the tree entirely.
+     */
+    @Test
+    void aMissingBoundingBoxDoesNotThrow() throws Exception {
+        assertTrue(captionComesFirst(null, box(0, 0, 10, 10)));
+        assertTrue(captionComesFirst(box(0, 0, 10, 10), null));
+    }
+
+    /**
+     * The sibling a caption is placed next to must be found by identity.
+     *
+     * <p>createCaptionStructElemBeside locates its sibling in the parent's /K
+     * array. COSIndirect.equals compares getDirect(), and COSDictionary.equals
+     * is a deep key-set-and-values comparison, so two struct elements built the
+     * same way compare equal — and two Figures on one page are built the same
+     * way, carrying the same /S, /Type and /Pg before their kids are attached.
+     *
+     * <p>A value search therefore returns the first match rather than the
+     * intended element, and the caption is inserted beside the wrong figure.
+     * Today's Sect holds only its own figure, so the wrong index happens to be
+     * the right one — but that method exists precisely so that adding anything
+     * else to the Sect does not move the caption, which is the case where the
+     * value search breaks. This pins the contract the fix relies on.
+     */
+    @Test
+    void twoStructElementsBuiltAlikeAreEqualButNotIdentical() {
+        COSDocument document = new COSDocument(null);
+        COSObject first = structElement(document, TaggedPDFConstants.FIGURE);
+        COSObject second = structElement(document, TaggedPDFConstants.FIGURE);
+
+        assertNotSame(first, second, "they are separate elements");
+        assertEquals(first, second,
+                "and they compare equal, which is why equals cannot locate either");
+
+        COSObject kids = COSArray.construct();
+        kids.add(first);
+        kids.add(second);
+
+        assertEquals(0, indexOfByValue(kids, second),
+                "a value search finds the wrong element");
+        assertEquals(1, indexOfByIdentity(kids, second),
+                "an identity search finds the intended one");
+    }
+
+    /** As addStructElement builds one, minus the parts needing a live document. */
+    private static COSObject structElement(COSDocument document, String type) {
+        COSObject element = COSIndirect.construct(COSDictionary.construct(), document);
+        element.setKey(ASAtom.S, COSName.construct(type));
+        element.setKey(ASAtom.TYPE, COSName.construct(ASAtom.STRUCT_ELEM));
+        return element;
+    }
+
+    private static int indexOfByValue(COSObject kids, COSObject wanted) {
+        for (int i = 0; i < kids.size(); i++) {
+            if (kids.at(i) != null && kids.at(i).equals(wanted)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int indexOfByIdentity(COSObject kids, COSObject wanted) {
+        for (int i = 0; i < kids.size(); i++) {
+            if (kids.at(i) == wanted) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ParentTreeOrderTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/processors/ParentTreeOrderTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.processors;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSInteger;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSObject;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.apache.pdfbox.pdmodel.interactive.action.PDActionURI;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
+import org.junit.jupiter.api.Test;
+import org.opendataloader.pdf.api.Config;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The {@code /ParentTree} number tree must have ascending keys.
+ *
+ * <p>ISO 32000-1 7.9.7: {@code /Nums} keys have to ascend, because a reader
+ * binary-searches them. Page keys and annotation keys are allocated from one
+ * counter ({@code currentStructParent++} in {@code processAnnotations}) and
+ * interleave, so writing each group in its own pass produced descending runs —
+ * the search then missed entries that were present, and Acrobat showed no
+ * structure tag for the page's content.
+ *
+ * <p>The fixture needs link annotations to exercise this. Without them there is
+ * only one group and any order is trivially ascending. Measured over a
+ * 200-document corpus: every one of the 63 documents with unsorted keys had link
+ * annotations, and every one of the 137 sorted ones had none.
+ *
+ * <p>The assertion is on the <em>written</em> array, not on a lookup. A linear
+ * scan finds the entry either way, which is exactly how 63 documents read as
+ * healthy while a conforming reader's binary search failed on them.
+ */
+class ParentTreeOrderTest {
+
+    /**
+     * A tagged PDF with text and several links per page.
+     *
+     * <p>More than one link per page matters: the annotation keys for a page are
+     * allocated after that page's content keys, so a single link per page can
+     * leave the concatenation accidentally ascending.
+     */
+    private static Path writeTaggedPdfWithLinks(Path dir, int pageCount, int linksPerPage)
+            throws IOException {
+        Path file = dir.resolve("links.pdf");
+        try (PDDocument doc = new PDDocument()) {
+            for (int page = 0; page < pageCount; page++) {
+                PDPage pdPage = new PDPage(PDRectangle.LETTER);
+                doc.addPage(pdPage);
+                try (PDPageContentStream cs = new PDPageContentStream(doc, pdPage)) {
+                    cs.beginText();
+                    cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                    cs.newLineAtOffset(72, 720);
+                    cs.showText("Page " + (page + 1) + " body text above the links.");
+                    cs.endText();
+                    for (int link = 0; link < linksPerPage; link++) {
+                        cs.beginText();
+                        cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                        cs.newLineAtOffset(72, 680 - link * 30);
+                        cs.showText("link target " + link);
+                        cs.endText();
+                    }
+                }
+                for (int link = 0; link < linksPerPage; link++) {
+                    PDAnnotationLink annotation = new PDAnnotationLink();
+                    PDRectangle box = new PDRectangle();
+                    box.setLowerLeftX(72);
+                    box.setLowerLeftY(676 - link * 30);
+                    box.setUpperRightX(300);
+                    box.setUpperRightY(694 - link * 30);
+                    annotation.setRectangle(box);
+                    PDActionURI action = new PDActionURI();
+                    action.setURI("https://example.invalid/" + page + "/" + link);
+                    annotation.setAction(action);
+                    pdPage.getAnnotations().add(annotation);
+                }
+            }
+            doc.save(file.toFile());
+        }
+        return file;
+    }
+
+    /** The keys of {@code /ParentTree}'s {@code /Nums}, in the order written. */
+    private static List<Integer> numsKeys(File pdf) throws IOException {
+        try (PDDocument doc = Loader.loadPDF(pdf)) {
+            COSBase structTreeRoot = resolve(doc.getDocumentCatalog().getCOSObject()
+                    .getDictionaryObject(COSName.getPDFName("StructTreeRoot")));
+            assertNotNull(structTreeRoot, "the document should carry a structure tree");
+
+            COSBase parentTree = resolve(((COSDictionary) structTreeRoot)
+                    .getDictionaryObject(COSName.getPDFName("ParentTree")));
+            assertNotNull(parentTree, "the structure tree should carry a ParentTree");
+
+            COSBase nums = resolve(((COSDictionary) parentTree)
+                    .getDictionaryObject(COSName.getPDFName("Nums")));
+            assertNotNull(nums, "the ParentTree should carry Nums");
+
+            List<Integer> keys = new ArrayList<>();
+            COSArray array = (COSArray) nums;
+            // Nums is a flat [key value key value ...] array.
+            for (int i = 0; i < array.size(); i += 2) {
+                COSBase key = resolve(array.get(i));
+                if (key instanceof COSInteger) {
+                    keys.add(((COSInteger) key).intValue());
+                }
+            }
+            return keys;
+        }
+    }
+
+    private static COSBase resolve(COSBase base) {
+        return base instanceof COSObject ? ((COSObject) base).getObject() : base;
+    }
+
+    private static Path tempDir() throws IOException {
+        return Files.createTempDirectory("parenttree");
+    }
+
+    private static File tag(Path dir, Path source) throws IOException {
+        Config config = new Config();
+        config.setOutputFolder(dir.toString());
+        config.setGenerateJSON(false);
+        config.setGenerateTaggedPDF(true);
+        DocumentProcessor.processFile(source.toString(), config);
+
+        String base = source.getFileName().toString().replaceFirst("\\.pdf$", "");
+        File tagged = dir.resolve(base + "_tagged.pdf").toFile();
+        assertTrue(tagged.isFile(), "expected a tagged PDF at " + tagged);
+        return tagged;
+    }
+
+    @Test
+    void numsKeysAscendWhenAnnotationKeysInterleaveWithPageKeys() throws IOException {
+        Path dir = tempDir();
+        try {
+            // One page, one link is the minimal reproduction. Annotations are
+            // numbered in processAnnotations *before* the page's own content
+            // key, so the annotation gets the lower number while the page group
+            // was written first: a real corpus document emits exactly [1, 0].
+            List<Integer> keys = numsKeys(tag(dir, writeTaggedPdfWithLinks(dir, 1, 1)));
+
+            assertFalse(keys.isEmpty(), "Nums should hold at least one entry");
+            assertTrue(keys.size() >= 2,
+                    "the fixture needs both a page key and an annotation key, or there is "
+                            + "only one group and any order is trivially ascending: " + keys);
+            for (int i = 1; i < keys.size(); i++) {
+                assertTrue(keys.get(i - 1) < keys.get(i),
+                        "Nums keys must ascend (ISO 32000-1 7.9.7) — a reader binary-searches "
+                                + "them, so a descending run makes a present entry unreachable. "
+                                + "Got " + keys);
+            }
+        } finally {
+            deleteRecursively(dir.toFile());
+        }
+    }
+
+    /**
+     * A document with no annotations has one key group, and must stay ascending.
+     *
+     * <p>Such a document can legitimately produce an empty {@code /Nums} — with
+     * nothing to register there is nothing to order — so emptiness is accepted
+     * and only the ordering is asserted.
+     */
+    @Test
+    void numsKeysAscendWithoutAnnotations() throws IOException {
+        Path dir = tempDir();
+        try {
+            List<Integer> keys = numsKeys(tag(dir, writeTaggedPdfWithLinks(dir, 3, 0)));
+
+            for (int i = 1; i < keys.size(); i++) {
+                assertTrue(keys.get(i - 1) < keys.get(i), "Got " + keys);
+            }
+        } finally {
+            deleteRecursively(dir.toFile());
+        }
+    }
+
+    /** Every key appears once: a duplicate would make the lookup ambiguous. */
+    @Test
+    void numsKeysAreUnique() throws IOException {
+        Path dir = tempDir();
+        try {
+            List<Integer> keys = numsKeys(tag(dir, writeTaggedPdfWithLinks(dir, 4, 3)));
+
+            assertEquals(keys.size(), new java.util.HashSet<>(keys).size(),
+                    "a repeated key makes the reader's lookup ambiguous: " + keys);
+        } finally {
+            deleteRecursively(dir.toFile());
+        }
+    }
+
+    private static void assertEquals(int expected, int actual, String message) {
+        org.junit.jupiter.api.Assertions.assertEquals(expected, actual, message);
+    }
+
+    private static void deleteRecursively(File file) {
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        file.delete();
+    }
+}

--- a/node/opendataloader-pdf/src/cli-options.generated.ts
+++ b/node/opendataloader-pdf/src/cli-options.generated.ts
@@ -11,7 +11,7 @@ export function registerCliOptions(program: Command): void {
   program.option('-p, --password <value>', 'Password for encrypted PDF files');
   program.option('-f, --format <value>', 'Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.');
   program.option('-q, --quiet', 'Suppress console logging output');
-  program.option('--content-safety-off <value>', 'Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg');
+  program.option('--content-safety-off <value>', 'Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background');
   program.option('--sanitize', 'Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders');
   program.option('--keep-line-breaks', 'Preserve original line breaks in extracted text');
   program.option('--replace-invalid-chars <value>', 'Replacement character for invalid/unrecognized characters. Default: space');

--- a/node/opendataloader-pdf/src/convert-options.generated.ts
+++ b/node/opendataloader-pdf/src/convert-options.generated.ts
@@ -13,7 +13,7 @@ export interface ConvertOptions {
   format?: string | string[];
   /** Suppress console logging output */
   quiet?: boolean;
-  /** Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg */
+  /** Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background */
   contentSafetyOff?: string | string[];
   /** Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders */
   sanitize?: boolean;

--- a/options.json
+++ b/options.json
@@ -38,7 +38,7 @@
       "type": "string",
       "required": false,
       "default": null,
-      "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg"
+      "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background"
     },
     {
       "name": "sanitize",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/cli_options_generated.py
@@ -52,7 +52,7 @@ CLI_OPTIONS: List[Dict[str, Any]] = [
         "type": "string",
         "required": False,
         "default": None,
-        "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg",
+        "description": "Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background",
     },
     {
         "name": "sanitize",

--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -51,7 +51,7 @@ def convert(
         password: Password for encrypted PDF files
         format: Output formats (comma-separated). Values: json, text, html, pdf, markdown, tagged-pdf. Default: json. For HTML inside Markdown use --markdown-with-html. For image extraction control use --image-output.
         quiet: Suppress console logging output
-        content_safety_off: Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg
+        content_safety_off: Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg, background
         sanitize: Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders
         keep_line_breaks: Preserve original line breaks in extracted text
         replace_invalid_chars: Replacement character for invalid/unrecognized characters. Default: space


### PR DESCRIPTION
Three tagging changes for the PDF/UA output, each independently verifiable.

## `--disable-content-safety background`

Background removal is a size heuristic: a vector graphic covering most of the
page is assumed decorative and dropped. Size does not separate a watermark from a
page-sized graphic that carries content, so the heuristic cannot be right for
both. The new value lets a caller that knows which it has keep those vectors.
The default is unchanged, so nothing moves for anyone who does not pass it.

## `/ParentTree` keys in ascending order

A number tree's keys must ascend (ISO 32000-1 7.9.7) because a reader
binary-searches `/Nums`. Page keys and annotation keys are allocated from one
counter and interleave, and `createParentTree` wrote each group in its own pass,
so the emitted array had descending runs. A search then missed entries that were
present and Acrobat showed no structure tag for the page's content.

Collecting both groups and writing once in key order fixes it. The spec
constrains the emitted order, not the allocation order, so nothing upstream
changes.

## A figure's caption becomes its sibling inside a `Sect`

Nesting a Caption inside its Figure is legal, but it puts the caption's text in
the figure's subtree, where ISO 32000-1 14.9.4 makes the figure's own `/Alt`
stand in for everything below it — and readers disagree about which to announce.

The wrapper has to be `Sect`, and that is the part worth a test rather than a
comment. Caption is forbidden under 33 element types including Document, so
lifting it to the figure's parent unwrapped fails Table 5 Document-Caption.1.
`Div` looks like the fix and is not: veraPDF's `PDStructElem.isPassThroughTag`
treats Div, Part and NonStruct as transparent and `parentStandardType` walks past
them, so a Caption inside a Div still reports Document as its parent. Verified by
building it — correct tree, correct `/P` pointers, same failure.

Two further changes come with it:

- A float may carry one caption above it and one below. A figure titled above the
  image with a source line under it is ordinary, and keying captions by a single
  map entry silently deleted one of them. Two on the same side are dropped rather
  than written out, since PDF/UA-2 8.2.5.27.1 rejects a Caption with siblings on
  both sides.
- The sibling a caption is inserted next to is found by identity, not `equals`.
  `COSIndirect.equals` compares `getDirect()` and `COSDictionary.equals` is a deep
  key-set-and-values comparison, so two struct elements built the same way compare
  equal — which two Figures on one page are, before their kids are attached. A
  value search returns the first match rather than the intended element.

## Verification

22 new tests: `CaptionPlacementTest` (6), `ParentTreeOrderTest` (3),
`BackgroundFilterTest` (1), `FilterConfigTest` (2),
`CLIOptionsContentSafetyTest` (10). `CaptionPlacementTest` pins the two
contracts a comment cannot carry — that `Sect` is not a pass-through tag while
`Div` is, and that two alike struct elements are `equals` but not identical.

`options.json` and the Node/Python bindings are regenerated for the new CLI
value.

**Checklist:**

- [x] Documentation has been updated, if necessary. — reference docs are
      generated at release time; `options.json` and both bindings are regenerated
      here.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added background filtering to remove page-sized vector graphics by default.
  - Added `background` to the content-safety controls, allowing this filter to be disabled independently or with `all`.
  - Improved figure caption placement, including captions above or below figures.

- **Bug Fixes**
  - Improved tagged PDF structure for captioned figures.
  - Ensured parent-tree entries are written in the required ascending order.
  - Preserved background graphics when background filtering is disabled.

- **Documentation**
  - Updated command-line and Python option documentation with the new `background` value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->