### PR TITLE
fix(header-footer): skip text nodes with no first non-space line

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HeaderFooterProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HeaderFooterProcessor.java
@@ -311,6 +311,14 @@ public class HeaderFooterProcessor {
         for (int i = 0; i < textNodes.size(); i++) {
             SemanticTextNode textNode = textNodes.get(i);
             TextLine line = textNode.getFirstNonSpaceLine();
+            if (line == null) {
+                // Every line of the node is empty or space-only, so there is no
+                // label to match a header or footer numbering against. Skipping
+                // leaves fewer than two entries, so no interval is produced and
+                // the pair is rejected -- the correct answer for a node with no
+                // visible text.
+                continue;
+            }
             TextLine secondLine = textNode.getNonSpaceLine(1);
             textChildrenInfo.add(new ListItemTextInfo(i, textNode.getSemanticType(),
                     line, line.getValue().trim(), secondLine == null));


### PR DESCRIPTION
## Problem

`SemanticTextNode.getFirstNonSpaceLine()` returns `null` when every line of the node is empty or space-only — it delegates to `getNonSpaceLine(0)`, which only accepts a line satisfying `!line.isEmpty() && !line.isSpaceLine()`.

`getHeadersOrFootersIntervals` dereferenced the result immediately:

```java
TextLine line = textNode.getFirstNonSpaceLine();
TextLine secondLine = textNode.getNonSpaceLine(1);
textChildrenInfo.add(new ListItemTextInfo(i, textNode.getSemanticType(),
        line, line.getValue().trim(), secondLine == null));   // NPE
```

The exception propagated out of `processHeadersAndFooters` and aborted processing of the **entire document**:

```
java.lang.NullPointerException: Cannot invoke
  "org.verapdf.wcag.algorithms.entities.content.TextLine.getValue()" because "line" is null
	at HeaderFooterProcessor.getHeadersOrFootersIntervals(HeaderFooterProcessor.java:316)
	at HeaderFooterProcessor.arePossibleHeadersOrFooters(HeaderFooterProcessor.java:290)
	at HeaderFooterProcessor.processHeadersAndFooters(HeaderFooterProcessor.java:62)
	at HybridDocumentProcessor.postProcess(HybridDocumentProcessor.java:1268)
```

Reproduced on a real document; all six requested output formats were lost.

## Fix

Skip the node. Its lines carry no label to match a header or footer numbering against, so it has nothing to contribute.

`getHeadersOrFootersIntervals` has a single call site, which reads only the set cardinality:

```java
if (getHeadersOrFootersIntervals(textNodes, increment).size() == 1) {
    return true;
}
```

`textNodes` there is always exactly two elements. Skipping one leaves a single entry, from which no interval can form, so the candidate pair is rejected — the correct outcome for a node with no visible text. The change turns a crash into a rejection; it makes no previously-`true` result `false` or vice versa.

### Why not reuse the ListProcessor guard

`ListProcessor.calculateTextChildrenInfo` guards the equivalent code with `isSpaceNode() || isEmpty()`. Those predicates are **sufficient but not necessary** for a null line: they test chunks, while `getNonSpaceLine` tests lines. A node whose lines are each individually empty or space-only, while some chunk is non-whitespace, satisfies neither disjunct yet still yields `null`.

Checking the null directly tests exactly the postcondition that matters and does not drift if the upstream `isEmpty` / `isSpaceNode` definitions change.

### Sibling call

`getNonSpaceLine(1)` on the following line needs no guard — it routinely returns `null` for a single-line header and is only compared `== null` to flag that case. No dereference.

## Verification

| Check | Result |
|---|---|
| Affected document | NPE gone; JSON produced (5 pages, 100 elements: 80 paragraph, 17 heading, 1 table, 2 image) |
| Header/footer detection still active | `--include-header-footer` changes output size (15042 → 15126 bytes), so the feature is not disabled |
| Normal-mode spot check | 4 documents, all pass |
| Full module suite | 638 tests, 0 failures, 0 errors |

## Follow-up (not in this PR)

`ListProcessor.calculateTextChildrenInfo` keeps the weaker guard and dereferences `line` without a null check, so the same defect class remains reachable there. Left out to keep this fix scoped; worth a separate issue.

## Note on test coverage

No unit test is included. The null node arises from backend-derived content in the hybrid path, and two attempts at a synthetic fixture failed to reach the code path — one passed with the guard removed, the other tripped an unrelated NPE in `sortPageContents` because a bare `SemanticTextNode` has no page number. The reproducing document is customer data and is not suitable as a committed fixture. Verification rests on the real-document check above (fails with the guard removed, passes with it restored).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of headers and footers when text consists only of blank or whitespace-only lines.
  * Prevented invalid header or footer intervals from being created in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->