### PR TITLE
fix(hybrid): keep the backend text when bbox-matched stream chunks do not resemble it

### DIFF
--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/TextSimilarity.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/hybrid/TextSimilarity.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+/**
+ * Computes text similarity for stream vs OCR comparison.
+ * Used by enrichment to decide whether stream text is corrupted.
+ */
+public final class TextSimilarity {
+
+    /** Default similarity threshold. Below this, stream text is considered corrupted. */
+    public static final double DEFAULT_THRESHOLD = 0.5;
+
+    private TextSimilarity() {}
+
+    /**
+     * Computes normalized similarity between two strings (0.0 = completely different, 1.0 = identical).
+     * Uses Levenshtein distance normalized by the longer string's length.
+     */
+    public static double similarity(String a, String b) {
+        if (a == null || b == null) return 0.0;
+        if (a.equals(b)) return 1.0;
+        if (a.isEmpty() || b.isEmpty()) return 0.0;
+
+        int distance = levenshteinDistance(a, b);
+        int maxLen = Math.max(a.length(), b.length());
+        return 1.0 - ((double) distance / maxLen);
+    }
+
+    /**
+     * Returns true if stream text should be trusted over OCR text.
+     */
+    public static boolean trustStream(String streamText, String ocrText, double threshold) {
+        if (streamText == null || streamText.isEmpty()) return false;
+        if (ocrText == null || ocrText.isEmpty()) return true;
+        return similarity(streamText, ocrText) >= threshold;
+    }
+
+    private static int levenshteinDistance(String a, String b) {
+        int[] prev = new int[b.length() + 1];
+        int[] curr = new int[b.length() + 1];
+        for (int j = 0; j <= b.length(); j++) prev[j] = j;
+        for (int i = 1; i <= a.length(); i++) {
+            curr[0] = i;
+            for (int j = 1; j <= b.length(); j++) {
+                int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+                curr[j] = Math.min(Math.min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
+            }
+            int[] temp = prev; prev = curr; curr = temp;
+        }
+        return prev[b.length()];
+    }
+}

--- a/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
+++ b/java/opendataloader-pdf-core/src/main/java/org/opendataloader/pdf/processors/HybridDocumentProcessor.java
@@ -28,6 +28,7 @@ import org.opendataloader.pdf.hybrid.HybridClient.HybridResponse;
 import org.opendataloader.pdf.hybrid.HybridClient.OutputFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opendataloader.pdf.hybrid.HybridConfig;
+import org.opendataloader.pdf.hybrid.TextSimilarity;
 import org.opendataloader.pdf.hybrid.HybridSchemaTransformer;
 import org.opendataloader.pdf.hybrid.TriageLogger;
 import org.opendataloader.pdf.hybrid.TriageProcessor;
@@ -1067,7 +1068,20 @@ public class HybridDocumentProcessor {
             return;
         }
 
-        recordTextSource(textNode, "stream", null);
+        // The bbox test alone is not a proof that the stream chunks belong to this node: a merged or
+        // oversized table cell box also contains its neighbours' words, and the backend's own text is
+        // then the better answer. Keep the backend text when the stream text does not resemble it.
+        String streamText = extractTextFromChunks(matched);
+        String backendText = extractTextFromNode(textNode);
+        double sim = TextSimilarity.similarity(streamText, backendText);
+        if (!TextSimilarity.trustStream(streamText, backendText, TextSimilarity.DEFAULT_THRESHOLD)) {
+            LOGGER.fine(() -> "enrichSingleTextNode: stream text untrusted (sim="
+                + String.format("%.2f", sim) + "), keeping backend text for node at ["
+                + String.format("%.1f,%.1f,%.1f,%.1f", nLeft, nBottom, nRight, nTop) + "]");
+            recordTextSource(textNode, "ocr", sim);
+            return;
+        }
+        recordTextSource(textNode, "stream", sim);
 
         // Replace the backend's text with the Java TextChunks that carry StreamInfo
         textNode.getColumns().clear();
@@ -1157,10 +1171,51 @@ public class HybridDocumentProcessor {
             LOGGER.fine(() -> "replaceLineChunksWithJava: no Java TextChunk inside list line");
             return;
         }
+        // Same protection as enrichSingleTextNode: only swap the line when the stream text resembles it.
+        String streamText = extractTextFromChunks(matched);
+        String backendText = extractTextFromLine(line);
+        if (!TextSimilarity.trustStream(streamText, backendText, TextSimilarity.DEFAULT_THRESHOLD)) {
+            LOGGER.fine(() -> "replaceLineChunksWithJava: stream text untrusted, keeping backend list line");
+            return;
+        }
 
         line.getTextChunks().clear();
         line.getTextChunks().addAll(matched);
         usedJavaIndices.addAll(matchedIndices);
+    }
+
+    /** Joins chunk values with single spaces, for the stream-vs-backend similarity test. */
+    private static String extractTextFromChunks(List<TextChunk> chunks) {
+        StringBuilder sb = new StringBuilder();
+        for (TextChunk tc : chunks) {
+            if (sb.length() > 0) sb.append(' ');
+            sb.append(tc.getValue());
+        }
+        return sb.toString().trim();
+    }
+
+    /** Joins every chunk of a text node with single spaces, for the stream-vs-backend similarity test. */
+    private static String extractTextFromNode(SemanticTextNode node) {
+        StringBuilder sb = new StringBuilder();
+        for (TextColumn col : node.getColumns()) {
+            for (TextLine line : col.getLines()) {
+                for (TextChunk chunk : line.getTextChunks()) {
+                    if (sb.length() > 0) sb.append(' ');
+                    sb.append(chunk.getValue());
+                }
+            }
+        }
+        return sb.toString().trim();
+    }
+
+    /** Joins a line's chunk values, for the stream-vs-backend similarity test. */
+    private static String extractTextFromLine(TextLine line) {
+        StringBuilder sb = new StringBuilder();
+        for (TextChunk c : line.getTextChunks()) {
+            if (sb.length() > 0) sb.append(' ');
+            sb.append(c.getValue());
+        }
+        return sb.toString().trim();
     }
 
     /**

--- a/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/TextSimilarityTest.java
+++ b/java/opendataloader-pdf-core/src/test/java/org/opendataloader/pdf/hybrid/TextSimilarityTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025-2026 Hancom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendataloader.pdf.hybrid;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TextSimilarityTest {
+
+    @Test
+    void identical_strings_return_1() {
+        assertEquals(1.0, TextSimilarity.similarity("hello", "hello"));
+    }
+
+    @Test
+    void completely_different_return_low() {
+        assertTrue(TextSimilarity.similarity("abc", "xyz") < 0.5);
+    }
+
+    @Test
+    void corrupted_unicode_detected() {
+        assertFalse(TextSimilarity.trustStream(",QWURGXFWLRQ", "Introduction", 0.5));
+    }
+
+    @Test
+    void similar_strings_trust_stream() {
+        assertTrue(TextSimilarity.trustStream("Introduction to Biology", "Introduction to Biology", 0.5));
+    }
+
+    @Test
+    void minor_ocr_error_still_trusts_stream() {
+        assertTrue(TextSimilarity.trustStream("Introduction", "Introductlon", 0.5));
+    }
+
+    @Test
+    void null_stream_returns_false() {
+        assertFalse(TextSimilarity.trustStream(null, "text", 0.5));
+    }
+
+    @Test
+    void null_ocr_returns_true() {
+        assertTrue(TextSimilarity.trustStream("text", null, 0.5));
+    }
+
+    @Test
+    void empty_stream_returns_false() {
+        assertFalse(TextSimilarity.trustStream("", "text", 0.5));
+    }
+
+    @Test
+    void both_null_returns_zero_similarity() {
+        assertEquals(0.0, TextSimilarity.similarity(null, null));
+    }
+
+    @Test
+    void both_empty_strings_are_identical() {
+        assertEquals(1.0, TextSimilarity.similarity("", ""));
+    }
+
+    @Test
+    void one_empty_one_nonempty_returns_zero() {
+        assertEquals(0.0, TextSimilarity.similarity("", "hello"));
+        assertEquals(0.0, TextSimilarity.similarity("hello", ""));
+    }
+
+    @Test
+    void default_threshold_is_0_5() {
+        assertEquals(0.5, TextSimilarity.DEFAULT_THRESHOLD);
+    }
+}


### PR DESCRIPTION
### Description

`HybridDocumentProcessor.enrichSingleTextNode` (and, since v2.5.4, `replaceLineChunksWithJava` for list lines) replaces
a backend text node's chunks with the Java stream chunks whose centre lies inside the node's bbox (±5 pt). Up to v2.5.3
this replacement was guarded by `TextSimilarity.trustStream(streamText, backendText)` whenever the OCR strategy was
`auto` (the default): when the bbox-matched chunks did not resemble the backend text — a merged or oversized table cell
box also contains its neighbours' words — the backend text was kept.

Commit 63c01b6 (v2.5.4) flipped the default strategy to `off` for the hancom-ai layout cost, which also switched the
guard off for the docling-fast path, and #701 (v2.5.6) removed the guard together with the hancom-ai code. Since then the
replacement is unconditional. With the same docling backend for every run, v2.5.5–v2.5.7 change 3,543 of 11,283 table
cells (31%) of a 67-page Korean plan, 57% of the cells of a 103-page Korean guide and 55% of the cells of arXiv 2206.01062
(English) compared with v2.5.3 — header cells absorb their neighbours (`항목` → `항목 생산면적`, `Train` → `Count`), contents
shift into the adjacent cell, bullets inside cells disappear. Rebuilding v2.5.5 with only the default flipped back to `auto`
brings the cells back to 0 changed, which pins the cause to the missing guard.

This change restores the guard independently of any OCR strategy: `TextSimilarity` is reinstated and both replacement
paths keep the backend text when the stream text does not resemble it (threshold 0.5, chunk bookkeeping and `textSource`
values exactly as before #701). Rebuilt on `main` and re-run with the same backend: the 67-page document's table cells go
back to their pre-v2.5.4 content (see numbers below).

Verification on `main` (this branch built and run against the same docling backend):

| build | table cells changed vs v2.5.0 (72 tables / 11,283 cells) | Markdown lines changed |
|---|---|---|
| `main` (v2.5.7 behaviour) | 3,543 (31.4%) | 943 |
| this branch | **0** | 80 (list-marker rendering of #648 only) |

`TextSimilarityTest` (12) and `HybridDocumentProcessorTest` (38): 0 failures.

Related: #720 and #627 describe hybrid table corruption too, but from the TableFormer side; this is the Java-side
replacement and reproduces with a byte-identical backend output.

**Checklist:**

- [x] Documentation has been updated, if necessary. (Javadoc)
- [ ] Examples have been added, if necessary. (not needed)
- [x] Tests have been added, if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hybrid PDF text extraction by comparing stream text with OCR text before selecting the preferred content.
  * Preserves OCR text when extracted stream text is incomplete, corrupted, or insufficiently similar.
  * Applies consistent text validation to document text and list content.
* **Bug Fixes**
  * Prevents unreliable stream-extracted text from replacing higher-quality OCR results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->