### PR TITLE
feat(hybrid): let `--device directml` run RapidOCR on DirectML

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/hybrid_server.py
@@ -36,6 +36,9 @@ Usage:
     # Force CPU-only processing
     opendataloader-pdf-hybrid --device cpu
 
+    # Run RapidOCR on the GPU through DirectML (Windows; needs onnxruntime-directml)
+    opendataloader-pdf-hybrid --ocr-engine rapidocr --device directml
+
     # With formula enrichment (LaTeX extraction)
     opendataloader-pdf-hybrid --enrich-formula
 
@@ -92,6 +95,21 @@ UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1MB chunks for streaming upload
 # Single source of truth shared by `create_converter`, `main()` argparse, and tests
 # to avoid drift between production and test code.
 _OCR_ENGINE_DENYLIST = frozenset({"kserve_v2_ocr"})
+
+# DirectML is a Windows-only ONNX Runtime execution provider. Docling's
+# AcceleratorDevice has no DirectML member, so the name is accepted on `--device`
+# and mapped onto RapidOCR in `create_converter()` instead of being forwarded to
+# AcceleratorOptions, whose validator would reject it.
+_DEVICE_DIRECTML = "directml"
+
+# Docling asks RapidOCR for DirectML by setting `Det.use_dml` / `Cls.use_dml` /
+# `Rec.use_dml`. Those are RapidOCR 2.x keys: since RapidOCR 3 the provider
+# switches live under `EngineConfig.<engine>.*`, which is where rapidocr's
+# ProviderConfig reads them. Docling's request therefore never lands and RapidOCR
+# silently stays on CPU, without a single warning. `RapidOcrOptions.rapidocr_params`
+# is merged over docling's own params last, so it is the supported way to set the
+# key that rapidocr actually reads.
+_RAPIDOCR_DML_PARAMS = {"EngineConfig.onnxruntime.use_dml": True}
 
 
 def _non_negative_int(value: str) -> int:
@@ -304,7 +322,21 @@ def _check_dependencies():
         )
 
 
-def _check_ocr_engine_available(engine_kind: str) -> tuple[bool, str]:
+def _is_directml_available() -> bool:
+    """Return True when the installed ONNX Runtime exposes DirectML.
+
+    The DirectML execution provider only ships in the `onnxruntime-directml`
+    wheel, which cannot coexist with plain `onnxruntime`: both install the same
+    `onnxruntime` module, so the two wheels must be swapped rather than combined.
+    """
+    try:
+        from onnxruntime import get_available_providers
+    except ImportError:
+        return False
+    return "DmlExecutionProvider" in get_available_providers()
+
+
+def _check_ocr_engine_available(engine_kind: str, device: str = "auto") -> tuple[bool, str]:
     """Probe runtime prerequisites for the selected OCR engine.
 
     Called at startup so a missing binary or Python package surfaces before the
@@ -314,9 +346,25 @@ def _check_ocr_engine_available(engine_kind: str) -> tuple[bool, str]:
     docling at conversion time, so both are treated as always available. Other
     engines pull in extra system or Python dependencies that are not declared
     in pyproject and must be installed by the user.
+
+    `device` is checked alongside the engine because a device can carry its own
+    prerequisite; DirectML is currently the only such case.
     """
     import importlib.util
     import shutil
+
+    if device == _DEVICE_DIRECTML and not _is_directml_available():
+        return False, (
+            "--device directml selected but the installed ONNX Runtime does not "
+            "expose DmlExecutionProvider. DirectML ships in the "
+            "`onnxruntime-directml` wheel, which cannot be installed alongside "
+            "plain `onnxruntime` (both provide the same `onnxruntime` module), so "
+            "the wheels have to be swapped:\n"
+            "  pip uninstall -y onnxruntime\n"
+            "  pip install onnxruntime-directml\n"
+            "Then confirm the provider is listed by "
+            "onnxruntime.get_available_providers()."
+        )
 
     if engine_kind in ("auto", "easyocr"):
         return True, ""
@@ -419,8 +467,10 @@ def create_converter(
         enrich_formula: If True, enable formula enrichment (LaTeX extraction).
         enrich_picture_description: If True, enable picture description (alt text generation).
         picture_description_prompt: Custom prompt forwarded to the VLM. If None or blank/whitespace-only, docling's default prompt is used.
-        device: Accelerator device for model inference. Options: "auto", "cpu", "cuda", "mps", "xpu".
-                "auto" lets Docling select the best available device. Default: "auto".
+        device: Accelerator device for model inference. Options: "auto", "cpu", "cuda", "mps",
+                "xpu", "directml". "auto" lets Docling select the best available device.
+                "directml" runs the ONNX Runtime based OCR stage (RapidOCR) on the GPU through
+                DirectML; the other models stay on the CPU path. Default: "auto".
     """
     from docling.datamodel.accelerator_options import AcceleratorOptions
     from docling.datamodel.base_models import InputFormat
@@ -428,6 +478,7 @@ def create_converter(
         AcceleratorOptions,
         PdfPipelineOptions,
         PictureDescriptionVlmOptions,
+        RapidOcrOptions,
         TableFormerMode,
         TableStructureOptions,
         TesseractCliOcrOptions,
@@ -473,6 +524,22 @@ def create_converter(
     ):
         ocr_options.psm = psm
 
+    # RapidOCR-only: DirectML execution provider.
+    # RapidOCR is the only ONNX Runtime stage in the pipeline, so it is the only
+    # part DirectML can accelerate; layout and table structure keep the device
+    # docling resolves for them. Warn — rather than pass silently — when the
+    # selected engine cannot make use of it, since `--device directml` would
+    # otherwise look accepted while doing nothing (cf. PDFDLOSP-20).
+    if device == _DEVICE_DIRECTML:
+        if isinstance(ocr_options, RapidOcrOptions):
+            ocr_options.rapidocr_params.update(_RAPIDOCR_DML_PARAMS)
+        else:
+            logger.warning(
+                "--device directml only affects the rapidocr engine; ignoring it "
+                "for ocr_engine=%r",
+                ocr_engine,
+            )
+
     # Configure picture description options with custom prompt.
     # When picture_description_prompt is None or blank, omit the field so
     # docling's built-in default prompt is used. A blank string would otherwise
@@ -495,13 +562,14 @@ def create_converter(
         "do_formula_enrichment": enrich_formula,
         "do_picture_description": enrich_picture_description,
         "generate_picture_images": enrich_picture_description,
-        "accelerator_options": AcceleratorOptions(device=device),
+        # AcceleratorOptions validates against AcceleratorDevice, which has no
+        # DirectML member, so "directml" is consumed above and must not reach here.
+        "accelerator_options": AcceleratorOptions(
+            device="cpu" if device == _DEVICE_DIRECTML else device
+        ),
     }
     if picture_description_options is not None:
         pipeline_kwargs["picture_description_options"] = picture_description_options
-
-    if device != "auto":
-        pipeline_kwargs["accelerator_options"] = AcceleratorOptions(device=device)
 
     pipeline_options = PdfPipelineOptions(**pipeline_kwargs)
 
@@ -536,7 +604,8 @@ def create_app(
         enrich_picture_description: If True, enable picture description (alt text generation).
         picture_description_prompt: Custom prompt forwarded to the VLM. If None or blank/whitespace-only, docling's default prompt is used.
         max_file_size: Maximum file size in bytes. 0 means no limit (default).
-        device: Accelerator device for model inference ("auto", "cpu", "cuda", "mps", "xpu").
+        device: Accelerator device for model inference ("auto", "cpu", "cuda", "mps", "xpu",
+                "directml").
     """
     from fastapi import FastAPI, File, Form, UploadFile
     from fastapi.responses import JSONResponse
@@ -925,8 +994,10 @@ def main():
         "--device",
         type=str,
         default="auto",
-        choices=["auto", "cpu", "cuda", "mps", "xpu"],
-        help="Accelerator device for model inference: auto (default), cpu, cuda, mps (Apple Silicon), xpu (Intel GPU).",
+        choices=["auto", "cpu", "cuda", "mps", "xpu", _DEVICE_DIRECTML],
+        help="Accelerator device for model inference: auto (default), cpu, cuda, "
+             "mps (Apple Silicon), xpu (Intel GPU), directml (Windows GPU for the "
+             "rapidocr engine; requires the onnxruntime-directml wheel).",
     )
     args = parser.parse_args()
 
@@ -964,7 +1035,7 @@ def main():
     # `tesseract` binary or Python package surfaces here as a clear, actionable
     # error rather than as a deferred runtime exception during the first request.
     if not args.no_ocr:
-        ok, err = _check_ocr_engine_available(args.ocr_engine)
+        ok, err = _check_ocr_engine_available(args.ocr_engine, device=args.device)
         if not ok:
             logger.error(err)
             sys.exit(2)

--- a/python/opendataloader-pdf/tests/test_hybrid_server_ocr_options.py
+++ b/python/opendataloader-pdf/tests/test_hybrid_server_ocr_options.py
@@ -9,6 +9,7 @@ Covers:
     * Unknown / denylisted engines exit with a clear message
     * argparse `--no-ocr` and `--force-ocr` are mutually exclusive
     * argparse `--ocr-engine` choices exclude `kserve_v2_ocr`
+    * `--device directml` routes through `RapidOcrOptions.rapidocr_params`
 """
 
 import argparse
@@ -146,6 +147,59 @@ def test_create_converter_rejects_denylisted_engine():
     assert "_OCR_ENGINE_DENYLIST" in msg
 
 
+# ---------- --device directml ----------
+
+def test_device_directml_sets_rapidocr_use_dml():
+    """`device='directml'` lands the switch where rapidocr 3 actually reads it.
+
+    Docling emits `Det.use_dml` / `Cls.use_dml` / `Rec.use_dml`, which stopped being
+    read when rapidocr 3 moved the provider switches under `EngineConfig`. Locks in
+    that we set the key rapidocr's ProviderConfig consumes.
+    """
+    opts = _capture_pipeline_options(ocr_engine="rapidocr", device="directml")
+    assert opts.ocr_options.rapidocr_params["EngineConfig.onnxruntime.use_dml"] is True
+
+
+def test_device_directml_is_not_forwarded_to_accelerator_options():
+    """`directml` must not reach AcceleratorOptions, whose validator rejects it."""
+    opts = _capture_pipeline_options(ocr_engine="rapidocr", device="directml")
+    assert opts.accelerator_options.device == "cpu"
+
+
+def test_other_devices_leave_rapidocr_params_untouched():
+    """Without `--device directml`, RapidOCR keeps docling's own defaults."""
+    for device in ("auto", "cpu"):
+        opts = _capture_pipeline_options(ocr_engine="rapidocr", device=device)
+        assert opts.ocr_options.rapidocr_params == {}, device
+
+
+def test_device_directml_warns_for_engines_that_cannot_use_it(caplog):
+    """`--device directml` with a non-RapidOCR engine warns instead of no-op'ing."""
+    caplog.set_level("WARNING", logger=hybrid_server.logger.name)
+    _capture_pipeline_options(ocr_engine="easyocr", device="directml")
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("directml" in w and "easyocr" in w for w in warnings), warnings
+
+
+def test_directml_probe_fails_when_provider_missing():
+    """`--device directml` without DirectML in the ONNX Runtime wheel fails closed."""
+    with patch.object(hybrid_server, "_is_directml_available", return_value=False):
+        ok, msg = hybrid_server._check_ocr_engine_available("rapidocr", device="directml")
+    assert ok is False
+    assert "DmlExecutionProvider" in msg
+    assert "onnxruntime-directml" in msg
+
+
+def test_directml_probe_passes_when_provider_present():
+    """`--device directml` is accepted once DirectML is available."""
+    with patch.object(
+        hybrid_server, "_is_directml_available", return_value=True
+    ), patch("importlib.util.find_spec", return_value=object()):
+        ok, msg = hybrid_server._check_ocr_engine_available("rapidocr", device="directml")
+    assert ok is True
+    assert msg == ""
+
+
 # ---------- argparse: --no-ocr / --force-ocr / --ocr-engine / --psm ----------
 
 def _build_parser_subset():
@@ -171,6 +225,11 @@ def _build_parser_subset():
     )
     parser.add_argument("--psm", type=int, default=None)
     parser.add_argument("--ocr-lang", default=None)
+    parser.add_argument(
+        "--device",
+        default="auto",
+        choices=["auto", "cpu", "cuda", "mps", "xpu", hybrid_server._DEVICE_DIRECTML],
+    )
     return parser
 
 
@@ -208,6 +267,15 @@ def test_argparse_tesseract_path_for_issue_439():
     assert args.ocr_lang == "mal"
     assert args.force_ocr is True
     assert args.no_ocr is False
+
+
+def test_argparse_device_directml_is_accepted():
+    """`--device directml` parses, so the flag reaches create_converter()."""
+    args = _build_parser_subset().parse_args(
+        ["--ocr-engine", "rapidocr", "--device", "directml"]
+    )
+    assert args.device == "directml"
+    assert args.ocr_engine == "rapidocr"
 
 
 def test_argparse_psm_accepted_as_integer():


### PR DESCRIPTION
## Summary

On Windows, RapidOCR runs on CPU even when a GPU is available — and says nothing about it. This adds a `directml` value to the existing `--device` flag so RapidOCR can use the GPU through DirectML:

```bash
pip uninstall -y onnxruntime
pip install onnxruntime-directml
opendataloader-pdf-hybrid --ocr-engine rapidocr --device directml
```

## Root cause

Docling already *tries* to enable DirectML. In `docling/models/stages/ocr/rapid_ocr_model.py`:

```python
use_dml = accelerator_options.device == AcceleratorDevice.AUTO   # True by default
...
"Det.use_dml": use_dml, "Cls.use_dml": use_dml, "Rec.use_dml": use_dml,
```

But `Det.use_dml` / `Cls.use_dml` / `Rec.use_dml` are **RapidOCR 2.x** keys. Since RapidOCR 3 the execution-provider switches moved to `EngineConfig.<engine>.*`, which is the only place rapidocr's `ProviderConfig` reads them:

```python
# rapidocr/inference_engine/onnxruntime/provider_config.py
self.cfg_use_dml = engine_cfg.get("use_dml", False)   # <- EngineConfig.onnxruntime.use_dml
```

OmegaConf accepts the stale `Det.use_dml` key without complaint, so the request is silently dropped. Verified against docling 2.122.0 / rapidocr 3.9.2: with `--device auto`, all three sessions come up as `['CPUExecutionProvider']` **with zero warnings**.

## Fix

`RapidOcrOptions.rapidocr_params` is docling's documented escape hatch and is merged over docling's own params **last**, so it is the supported way to set the key rapidocr actually reads:

```python
_RAPIDOCR_DML_PARAMS = {"EngineConfig.onnxruntime.use_dml": True}
```

`directml` reuses the existing `--device` plumbing end-to-end (`create_app` → `create_converter`, including the `/v1/profile/file` converters) instead of adding a second, overlapping flag. `AcceleratorDevice` has no DirectML member and its validator rejects unknown values, so `AcceleratorOptions` keeps receiving `cpu`; RapidOCR is the only ONNX Runtime stage in the pipeline, so nothing else could use DirectML anyway.

Two small guardrails, both in the spirit of the existing silent-flag handling in this file:

- `--device directml` with a non-RapidOCR engine warns instead of quietly doing nothing.
- `DmlExecutionProvider` only ships in the `onnxruntime-directml` wheel, which cannot coexist with plain `onnxruntime` (same `onnxruntime` module). A missing provider now exits 2 at startup with the swap instructions, rather than falling back to CPU mid-conversion.

Also drops the dead `if device != "auto":` reassignment of `accelerator_options` in `create_converter()` — it rebuilt the identical `AcceleratorOptions` the dict literal above it already holds.

## Test plan

- [x] 7 new tests in `tests/test_hybrid_server_ocr_options.py`: the param lands on `RapidOcrOptions`, `directml` never reaches `AcceleratorOptions`, other devices leave `rapidocr_params` empty, the non-RapidOCR warning fires, and the DirectML probe passes/fails with the right message.
- [x] Full suite: `103 passed` (only `test_convert_integration.py` skipped — it needs the Maven-built JAR, unavailable in a fresh checkout).
- [x] End-to-end chain check on docling 2.122.0 + rapidocr 3.9.2, driving the patched `create_converter` into docling's real `RapidOcrModel`:

  | `device` | `rapidocr_params` | rapidocr asks for DirectML |
  |---|---|---|
  | `auto` | `{}` | no |
  | `directml` | `{'EngineConfig.onnxruntime.use_dml': True}` | **yes** |

  (Sessions still report `CPUExecutionProvider` here because this box has plain `onnxruntime`; the point is that rapidocr now reaches its DirectML branch and logs it.)
- [x] Separately, in a throwaway venv with `onnxruntime-directml` 1.24.4: `get_available_providers() == ['DmlExecutionProvider', 'CPUExecutionProvider']`, and all five checkpoints in `rapidocr/models/` (`PP-OCRv6_det_small`, `PP-OCRv6_rec_small`, `ch_PP-OCRv5_det_mobile`, `ch_ppocr_mobile_v2.0_cls_mobile`, `cyrillic_PP-OCRv5_rec_mobile`) create sessions on `['DmlExecutionProvider', 'CPUExecutionProvider']` **including via rapidocr's default path** (`dml_ep_cfg: null`, which falls back to the CPU provider options) — so no extra provider config is needed.
- [ ] Manual on a Windows GPU box: install the DirectML wheel, run with `--ocr-engine rapidocr --device directml`, and compare the `timings.ocr` field of `/v1/convert/file` against CPU.

## Notes

- **No dependency change.** The DirectML wheel is a *swap*, not an addition, and an extra for it cannot be expressed without silently no-op'ing: `onnxruntime-directml` requires Python `>=3.11` while this package's floor is `>=3.10`. The startup probe and `--device` help text carry the install instructions instead. Nothing in the current `hybrid` graph hard-requires `onnxruntime`, so the swap is conflict-free.
- "Vulkan" does not exist as an ONNX Runtime execution provider in any published wheel; on Windows, DirectML (D3D12) is the portable GPU path and covers AMD/NVIDIA/Intel alike.
- The underlying key mismatch is a docling bug; this change works around it without patching docling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DirectML GPU support for RapidOCR on Windows.
  * Added a `--device directml` option for selecting DirectML acceleration.
  * Added availability checks and clear handling when DirectML is unavailable.

* **Documentation**
  * Updated hybrid server usage documentation to describe DirectML support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->