### PR TITLE
feat(python): add timeout parameter to run_jar and convert

### DIFF
--- a/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py
@@ -41,6 +41,7 @@ def convert(
     threads: Optional[str] = None,
     image_resolution: Optional[str] = None,
     space_ratio: Optional[str] = None,
+    timeout: Optional[float] = None,
 ) -> None:
     """
     Convert PDF(s) into the requested output format(s).
@@ -77,6 +78,7 @@ def convert(
         threads: Number of worker threads for per-page processing. Default: 1 (sequential, stable). Values >1 (experimental) run pages in parallel for faster throughput; output may vary slightly on some PDFs. Capped at the number of available CPU cores. Applies to the native Java pipeline only; ignored in --hybrid mode
         image_resolution: Set the rendering resolution for images in DPI. Higher values improve image quality but increase memory consumption; lower values reduce memory usage at the cost of detail. Accepts positive decimal DPI values (e.g., 144.0). Default: 144.0.
         space_ratio: Set the ratio used to calculate the automatic space-insertion threshold (threshold = space-ratio * font size). If the horizontal gap between two adjacent symbols exceeds this threshold, an extra space is inserted to text value. Accepts decimals (e.g., 0.17). Default: 0.17
+        timeout: Wall-clock limit in seconds for the CLI process. None (default) waits indefinitely. On expiry the JVM is killed and subprocess.TimeoutExpired is raised. Not a CLI option: the JAR declares no processing bound, so this is enforced by the wrapper.
     """
     args: List[str] = []
 
@@ -155,4 +157,4 @@ def convert(
     if space_ratio:
         args.extend(["--space-ratio", space_ratio])
 
-    run_jar(args, quiet)
+    run_jar(args, quiet, timeout=timeout)

--- a/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
@@ -3,15 +3,58 @@ Low-level JAR runner for opendataloader-pdf.
 """
 import subprocess
 import sys
+import threading
 import importlib.resources as resources
-from typing import List
+from typing import IO, List, Optional
 
 # The consistent name of the JAR file bundled with the package
 _JAR_NAME = "opendataloader-pdf-cli.jar"
 
+# How long to wait for the relay thread after the JVM has exited or been
+# killed. The thread only drains a pipe that is already closed, so it ends
+# immediately in practice; the bound exists so a wedged read cannot hold the
+# caller. It is a daemon thread, so overrunning it never blocks interpreter
+# exit.
+_RELAY_JOIN_TIMEOUT_S = 1.0
 
-def run_jar(args: List[str], quiet: bool = False) -> str:
-    """Run the opendataloader-pdf JAR with the given arguments."""
+
+def _write_stdout(text: str) -> None:
+    """Relay JAR output to the parent stdout, preserving UTF-8 bytes."""
+    if hasattr(sys.stdout, "buffer"):
+        sys.stdout.buffer.write(text.encode("utf-8", errors="replace"))
+        sys.stdout.buffer.flush()
+    else:
+        sys.stdout.write(text)
+
+
+def _relay_lines(stream: IO[str], sink: List[str]) -> None:
+    """Write every line of ``stream`` to stdout, collecting it in ``sink``."""
+    for line in stream:
+        _write_stdout(line)
+        sink.append(line)
+
+
+def run_jar(args: List[str], quiet: bool = False, timeout: Optional[float] = None) -> str:
+    """Run the opendataloader-pdf JAR with the given arguments.
+
+    Args:
+        args: Arguments to pass to the CLI.
+        quiet: Suppress the JAR's log stream (stderr) and return its stdout.
+        timeout: Wall-clock limit in seconds for the JAR process. ``None``
+            (the default) waits indefinitely, which is the historical
+            behaviour. On expiry the JVM is killed and
+            ``subprocess.TimeoutExpired`` is raised. The CLI declares no
+            processing bound of its own -- ``--hybrid-timeout`` covers the
+            hybrid HTTP call only -- so this is the only way for a caller to
+            stop waiting on a conversion that does not return. Note that ``0``
+            is **not** "no timeout" here, unlike ``--hybrid-timeout``: it means
+            an immediate one. Pass ``None`` to wait indefinitely.
+
+    Raises:
+        FileNotFoundError: If the 'java' command is not found.
+        subprocess.CalledProcessError: If the CLI returns a non-zero exit code.
+        subprocess.TimeoutExpired: If ``timeout`` elapses before the CLI exits.
+    """
     try:
         # Access the embedded JAR inside the package
         jar_ref = resources.files("opendataloader_pdf").joinpath("jar", _JAR_NAME)
@@ -42,15 +85,12 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
                     check=True,
                     encoding="utf-8",
                     errors="replace",
+                    # subprocess.run kills the child and reaps it before
+                    # raising TimeoutExpired, so no JVM is left behind.
+                    timeout=timeout,
                 )
                 if result.stdout:
-                    if hasattr(sys.stdout, "buffer"):
-                        sys.stdout.buffer.write(
-                            result.stdout.encode("utf-8", errors="replace")
-                        )
-                        sys.stdout.buffer.flush()
-                    else:
-                        sys.stdout.write(result.stdout)
+                    _write_stdout(result.stdout)
                 return result.stdout
 
             # Streaming mode → live output
@@ -63,15 +103,38 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
                 errors="replace",
             ) as process:
                 output_lines: List[str] = []
-                for line in process.stdout:
-                    if hasattr(sys.stdout, "buffer"):
-                        sys.stdout.buffer.write(line.encode("utf-8", errors="replace"))
-                        sys.stdout.buffer.flush()
-                    else:
-                        sys.stdout.write(line)
-                    output_lines.append(line)
 
-                return_code = process.wait()
+                if timeout is None:
+                    for line in process.stdout:
+                        _write_stdout(line)
+                        output_lines.append(line)
+                    return_code = process.wait()
+                else:
+                    # A blocking read on the pipe cannot itself be bounded, so
+                    # the relay runs on a helper thread and the timeout is
+                    # applied to the process: a JVM that wedges without
+                    # emitting another line is still stopped.
+                    reader = threading.Thread(
+                        target=_relay_lines,
+                        args=(process.stdout, output_lines),
+                        daemon=True,
+                    )
+                    reader.start()
+                    try:
+                        return_code = process.wait(timeout=timeout)
+                    except subprocess.TimeoutExpired as expired:
+                        # Kill before propagating: the caller stops waiting, but
+                        # an unkilled JVM keeps the CPU and its output directory.
+                        process.kill()
+                        process.wait()
+                        reader.join(timeout=_RELAY_JOIN_TIMEOUT_S)
+                        # Attach what the JAR had already emitted to the original
+                        # exception rather than raising a second one, so the
+                        # traceback still points at the wait() that timed out.
+                        expired.output = "".join(output_lines)
+                        raise
+                    reader.join(timeout=_RELAY_JOIN_TIMEOUT_S)
+
                 captured_output = "".join(output_lines)
 
                 if return_code:
@@ -83,6 +146,15 @@ def run_jar(args: List[str], quiet: bool = False) -> str:
     except FileNotFoundError:
         print(
             "Error: 'java' command not found. Please ensure Java is installed and in your system's PATH.",
+            file=sys.stderr,
+        )
+        raise
+
+    except subprocess.TimeoutExpired as error:
+        # The JVM has already been killed; surface the bound that was hit so a
+        # timeout is distinguishable from a crash in the caller's logs.
+        print(
+            f"opendataloader-pdf CLI timed out after {error.timeout}s.",
             file=sys.stderr,
         )
         raise

--- a/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
+++ b/python/opendataloader-pdf/src/opendataloader_pdf/runner.py
@@ -10,11 +10,12 @@ from typing import IO, List, Optional
 # The consistent name of the JAR file bundled with the package
 _JAR_NAME = "opendataloader-pdf-cli.jar"
 
-# How long to wait for the relay thread after the JVM has exited or been
-# killed. The thread only drains a pipe that is already closed, so it ends
-# immediately in practice; the bound exists so a wedged read cannot hold the
-# caller. It is a daemon thread, so overrunning it never blocks interpreter
-# exit.
+# How long to wait for the relay thread after the JVM has been KILLED. Only the
+# timeout path uses this: the output is incomplete by definition once the JVM is
+# killed mid-document, so there is nothing to be gained by waiting on it, and a
+# bound keeps a wedged read from holding the caller. The success path joins
+# without a bound instead -- see `run_jar`. The thread is a daemon, so
+# overrunning this never blocks interpreter exit.
 _RELAY_JOIN_TIMEOUT_S = 1.0
 
 
@@ -133,7 +134,15 @@ def run_jar(args: List[str], quiet: bool = False, timeout: Optional[float] = Non
                         # traceback still points at the wait() that timed out.
                         expired.output = "".join(output_lines)
                         raise
-                    reader.join(timeout=_RELAY_JOIN_TIMEOUT_S)
+                    # Success: the JVM has exited, so the pipe reaches EOF and
+                    # the relay ends on its own. Joining WITHOUT a bound here is
+                    # deliberate -- the JVM can exit while the pipe still holds
+                    # buffered output, and relaying that onward can outlast any
+                    # short bound when the parent's stdout is slow. Cutting the
+                    # join short would silently truncate `captured_output`,
+                    # including a `--to-stdout` payload. `timeout` bounds the
+                    # JVM, not the caller's own stdout.
+                    reader.join()
 
                 captured_output = "".join(output_lines)
 

--- a/python/opendataloader-pdf/tests/test_runner.py
+++ b/python/opendataloader-pdf/tests/test_runner.py
@@ -9,6 +9,7 @@ yet and is allowed to print the captured streams — but only once
 
 import io
 import subprocess
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -230,3 +231,31 @@ def test_streaming_without_timeout_keeps_the_inline_read(monkeypatch, patched_ja
     assert returned == "line one\nline two\n"
     no_threads.assert_not_called()
     fake_process.wait.assert_called_once_with()
+
+
+def test_streaming_success_waits_for_the_full_relay(monkeypatch, patched_jar):
+    """A bounded run that SUCCEEDS must still return everything the JAR wrote.
+
+    The JVM can exit while the pipe still holds buffered output, and relaying it
+    onward can outlast the relay-join bound when the parent's stdout is slow.
+    Cutting the join short there would silently truncate the return value --
+    including a ``--to-stdout`` payload -- which is worse than the wait it saves.
+    The timeout bounds the JVM; once the JVM is gone the relay runs to EOF.
+    """
+    def slow_lines():
+        yield "first line\n"
+        # Outlast the join bound while the process has already exited.
+        time.sleep(runner._RELAY_JOIN_TIMEOUT_S + 0.3)
+        yield "last line\n"
+
+    fake_process = MagicMock()
+    fake_process.stdout = slow_lines()
+    fake_process.wait.return_value = 0
+    fake_process.__enter__ = lambda self: self
+    fake_process.__exit__ = lambda self, *_a: False
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *_a, **_kw: fake_process)
+
+    returned = runner.run_jar(["doc.pdf"], quiet=False, timeout=30)
+
+    # Nothing may be dropped: the tail arrived after the join bound elapsed.
+    assert returned == "first line\nlast line\n"

--- a/python/opendataloader-pdf/tests/test_runner.py
+++ b/python/opendataloader-pdf/tests/test_runner.py
@@ -151,3 +151,82 @@ def test_quiet_failure_prints_captured_streams_once(monkeypatch, capsys, patched
     assert "Stderr: captured stderr text" in err
     assert "Error running opendataloader-pdf CLI." in err
     assert "Return code: 2" in err
+
+
+def test_quiet_forwards_timeout_to_subprocess_run(monkeypatch, patched_jar):
+    """The bound must reach ``subprocess.run``, which is what actually kills
+    the JVM. Default stays ``None`` so existing callers wait exactly as
+    before."""
+    result = subprocess.CompletedProcess(
+        args=["java", "-jar", "fake.jar"], returncode=0, stdout="", stderr=""
+    )
+    fake_run = MagicMock(return_value=result)
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    runner.run_jar(["doc.pdf"], quiet=True, timeout=12.5)
+    assert fake_run.call_args.kwargs["timeout"] == 12.5
+
+    runner.run_jar(["doc.pdf"], quiet=True)
+    assert fake_run.call_args.kwargs["timeout"] is None
+
+
+def test_quiet_timeout_is_reported_and_reraised(monkeypatch, capsys, patched_jar):
+    """A timeout must be distinguishable from a crash in the caller's logs,
+    and must propagate: swallowing it would report a truncated conversion as
+    a successful one."""
+    monkeypatch.setattr(
+        runner.subprocess,
+        "run",
+        MagicMock(side_effect=subprocess.TimeoutExpired(cmd=["java"], timeout=3)),
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner.run_jar(["doc.pdf"], quiet=True, timeout=3)
+
+    err = capsys.readouterr().err
+    assert "timed out after 3s" in err
+    # Not misreported as a non-zero exit.
+    assert "Error running opendataloader-pdf CLI." not in err
+
+
+def test_streaming_timeout_kills_the_jvm(monkeypatch, patched_jar):
+    """Streaming mode blocks on the pipe, so the timeout is applied to the
+    process and the relay runs on a helper thread: a JVM that stops emitting
+    lines is still killed rather than waited on forever."""
+    fake_process = MagicMock()
+    fake_process.stdout = iter(["[INFO] parsing page 1\n"])
+    fake_process.wait.side_effect = [
+        subprocess.TimeoutExpired(cmd=["java"], timeout=5),
+        0,
+    ]
+    fake_process.__enter__ = lambda self: self
+    fake_process.__exit__ = lambda self, *_a: False
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *_a, **_kw: fake_process)
+
+    with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+        runner.run_jar(["doc.pdf"], quiet=False, timeout=5)
+
+    # The JVM is killed, not left running behind a raised exception.
+    fake_process.kill.assert_called_once()
+    # Whatever the JAR had already emitted is attached, not discarded.
+    assert "parsing page 1" in (excinfo.value.output or "")
+
+
+def test_streaming_without_timeout_keeps_the_inline_read(monkeypatch, patched_jar):
+    """Default behaviour is unchanged: no helper thread, and ``wait()`` is
+    called without a bound."""
+    fake_process = MagicMock()
+    fake_process.stdout = iter(["line one\n", "line two\n"])
+    fake_process.wait.return_value = 0
+    fake_process.__enter__ = lambda self: self
+    fake_process.__exit__ = lambda self, *_a: False
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *_a, **_kw: fake_process)
+
+    no_threads = MagicMock()
+    monkeypatch.setattr(runner.threading, "Thread", no_threads)
+
+    returned = runner.run_jar(["doc.pdf"], quiet=False)
+
+    assert returned == "line one\nline two\n"
+    no_threads.assert_not_called()
+    fake_process.wait.assert_called_once_with()

--- a/scripts/generate-options.mjs
+++ b/scripts/generate-options.mjs
@@ -313,6 +313,9 @@ function generatePythonConvert() {
     lines.push(`    ${snakeName}: ${typeHint} = ${defaultVal},`);
   }
 
+  // Wrapper-level parameters: enforced in Python, not passed to the JAR.
+  lines.push('    timeout: Optional[float] = None,');
+
   lines.push(') -> None:');
   lines.push('    """');
   lines.push('    Convert PDF(s) into the requested output format(s).');
@@ -324,6 +327,8 @@ function generatePythonConvert() {
     const snakeName = toSnakeCase(opt.name);
     lines.push(`        ${snakeName}: ${opt.description}`);
   }
+
+  lines.push('        timeout: Wall-clock limit in seconds for the CLI process. None (default) waits indefinitely. On expiry the JVM is killed and subprocess.TimeoutExpired is raised. Not a CLI option: the JAR declares no processing bound, so this is enforced by the wrapper.');
 
   lines.push('    """');
 
@@ -359,7 +364,7 @@ function generatePythonConvert() {
   }
 
   lines.push('');
-  lines.push('    run_jar(args, quiet)');
+  lines.push('    run_jar(args, quiet, timeout=timeout)');
   lines.push('');
 
   const outputPath = join(ROOT_DIR, 'python/opendataloader-pdf/src/opendataloader_pdf/convert_generated.py');
@@ -402,6 +407,13 @@ function generatePythonConvertOptionsMdx() {
     const description = escapeMarkdown(opt.description);
     rows.push([`\`${snakeName}\``, `\`${pyType}\``, defaultVal, description]);
   }
+
+  // Wrapper-level parameter, appended last to match the convert() signature.
+  // Not in options.json because it is enforced in Python, not by the CLI --
+  // same reason input_path is added by hand above.
+  rows.push(['`timeout`', '`float`', '`None`',
+    'Wall-clock limit in seconds for the CLI process. `None` waits indefinitely. '
+    + 'On expiry the JVM is killed and `subprocess.TimeoutExpired` is raised.']);
 
   lines.push(...formatTable(['Parameter', 'Type', 'Default', 'Description'], rows));
   lines.push('');


### PR DESCRIPTION

## Why

A caller that must not hang has no bound available today.

`run_jar` passes no `timeout=` to `subprocess.run` or `Popen.wait`, and the CLI declares
no processing bound of its own:

```
$ java -jar opendataloader-pdf-cli.jar --export-options
30 options declared; exactly one names a timeout:
{"name": "hybrid-timeout", "default": "0",
 "description": "Hybrid backend request timeout in milliseconds
                 (0 = use the backend's own default). Default: 0"}
```

That one is the hybrid HTTP call — `HybridConfig.getTimeoutMs()` feeds OkHttp
`connectTimeout`/`readTimeout`/`writeTimeout` — and it ships at `0`.

```
$ javap -p -cp opendataloader-pdf-cli.jar \
    org.opendataloader.pdf.processors.DocumentProcessor \
    org.opendataloader.pdf.processors.HybridDocumentProcessor \
    org.opendataloader.pdf.api.Config | grep -iE 'time|interrupt|cancel|abort|watchdog'
(no matches on any of the three)
```

So `convert()` runs the JVM in the calling thread with nothing able to stop it, and
because Python cannot kill a thread, a conversion that does not return takes the worker
with it for the life of the process. Today the only way to bound it is to stop using
`convert()` and spawn the bundled JAR yourself just to reach
`subprocess.run(timeout=...)` — which is what we do, and it is the sole reason we do it.

This PR adds the bound at the only layer that can enforce it today.

## What changed

- **`run_jar(args, quiet=False, timeout=None)`** — forwarded to `subprocess.run` in quiet
  mode. In streaming mode a blocking read on the pipe cannot itself be bounded, so the
  relay moves to a helper thread and the timeout is applied to the process: a JVM that
  wedges without emitting another line is still killed rather than waited on forever.
- **`convert(..., timeout=None)`** — a wrapper-level parameter, so it is added in
  `scripts/generate-options.mjs`, **not** `options.json`: it is not a CLI flag and must
  not become one. Regenerated with `npm run generate-options`; the Node bindings come out
  byte-identical.
- On expiry the JVM is killed and `subprocess.TimeoutExpired` propagates, with whatever
  the JAR had already emitted attached as `.output`. One line on stderr names the bound
  that was hit, so a timeout stays distinguishable from a non-zero exit in a caller's logs.
- The generated Python convert-options table gains a `timeout` row, appended the way
  `input_path` already is — both are wrapper-level and absent from `options.json`, so the
  reference table would otherwise omit the parameter entirely.

## Backward compatibility

`timeout=None` is the default everywhere, so existing callers wait exactly as before. The
inline read loop and the unbounded `wait()` are kept for that path rather than routed
through the new thread, and `test_streaming_without_timeout_keeps_the_inline_read` pins it.

## Verification

Against the shipped 2.5.7 JAR, using only PDFs this repo ships — here
`samples/pdf/1901.03003.pdf` (15 pages, ~1.3 s to parse on an M4; 1.1–1.7 s across runs):

| call | result |
|---|---|
| `convert(...)` no timeout | ~1.3 s, JSON written — **default unchanged** |
| `run_jar(..., quiet=True, timeout=0.32)` | `TimeoutExpired` after 0.33 s, **no `java` process left behind** |
| `run_jar(..., quiet=False, timeout=0.32)` | `TimeoutExpired` after 0.33 s, **no `java` process left behind** |
| `convert(..., timeout=0.32)` | `TimeoutExpired` |
| `convert(..., timeout=120)` | completes, JSON written |

**The wedged case was exercised for real, not only mocked.** Against a jar that starts,
prints nothing and sleeps for an hour, `timeout=1.0` raises after 1.00 s (quiet) and 1.01 s
(streaming), and `pgrep` finds no surviving process either time. That is the scenario the
streaming branch's helper thread exists for: a blocking `readline` on the pipe would
otherwise never observe the bound, no matter how long it elapsed.

`./scripts/build-python.sh`'s test step — which is what the PR gate runs via
`build-all.sh` — passes: **21 passed** (`uv run pytest tests`, the six
`test_hybrid_server*` files excluded locally because they need the `hybrid`
extra and nothing here touches `hybrid_server.py`). Four of those 21 are new.

`ruff check` (the repo's own config: `select = E,F,I`, line-length 100) reports
the same two findings as the pristine file — `I001` on the import block and
`E501` on the untouched `'java' command not found` string — and **none on a line
this branch adds**. No workflow runs ruff, so those two are left alone rather
than fixed as churn inside a feature PR.

`convert_generated.py` was produced by `node scripts/generate-options.mjs`, and
re-running it against the committed file yields no diff, so nothing here is a
hand-edit of a generated file. Its one new line is a docstring `Args` entry
emitted by the same code path as every other option; the file already carries 18
lines over 100 characters (up to 320) for exactly that reason.

## Scope — what this does not fix

This gives no **per-document** bound inside a batched invocation: several inputs still
share one process, so one pathological PDF still ends the run, and nothing says which
input hung. That needs a bound in the JAR itself, and it is why #456 (long-running server
mode) is the more complete answer. This PR is the part that can be fixed in the wrapper.

Related: #572 proposes splitting the CLI relay from the library API in `run_jar`, with a
relay-control flag on `run_jar` and a `_run_for_cli()` helper in `wrapper.py`. This patch
adds the bound to both existing paths, so the two are orthogonal: under that split the
threaded bound stays in `run_jar` and simply becomes conditional on the relay flag, while
`convert()` — which would no longer relay — keeps the plain `subprocess.run(timeout=...)`
case. Landing either first should not complicate the other.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional timeout for PDF conversion operations.
  - Timeout limits apply to both quiet and streaming execution modes.
  - Timed-out processes are stopped, and previously emitted output is preserved.
  - Timeout failures are reported clearly while remaining available for application handling.

- **Documentation**
  - Documented timeout behavior, including indefinite waiting when unset and immediate timeout when set to zero.
  - Added the timeout option to the conversion options reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->